### PR TITLE
Require openai >= 3.0.0 (httpx2-based), fixing mypy failures and a timeout bug under openai 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
 - Control Channel: `inspect ctl` mutations with piped or captured output now print one outcome line each instead of repeating the full task header (`--terse/--no-terse` to override).
 - Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys.
+- OpenAI: the OpenAI providers and agent bridge now require openai >= 3.0.0, which verifies TLS against the OS trust store instead of certifi's bundle.
 
 ## 0.3.258 (11 August 2026)
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -43,7 +43,7 @@ The `openai` provider supports the following custom model args (other model args
 | `safety_identifier` | A stable identifier used to help detect users of your application. |
 | `prompt_cache_key` | Used by OpenAI to cache responses for similar requests. |
 | `prompt_cache_retention` | Retention policy for the prompt cache. |
-| `http_client` | Custom instance of `httpx.AsyncClient` for handling requests. |
+| `http_client` | Custom instance of `httpx2.AsyncClient` (or legacy `httpx.AsyncClient`) for handling requests. |
 
 : {tbl-colwidths=\[35,65\]}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ mistralai>=2.4.5
 moto[server]>=5.1.5
 mypy>=2.3.0 # older mypy emits a `misc` error at a site where the ignore was removed as unused
 nbformat
-openai>=2.45.0
+openai>=3.0.0
 pandas>=2.0.0
 pandas-stubs
 panflute

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -244,6 +244,10 @@ def init_openai_request_patch() -> None:
         return
     validate_openai_client("agent bridge")
 
+    # deferred with the openai imports below: httpx2 is not a dependency of
+    # inspect_ai (we only get it transitively via openai >= 3), and this
+    # module must import without openai installed
+    import httpx2
     from openai._base_client import AsyncAPIClient, _AsyncStreamT
     from openai._constants import RAW_RESPONSE_HEADER
     from openai._models import FinalRequestOptions
@@ -294,7 +298,7 @@ def init_openai_request_patch() -> None:
         if not raw_response:
             return result
 
-        response = httpx.Response(
+        response = httpx2.Response(
             status_code=200,
             headers={"content-type": "application/json"},
             content=result.model_dump_json().encode(),

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
 if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
-import httpx
 from openai import (
     APIConnectionError,
     APIStatusError,
@@ -1220,32 +1219,3 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
         value = copy(value)
         value.update(data=BASE_64_DATA_REMOVED)
     return value
-
-
-# httpx-native equivalents of openai's DEFAULT_TIMEOUT / DEFAULT_CONNECTION_LIMITS
-# (same values). Do NOT import those from `openai`: openai >= 3.0 is built on
-# httpx2, and its httpx2-typed constants silently corrupt the timeout config of
-# our legacy `httpx.AsyncClient`, failing every request with APIConnectionError.
-DEFAULT_TIMEOUT = httpx.Timeout(timeout=600, connect=5.0)
-DEFAULT_CONNECTION_LIMITS = httpx.Limits(
-    max_connections=1000, max_keepalive_connections=100
-)
-
-
-class OpenAIAsyncHttpxClient(httpx.AsyncClient):
-    """Custom async client that uses OpenAI's default settings.
-
-    This ensures proper proxy support and follows OpenAI's recommended configuration.
-    OpenAI has already incorporated timeout improvements for reasoning models in their
-    default transport, so we don't need custom socket options.
-
-    """
-
-    def __init__(self, **kwargs: Any) -> None:
-        # Use OpenAI's default settings which handle proxies correctly
-        # https://github.com/openai/openai-python/commit/347363ed67a6a1611346427bb9ebe4becce53f7e
-        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-        kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
-        kwargs.setdefault("follow_redirects", True)
-
-        super().__init__(**kwargs)

--- a/src/inspect_ai/model/_providers/_openai_batch.py
+++ b/src/inspect_ai/model/_providers/_openai_batch.py
@@ -1,6 +1,6 @@
 from typing import IO, Any, Generic, Literal, TypeVar
 
-import httpx
+import httpx2
 import pydantic
 from openai import AsyncOpenAI
 from openai._types import NOT_GIVEN
@@ -150,7 +150,7 @@ class OpenAIBatcher(FileBatcher[ResponseT, CompletedBatchInfo], Generic[Response
         else:
             return request_id, (
                 self._openai_client._make_status_error_from_response(  # pyright: ignore[reportPrivateUsage]
-                    httpx.Response(status_code=error["code"], text=error["message"])
+                    httpx2.Response(status_code=error["code"], text=error["message"])
                 )
             )
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -8,6 +8,7 @@ from openai import (
     AsyncAzureOpenAI,
     AsyncBedrockOpenAI,
     AsyncOpenAI,
+    DefaultAsyncHttpxClient,
     NotFoundError,
     NotGiven,
     RateLimitError,
@@ -35,7 +36,6 @@ from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall
 from .._model_output import ModelOutput, ModelUsage
 from .._openai import (
-    OpenAIAsyncHttpxClient,
     is_gpt_5_model,
     is_latest_model,
     is_o_series_model,
@@ -240,7 +240,7 @@ class OpenAIAPI(ModelAPI):
 
         # extract http_client and api_version before storing model_args
         self.http_client = (
-            model_args.pop("http_client", None) or OpenAIAsyncHttpxClient()
+            model_args.pop("http_client", None) or DefaultAsyncHttpxClient()
         )
         if self.is_azure():
             # resolve version
@@ -316,7 +316,7 @@ class OpenAIAPI(ModelAPI):
         super().initialize()
 
         if self.http_client.is_closed:
-            self.http_client = OpenAIAsyncHttpxClient()
+            self.http_client = DefaultAsyncHttpxClient()
 
         self.client = self._create_client()
 

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -2,11 +2,12 @@ import os
 from logging import getLogger
 from typing import Any, cast
 
-import httpx
+import httpx2
 from openai import (
     APIStatusError,
     AsyncOpenAI,
     BadRequestError,
+    DefaultAsyncHttpxClient,
     LengthFinishReasonError,
     PermissionDeniedError,
     UnprocessableEntityError,
@@ -40,7 +41,6 @@ from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall, as_error_response
 from .._model_output import ChatCompletionChoice, ModelOutput
 from .._openai import (
-    OpenAIAsyncHttpxClient,
     OpenAIResponseError,
     is_gpt_5_model,
     is_o_series_model,
@@ -147,12 +147,18 @@ class OpenAICompatibleAPI(ModelAPI):
         # create client
         self.initialize()
 
-    def _create_http_client(self) -> OpenAIAsyncHttpxClient:
+    def _create_http_client(self) -> DefaultAsyncHttpxClient:
+        # DefaultAsyncHttpxClient is the SDK's own httpx2.AsyncClient with
+        # OpenAI's recommended defaults (timeout, connection limits, redirect
+        # and proxy handling). Source the client from the SDK rather than
+        # hand-building an httpx client with equivalent defaults: a client and
+        # its config objects must be the same httpx flavor — a mismatch
+        # silently corrupts the timeout config (#4837).
         if self.client_timeout is not None:
-            return OpenAIAsyncHttpxClient(
-                timeout=httpx.Timeout(timeout=self.client_timeout, connect=5.0)
+            return DefaultAsyncHttpxClient(
+                timeout=httpx2.Timeout(timeout=self.client_timeout, connect=5.0)
             )
-        return OpenAIAsyncHttpxClient()
+        return DefaultAsyncHttpxClient()
 
     def _create_client(self) -> AsyncOpenAI:
         return AsyncOpenAI(

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -121,6 +121,10 @@ def vllm_completions() -> type[ModelAPI]:
 
 @modelapi(name="cloudflare")
 def cloudflare() -> type[ModelAPI]:
+    # validate
+    validate_openai_client("CloudFlare API")
+
+    # in the clear
     from .cloudflare import CloudFlareAPI
 
     return CloudFlareAPI
@@ -359,7 +363,7 @@ def hf_inference_providers() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "2.45.0"
+    MIN_VERSION = "3.0.0"
 
     # verify we have the package
     try:

--- a/src/inspect_ai/model/_providers/util/hooks.py
+++ b/src/inspect_ai/model/_providers/util/hooks.py
@@ -1,9 +1,8 @@
 import re
 import time
 from logging import getLogger
-from typing import Any, Literal, Mapping, NamedTuple, cast
+from typing import Any, Callable, Literal, Mapping, NamedTuple, Protocol, cast
 
-import httpx
 from shortuuid import uuid
 
 from inspect_ai._util.constants import HTTP
@@ -278,21 +277,56 @@ class ConverseHooks(HttpHooks):
     USER_AGENT_PREFIX = "ins/rid#"
 
 
+# Structural stand-ins for httpx types, covering only what the hooks touch.
+# The openai SDK is built on `httpx2` while other SDKs (anthropic, google,
+# mistral, groq) hand us legacy `httpx` clients; both flavors satisfy these
+# protocols.
+class HttpxRequestLike(Protocol):
+    @property
+    def method(self) -> str: ...
+    @property
+    def url(self) -> object: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+class HttpxResponseLike(Protocol):
+    @property
+    def request(self) -> HttpxRequestLike: ...
+    @property
+    def status_code(self) -> int: ...
+    @property
+    def http_version(self) -> str: ...
+    @property
+    def reason_phrase(self) -> str: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+class HttpxClientLike(Protocol):
+    @property
+    def event_hooks(self) -> dict[str, list[Callable[..., Any]]]: ...
+
+    # excludes sync clients (which have `close`): they would silently
+    # discard the async hooks' coroutines instead of awaiting them
+    async def aclose(self) -> None: ...
+
+
 class HttpxHooks(HttpHooks):
-    def __init__(self, client: httpx.AsyncClient):
+    def __init__(self, client: HttpxClientLike):
         super().__init__()
 
         # install hooks
         client.event_hooks["request"].append(self.request_hook)
         client.event_hooks["response"].append(self.response_hook)
 
-    async def request_hook(self, request: httpx.Request) -> None:
+    async def request_hook(self, request: HttpxRequestLike) -> None:
         # update the last request time for this request id (as there could be retries)
         request_id = request.headers.get(self.REQUEST_ID_HEADER, None)
         if request_id:
             self.update_request_time(request_id)
 
-    async def response_hook(self, response: httpx.Response) -> None:
+    async def response_hook(self, response: HttpxResponseLike) -> None:
         message = f'{response.request.method} {response.request.url} "{response.http_version} {response.status_code} {response.reason_phrase}" '
         logger.log(HTTP, message)
         # record status + Retry-After / x-ratelimit-reset-* for next retry classification

--- a/tests/model/providers/test_cloudflare.py
+++ b/tests/model/providers/test_cloudflare.py
@@ -33,7 +33,7 @@ async def test_cloudflare_empty_assistant_message() -> None:
 @skip_if_no_openai_package
 def test_cloudflare_retries_503_as_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """503 must be retried as a rate limit (scales down adaptive concurrency)."""
-    import httpx
+    import httpx2
     from openai import InternalServerError
 
     from inspect_ai.model._model import RetryDecision
@@ -44,10 +44,10 @@ def test_cloudflare_retries_503_as_rate_limit(monkeypatch: pytest.MonkeyPatch) -
     api = CloudFlareAPI(model_name="moonshotai/kimi-k3")
 
     def sdk_error(status_code: int, headers: dict[str, str] | None = None):
-        response = httpx.Response(
+        response = httpx2.Response(
             status_code=status_code,
             headers=headers,
-            request=httpx.Request("POST", "https://example/v1/chat/completions"),
+            request=httpx2.Request("POST", "https://example/v1/chat/completions"),
         )
         return InternalServerError("Server Error", response=response, body=None)
 

--- a/tests/model/providers/test_moonshot.py
+++ b/tests/model/providers/test_moonshot.py
@@ -173,16 +173,16 @@ def test_moonshot_legacy_model_preserves_sampling_params(mock_moonshot_env):
 
 def test_moonshot_context_overflow_maps_to_model_length(mock_moonshot_env):
     """Moonshot's token-limit 400 (no error code) must map to stop_reason model_length."""
-    import httpx
+    import httpx2
     from openai import APIStatusError
 
     from inspect_ai.model._model_output import ModelOutput
     from inspect_ai.model._providers.moonshot import MoonshotAPI
 
     api = MoonshotAPI(model_name="kimi-k3")
-    response = httpx.Response(
+    response = httpx2.Response(
         status_code=400,
-        request=httpx.Request("POST", "https://api.moonshot.ai/v1/chat/completions"),
+        request=httpx2.Request("POST", "https://api.moonshot.ai/v1/chat/completions"),
     )
     message = (
         "Invalid request: Your request exceeded model token limit: "
@@ -215,7 +215,7 @@ def test_moonshot_base_url_default(mock_moonshot_env):
 
 def test_moonshot_retries_503_as_rate_limit(mock_moonshot_env) -> None:
     """503 must be retried as a rate limit (scales down adaptive concurrency)."""
-    import httpx
+    import httpx2
     from openai import InternalServerError
 
     from inspect_ai.model._model import RetryDecision
@@ -224,10 +224,10 @@ def test_moonshot_retries_503_as_rate_limit(mock_moonshot_env) -> None:
     api = MoonshotAPI(model_name="kimi-k3")
 
     def sdk_error(status_code: int, headers: dict[str, str] | None = None):
-        response = httpx.Response(
+        response = httpx2.Response(
             status_code=status_code,
             headers=headers,
-            request=httpx.Request(
+            request=httpx2.Request(
                 "POST", "https://api.moonshot.ai/v1/chat/completions"
             ),
         )

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import httpx
+import httpx2
 import pytest
 from openai import APIStatusError, LengthFinishReasonError
 from openai.types.chat import ChatCompletion
@@ -137,8 +137,8 @@ def test_handle_bad_request(
     )
     error = APIStatusError(
         message=message,
-        response=httpx.Response(
-            request=httpx.Request(method="POST", url="https://example.com"),
+        response=httpx2.Response(
+            request=httpx2.Request(method="POST", url="https://example.com"),
             status_code=status_code,
             json={"message": message},
         ),
@@ -222,8 +222,8 @@ def test_handle_bad_request_content_filter(
     )
     error = APIStatusError(
         message=body["message"],
-        response=httpx.Response(
-            request=httpx.Request(method="POST", url="https://example.com"),
+        response=httpx2.Response(
+            request=httpx2.Request(method="POST", url="https://example.com"),
             status_code=400,
             json=body,
         ),
@@ -290,7 +290,7 @@ async def test_client_timeout_preserved_after_reinitialize() -> None:
 
 
 def test_user_supplied_http_client_not_overridden() -> None:
-    custom_client = httpx.AsyncClient(timeout=httpx.Timeout(42.0))
+    custom_client = httpx2.AsyncClient(timeout=httpx2.Timeout(42.0))
     api = OpenAICompatibleAPI(
         model_name="openai-api/openai/gpt-5",
         api_key="test",

--- a/tests/model/providers/test_openai_proxy.py
+++ b/tests/model/providers/test_openai_proxy.py
@@ -2,10 +2,9 @@ import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-import httpx
+import httpx2
 import pytest
-
-from inspect_ai.model._openai import OpenAIAsyncHttpxClient
+from openai import DefaultAsyncHttpxClient
 
 
 class _EchoHandler(BaseHTTPRequestHandler):
@@ -41,6 +40,6 @@ async def test_openai_async_client_respects_http_proxy(monkeypatch: pytest.Monke
         monkeypatch.setenv(key, proxy_url)
 
     with _http_server() as port:
-        async with OpenAIAsyncHttpxClient() as client:
-            with pytest.raises(httpx.TransportError):
+        async with DefaultAsyncHttpxClient() as client:
+            with pytest.raises(httpx2.TransportError):
                 await client.get(f"http://127.0.0.1:{port}/")

--- a/tests/model/providers/test_openai_reasoning_summaries.py
+++ b/tests/model/providers/test_openai_reasoning_summaries.py
@@ -7,7 +7,7 @@ the OpenAI SDK would produce.
 
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 from openai import APITimeoutError, BadRequestError
 
@@ -20,8 +20,8 @@ def _make_api() -> OpenAIAPI:
     return OpenAIAPI(model_name="gpt-5", api_key="test-key", responses_api=True)
 
 
-def _request() -> httpx.Request:
-    return httpx.Request("POST", "https://api.openai.com/v1/responses")
+def _request() -> httpx2.Request:
+    return httpx2.Request("POST", "https://api.openai.com/v1/responses")
 
 
 @pytest.mark.anyio
@@ -58,7 +58,7 @@ async def test_reasoning_summaries_unsupported_error_cached(
     api = _make_api()
     try:
         calls = {"n": 0}
-        response = httpx.Response(status_code=400, request=_request())
+        response = httpx2.Response(status_code=400, request=_request())
 
         async def unsupported(**kwargs: object) -> object:
             calls["n"] += 1

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -9,6 +9,7 @@ shapes, not just our naive default that assumes `.status_code` is universal.
 from __future__ import annotations
 
 import httpx
+import httpx2
 import pytest
 
 from inspect_ai.model import RetryDecision, get_model
@@ -20,6 +21,18 @@ def _http_response(
     """Build a stand-in httpx.Response for SDK exception constructors."""
     request = httpx.Request("POST", "https://example.com/v1/chat/completions")
     return httpx.Response(
+        status_code=status,
+        headers=headers or {},
+        request=request,
+    )
+
+
+def _openai_http_response(
+    status: int, headers: dict[str, str] | None = None
+) -> httpx2.Response:
+    """Like _http_response, but httpx2-flavored (what openai >= 3 is built on)."""
+    request = httpx2.Request("POST", "https://example.com/v1/chat/completions")
+    return httpx2.Response(
         status_code=status,
         headers=headers or {},
         request=request,
@@ -104,7 +117,7 @@ def test_openai_classify_rate_limit_429() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _http_response(429, {"retry-after": "30"})
+    response = _openai_http_response(429, {"retry-after": "30"})
     ex = APIStatusError(message="rate limited", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -120,7 +133,7 @@ def test_openai_classify_transient_5xx() -> None:
 
     ex = APIStatusError(
         message="internal error",
-        response=_http_response(503),
+        response=_openai_http_response(503),
         body=None,
     )
     decision = openai_classify_retry(ex)
@@ -136,7 +149,7 @@ def test_openai_classify_non_retryable_4xx_returns_none() -> None:
 
     ex = APIStatusError(
         message="bad request",
-        response=_http_response(400),
+        response=_openai_http_response(400),
         body=None,
     )
     assert openai_classify_retry(ex) is None
@@ -147,7 +160,7 @@ def test_openai_classify_rate_limit_error_subclass() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _http_response(429, {"retry-after": "5"})
+    response = _openai_http_response(429, {"retry-after": "5"})
     ex = RateLimitError(message="too many", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -164,7 +177,7 @@ def test_openai_provider_quota_exceeded_does_not_retry() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)  # avoid full init
     ex = RateLimitError(
         message="You exceeded your current quota, please check your plan.",
-        response=_http_response(429),
+        response=_openai_http_response(429),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -180,7 +193,7 @@ def test_openai_provider_429_classifies_as_rate_limit() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)
     ex = RateLimitError(
         message="rate limited",
-        response=_http_response(429, {"retry-after": "10"}),
+        response=_openai_http_response(429, {"retry-after": "10"}),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -682,7 +695,7 @@ def test_together_openai_compatible_429_classifies_as_rate_limit() -> None:
     api = TogetherAIAPI.__new__(TogetherAIAPI)
     ex = APIStatusError(
         message="rate limited",
-        response=_http_response(429, {"retry-after": "15"}),
+        response=_openai_http_response(429, {"retry-after": "15"}),
         body=None,
     )
     decision = api.should_retry(ex)

--- a/tests/test_model_env_mismatch.py
+++ b/tests/test_model_env_mismatch.py
@@ -31,7 +31,7 @@ class TestModelEnvironmentMismatch:
 
         # Mock the Azure client creation instead of the entire API class
         mocker.patch("inspect_ai.model._providers.openai.AsyncAzureOpenAI")
-        mocker.patch("inspect_ai.model._providers.openai.OpenAIAsyncHttpxClient")
+        mocker.patch("inspect_ai.model._providers.openai.DefaultAsyncHttpxClient")
 
         # Call get_model to trigger the mismatch warning
         caplog.clear()
@@ -85,7 +85,7 @@ class TestModelEnvironmentMismatch:
 
         # Mock the Azure client creation instead of the entire API class
         mocker.patch("inspect_ai.model._providers.openai.AsyncAzureOpenAI")
-        mocker.patch("inspect_ai.model._providers.openai.OpenAIAsyncHttpxClient")
+        mocker.patch("inspect_ai.model._providers.openai.DefaultAsyncHttpxClient")
 
         # Create a minimal task with proper solver and scorer
         task = Task(
@@ -277,7 +277,7 @@ class TestModelEnvironmentMismatch:
 
         # Mock the Azure client creation instead of the entire API class
         mocker.patch("inspect_ai.model._providers.openai.AsyncAzureOpenAI")
-        mocker.patch("inspect_ai.model._providers.openai.OpenAIAsyncHttpxClient")
+        mocker.patch("inspect_ai.model._providers.openai.DefaultAsyncHttpxClient")
 
         try:
             # Disable memoization to ensure fresh model creation

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
@@ -1804,6 +1805,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1825,6 +1839,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -2176,7 +2216,7 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'dev'" },
     { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'dev'", specifier = ">=2.45.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "panflute", marker = "extra == 'dev'" },
@@ -2370,7 +2410,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -3984,7 +4025,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -4143,7 +4185,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -4233,21 +4276,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.45.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
 ]
 
 [[package]]
@@ -4432,7 +4475,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -4522,7 +4566,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -6072,7 +6117,8 @@ resolution-markers = [
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -6718,6 +6764,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #4871

openai 3.x is built on `httpx2` instead of `httpx`, so its APIs type against `httpx2` objects while our code constructed legacy `httpx` ones — 22 mypy errors with openai 3.x installed, plus a latent runtime bug (`openai_compatible.py` passing a legacy `httpx.Timeout` that an httpx2 client misreads as a scalar, the mirror image of #4837). This PR resolves it by bumping the openai minimum to 3.0.0 — consistent with how this project has historically handled openai SDK version friction (e.g. 1.104.1 → 2.0.0 for tool-call images, 2.25 → 2.26 for mypy issues) — and moving the openai code paths to httpx2 outright.

Relationship to #4837: that PR fixed the runtime failure under openai 3.x by giving our legacy-httpx client locally defined, httpx-native default timeout/limits — the right fix while we supported both openai majors. With the minimum now at 3.0.0 the client can come from the SDK itself, so this PR supersedes those local constants (details under "What is the new behavior"). Everything else from #4837 stands.

Alternative considered: #4873 keeps the min at 2.45.0 and supports both majors via a runtime-selected shim. It's complete and green, but carrying dual-flavor support indefinitely (and relying on openai's explicitly temporary legacy-httpx escape hatch) isn't worth it given the project's history of tracking the SDK forward. That PR is left open for reference until this one lands.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

With openai 3.x installed, `mypy` reports 22 errors (#4871), and a `client_timeout` on OpenAI-compatible providers silently corrupts the http client's timeout config. CI is green only because the lock pins openai 2.45.0; fresh installs get 3.x.

### What is the new behavior?

The OpenAI providers (`openai`, `openai-api`, Azure/Bedrock variants) and the agent bridge require openai >= 3.0.0, enforced by the existing `validate_openai_client()` runtime gate. All objects handed to the SDK (`http_client`, `Response`, `Timeout`) are httpx2-flavored; mypy is clean with openai 3.x installed. `uv.lock` moves to openai 3.0.0 so CI gates against the new major.

Kept from the dual-support work in #4873 (still correct here):

- `OpenAIAsyncHttpxClient` is retired; call sites use `openai.DefaultAsyncHttpxClient` directly (the SDK's own defaults, right flavor by construction). This deletes the httpx-native `DEFAULT_TIMEOUT`/`DEFAULT_CONNECTION_LIMITS` workaround from #4837 — safe because that block existed only to keep a *legacy-httpx* client away from openai 3's httpx2-typed constants, and its values were verbatim copies of the SDK's (timeout 600/connect 5, limits 1000/100, follow_redirects). With the client sourced from the SDK, client and defaults are the same flavor by construction, so the corruption #4837 worked around is unrepresentable.
- `HttpxHooks` accepts structural protocols — required regardless of the bump, since anthropic/google/mistral/groq still hand it legacy `httpx` clients.
- The Anthropic path in `bridge.py` deliberately stays on legacy `httpx` (the anthropic SDK is still httpx-based).
- `test_openai_proxy.py` catches the flavor-matched `httpx2` transport error (previously masked by catching legacy `httpx.TransportError`).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, two user-facing changes:

1. Environments with openai 2.x get a clear "requires openai >= 3.0.0" error from the openai providers and agent bridge; users must `pip install -U openai`.
2. Riding along with openai 3.x / httpx2: TLS verifies against the OS trust store instead of certifi's bundle. This only affects deliberately lean images (e.g. `--no-install-recommends` or standalone Pythons on bare bases, where `ca-certificates` is absent); the fix is `apt-get install ca-certificates` or `SSL_CERT_FILE=$(python -m certifi)`. Official `python:*` images and normal installs are unaffected. A custom `http_client` model arg is best supplied as an `httpx2.AsyncClient`, though legacy `httpx` clients keep working: openai documents ([httpx2 migration guide](https://github.com/openai/openai-python/blob/main/httpx2.md)) that its runtime detects injected legacy clients and adapts, while noting this support is runtime-only and temporary. This PR doesn't rely on that layer for inspect's own client (it's native httpx2 via `openai.DefaultAsyncHttpxClient`); user-supplied legacy clients pass through untyped and ride openai's documented compatibility path.

### Other information:

Verified with openai 3.0.0 (the new lock): `mypy --exclude tests/test_package src tests` clean, 187 passed across the openai/hooks/bridge test files, `ruff check` and `ruff format --check` clean. Also ran the slow openai model tests against the live API (`pytest --runslow --runapi -m slow tests/model -k openai`): 8/8 passed — real requests over the httpx2 transport including streaming, server-side web search, image generation, and reasoning compaction.

### Agent review

- Reviewer: Claude Fable 5 via /code-review at high effort (fresh context; same model family as author), 1 pass with multi-angle finders and adversarial verification (8 finder angles, 12 candidates, refuted candidates dropped)
- Findings: 8 — 6 fixed, 2 dismissed
  - Fixed: top-level `import httpx2` in `bridge.py` made `import inspect_ai` fail in envs without openai >= 3 (httpx2 isn't a declared dependency) — deferred behind the existing openai gate; verified importable in a scratch venv with no openai/httpx2
  - Fixed: `cloudflare` factory was the only openai-compatible factory not calling `validate_openai_client` before importing `openai_compatible`, so openai 2.x users would get a raw `ModuleNotFoundError` instead of the actionable upgrade error
  - Fixed: CHANGELOG/docs wrongly claimed a legacy `httpx` `http_client` is unsupported (openai 3's compat layer accepts and normalizes them — empirically verified by the reviewer)
  - Fixed: `HttpxClientLike` protocol admitted sync clients, which would silently drop the async hooks' coroutines — now requires `aclose()`
  - Fixed: `OpenAIAsyncHttpxClient` reduced to a plain alias of `DefaultAsyncHttpxClient` (the subclass body added nothing)
  - Fixed: CHANGELOG entry regrouped next to the existing openai-3.x item and trimmed
  - Dismissed: background-response retry predicate (`openai_responses.py:264`) never matches openai SDK exceptions — real but pre-existing (dead since #2230, equally dead under openai 1.x/2.x) and outside this diff; filed as #4880
  - Dismissed: fourth copy of an httpx2 Request/Response test builder — copies differ in URLs/kwargs; centralizing saves little
