### PR TITLE
Reduce memory spikes and stalls when finalizing long samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Eval Set: An eval set driven by an external runner now honors the `INSPECT_EVAL_*` environment variables with the same meanings `inspect eval-set` gives them.
 - Control Channel: `inspect ctl config --max-samples` now works for tasks using adaptive connections — an integer pins sample concurrency, and `clear` resumes adaptive tracking.
 - Eval logs: Header-only `.eval` log uploads to S3 now appear in `inspect trace` output.
+- Logging: Reduced memory usage and event-loop stalls when finalizing long samples with realtime logging; summary-only hooks can opt out of full-sample materialization via `Hooks.needs_full_sample`.
 
 ## 0.3.261 (30 August 2026)
 

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -74,7 +74,7 @@ These events track the lifecycle of individual samples. Note the distinction bet
 | `on_sample_attempt_end` | `SampleAttemptEnd` | At the end of every attempt — `data.error` and `data.will_retry` describe the outcome. |
 | `on_sample_event` | `SampleEvent` | Each time a sample event (e.g. a `ModelEvent` or `ToolEvent`) is logged. Fires many times per sample. |
 | `on_sample_scoring` | `SampleScoring` | After the solver completes and before scoring begins. |
-| `on_sample_end` | `SampleEnd` | When a sample completes (or errors with no retries remaining). Once per epoch; `data.sample` is the full `EvalSample`. |
+| `on_sample_end` | `SampleEnd` | When a sample completes (or errors with no retries remaining). Once per epoch; `data.sample` is the full `EvalSample` (unless every hook [opts out](#skipping-full-sample-materialization)). |
 
 ### Model
 
@@ -92,7 +92,7 @@ Event data is owned by the framework. In particular, objects reachable from `Sam
 
 Hooks run within the evaluation, so keep them fast and resilient. Events from different samples and tasks may fire concurrently, and any exception raised by a hook is caught and logged as a warning (it does not fail the run) — with the exception of `LimitExceededError`, which is allowed to propagate so that hooks can enforce limits.
 
-In addition to these lifecycle events, two non-event methods let you control hook behaviour: [`enabled()`](#disabling-hooks) gates whether a hook is active, and [`override_api_key()`](#api-key-override) can rewrite model API keys. Both are covered below.
+In addition to these lifecycle events, three non-event controls let you tune hook behaviour: the [`enabled()`](#disabling-hooks) method gates whether a hook is active, the [`needs_full_sample()`](#skipping-full-sample-materialization) method lets summary-only hooks skip full-sample materialization, and the [`override_api_key()`](#api-key-override) method can rewrite model API keys. All are covered below.
 
 ## Hook Object Lifecycle
 
@@ -159,6 +159,22 @@ class WBHooks(Hooks):
 ```
 
 Because `enabled()` is consulted before every hook invocation (potentially many times per sample), keep its implementation cheap or cache the result.
+
+## Skipping Full Sample Materialization
+
+By default, `SampleEnd.sample` is the fully materialized `EvalSample`, complete `events` and `attachments` included. For long samples this can be expensive to reconstruct, so hooks whose `on_sample_end` reads only summary-level fields (scores, error, timings, etc.) can opt out by overriding the `needs_full_sample()` method to return `False`:
+
+``` python
+@hooks(name="score_tracker", description="Tracks sample scores")
+class ScoreTracker(Hooks):
+    def needs_full_sample(self) -> bool:
+        return False
+
+    async def on_sample_end(self, data: SampleEnd) -> None:
+        record(data.sample_id, data.sample.scores)
+```
+
+This is a permission: it allows the framework to deliver a sample with empty `events` and `attachments` and `timelines` set to `None`, but the reduction only happens when *every* enabled hook has opted out and nothing else in the eval needs the full sample. If you override `needs_full_sample()` to return `False` you must tolerate both forms.
 
 ## Requiring Hooks
 

--- a/examples/hooks/mlflow_tracking.py
+++ b/examples/hooks/mlflow_tracking.py
@@ -99,6 +99,11 @@ class MlflowTrackingHooks(Hooks):
     def enabled(self) -> bool:
         return os.getenv("MLFLOW_TRACKING_URI") is not None
 
+    # on_sample_end reads only summary fields (scores, timing), so the
+    # framework may skip rebuilding full sample events/attachments/timelines
+    def needs_full_sample(self) -> bool:
+        return False
+
     async def on_run_start(self, data: RunStart) -> None:
         experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", "inspect_ai")
         mlflow.set_experiment(experiment_name)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -2834,6 +2834,21 @@ async def _task_run_sample_attempt(
                                 logger.buffer_db is None
                                 or not sample_transcript.history.resident_events_truncated
                             )
+                            # the log_from_memory disjunct is inert for
+                            # behavior (log_sample never reads
+                            # materialize_full_sample on the from-memory
+                            # path) but upholds the documented invariant
+                            # that from_memory=True is always paired with
+                            # materialize_full_sample=True
+                            materialize_full_sample = (
+                                log_from_memory
+                                or _finalization_consumes_events(
+                                    scanning=scanner is not None
+                                    and scan_id is not None,
+                                    sample_feed=sample_feed,
+                                    task_source=task_source,
+                                )
+                            )
                             eval_sample = await log_sample(
                                 eval_sample=make_eval_sample(
                                     include_events=log_from_memory
@@ -2841,6 +2856,7 @@ async def _task_run_sample_attempt(
                                 logger=logger,
                                 log_images=log_images,
                                 from_memory=log_from_memory,
+                                materialize_full_sample=materialize_full_sample,
                             )
                         else:
                             eval_sample = make_eval_sample()
@@ -3041,18 +3057,67 @@ def create_eval_sample(
     )
 
 
+def _finalization_consumes_events(
+    *,
+    scanning: bool,
+    sample_feed: SampleSource | None,
+    task_source: TaskSource | None,
+) -> bool:
+    """Whether any finalization consumer reads the sample's event history.
+
+    On the bounded-evicted path the full event history is re-materialized
+    from the buffer only if some consumer actually reads it. Consumers are
+    the scanner, a sample-feed / task-source completion callback, and any
+    enabled hook that hasn't opted out via ``Hooks.needs_full_sample()``.
+    Hooks are snapshotted here, at finalization start, not at the later
+    ``on_sample_end`` dispatch: a hook that enables itself in that window
+    would still receive the reduced sample. Accepted — hook
+    registration/enablement is a startup-time activity, not something
+    toggled mid-finalization.
+    """
+    from inspect_ai.hooks._hooks import any_hook_needs_full_sample
+
+    return (
+        scanning
+        or sample_feed is not None
+        or task_source is not None
+        or any_hook_needs_full_sample()
+    )
+
+
 async def log_sample(
     eval_sample: EvalSample,
     logger: TaskLogger,
     log_images: bool,
     *,
     from_memory: bool,
+    materialize_full_sample: bool,
 ) -> EvalSample:
-    # No realtime buffer DB, or the full history is still resident in memory:
-    # log directly from the in-memory sample (which carries its events). This
-    # avoids the open_sample_history -> materialize_streaming_sample round-trip
-    # (read every event back out of SQLite + re-validate). `complete_sample`
-    # still finalizes the buffer DB via `_finalize_sample`, so when a realtime
+    """Log a completed sample, returning the sample finalization consumers see.
+
+    Args:
+        eval_sample: The completed sample. Carries its full event history
+            when ``from_memory`` is True, empty events otherwise.
+        logger: Task logger to record the sample with.
+        log_images: Whether to retain base64 images in the log.
+        from_memory: True when the full event history is resident in memory
+            (no realtime buffer DB, or the transcript was never
+            bounded-evicted), so the sample is logged directly rather than
+            streamed back from the buffer.
+        materialize_full_sample: On the buffer read-back path, whether some
+            finalization consumer reads the returned sample's event history;
+            when False the returned sample is reduced (empty events and
+            attachments, timelines ``None``) instead of re-materialized.
+            ``from_memory=True``
+            with ``materialize_full_sample=False`` is a meaningless
+            combination — the from-memory path returns before
+            ``materialize_full_sample`` is read — so callers must pair
+            ``from_memory=True`` with ``materialize_full_sample=True``.
+    """
+    # Logging directly from the in-memory sample avoids the
+    # open_sample_history -> materialize_streaming_sample round-trip (read
+    # every event back out of SQLite + re-validate). `complete_sample` still
+    # finalizes the buffer DB via `_finalize_sample`, so when a realtime
     # buffer exists it stays consistent for live viewing.
     if logger.buffer_db is None or from_memory:
         await logger.complete_sample(
@@ -3070,7 +3135,24 @@ async def log_sample(
     with logger.buffer_db.open_sample_history(
         eval_sample.id, eval_sample.epoch
     ) as sample_history:
-        materialized_sample = materialize_streaming_sample(eval_sample, sample_history)
+        # eval_sample carries full attachments even though its events are
+        # empty on this path: checkpoint-restored attachment content can
+        # live only in the transcript dict, not the buffer history, so it
+        # must seed both the written log and materialize_streaming_sample's
+        # merge. The materialize_full_sample=False branch empties
+        # attachments and timelines too (TimelineEvent holds real Event
+        # refs, which would otherwise hand back the event tree the
+        # reduction withholds), so an opted-out consumer
+        # (Hooks.needs_full_sample()) gets the fully reduced sample;
+        # consumers that read them force materialize_full_sample=True at
+        # the call site, so nothing that reads them can observe the
+        # reduced sample. logging_sample was derived above, before this
+        # branch, so the written log keeps its timelines either way.
+        materialized_sample = (
+            materialize_streaming_sample(eval_sample, sample_history)
+            if materialize_full_sample
+            else eval_sample.model_copy(update={"attachments": {}, "timelines": None})
+        )
         await logger.complete_sample_streaming(
             logging_sample, sample_history, flush=True
         )

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -191,7 +191,12 @@ class SampleEnd:
     sample_id: str
     """The globally unique identifier for the sample execution."""
     sample: EvalSample
-    """The sample that has run."""
+    """The sample that has run.
+
+    ``events`` and ``attachments`` may be empty and ``timelines`` ``None``
+    when the receiving hook overrides ``needs_full_sample()`` to return
+    ``False`` (see ``Hooks.needs_full_sample``).
+    """
 
 
 @dataclass(frozen=True)
@@ -405,7 +410,25 @@ class Hooks:
         variable or a configuration setting.
 
         Will be called frequently, so consider caching the result if the computation is
-        expensive.
+        expensive. Implementations should return a stable value for the duration of a
+        sample: enablement is consulted both when sample finalization begins and again
+        at each hook dispatch, and a value that flips in between can deliver a reduced
+        ``SampleEnd.sample`` to a hook that did not opt out.
+        """
+        return True
+
+    def needs_full_sample(self) -> bool:
+        """Whether ``on_sample_end`` requires the fully materialized sample.
+
+        Default implementation returns True, preserving the fully populated
+        sample for hooks enabled when sample finalization begins.
+
+        Hooks that read only summary-level fields (id, scores, error, ...) may
+        override this to return ``False``, permitting delivery of
+        ``SampleEnd.sample`` with empty ``events`` and ``attachments`` and
+        ``timelines`` set to ``None``. A permission, not a guarantee: the
+        fully populated sample is still delivered whenever anything else in
+        the eval needs it, so an opted-out hook must tolerate both forms.
         """
         return True
 
@@ -1089,6 +1112,35 @@ def get_all_hooks() -> list[Hooks]:
         )
         _hooks_cache_state = state
     return _hooks_cache
+
+
+def any_hook_needs_full_sample() -> bool:
+    """Whether any enabled hook requires the fully materialized sample.
+
+    Read at sample-finalization start to decide whether a bounded-evicted
+    event history must be re-materialized for ``on_sample_end``: an
+    opted-out hook (``needs_full_sample()`` returning ``False``) permits
+    skipping that re-materialization, but any other registered consumer —
+    another hook, a scanner, a sample/task source — still forces it for
+    every hook (see ``_finalization_consumes_events`` in
+    ``_eval/task/run.py``). The ``enabled()`` gate is load-bearing:
+    always-registered module-level hooks (e.g. in ``tests/_control/``) rely
+    on it to not defeat the optimization. A hook whose ``enabled()`` or
+    ``needs_full_sample()`` raises is logged and counted as needing the
+    full sample: fail toward materialization, never toward silently
+    reducing a sample a broken hook might need.
+    """
+    for hook in get_all_hooks():
+        try:
+            if hook.enabled() and hook.needs_full_sample():
+                return True
+        except Exception as ex:
+            logger.warning(
+                f"Exception consulting enabled()/needs_full_sample() on hook "
+                f"'{hook.__class__.__name__}': {ex}"
+            )
+            return True
+    return False
 
 
 async def _emit_to_all(callable: Callable[[Hooks], Awaitable[None]]) -> None:

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -69,6 +69,12 @@ from .._log import (
 )
 from .._resolve import rebind_sample_timelines, resolve_sample_events_data
 from .file import FileRecorder, write_local_snapshot
+from .json_write import (
+    BinaryWriteStream,
+    write_events_data_field,
+    write_json_array_field,
+    write_json_object_field,
+)
 
 logger = getLogger(__name__)
 
@@ -934,7 +940,11 @@ class ZipLogFile:
             attachments = _sample_history_attachments(
                 sample, history, events, events_data
             )
-            sample_data: dict[str, Any] = jsonable_dict(
+            # Header = the event-less sample's own fields (small). The large
+            # collections are streamed after it chunk-by-chunk, so the
+            # whole-sample jsonable tree and byte blob never exist at once
+            # and the event loop gets a checkpoint between chunks.
+            header: dict[str, JsonValue] = jsonable_dict(
                 sample.model_dump(
                     mode="python",
                     exclude_none=True,
@@ -942,15 +952,44 @@ class ZipLogFile:
                     fallback=lambda _x: None,
                 )
             )
-            sample_data.update(
-                {
-                    "events": events,
-                    "attachments": attachments,
-                    "events_data": events_data,
-                }
-            )
-
-            self._zip_writestr(_sample_filename(sample.id, sample.epoch), sample_data)
+            header_bytes = to_json_safe(header, indent=None)
+            # non-empty dict ({...} not {}): id/epoch are required non-None
+            assert len(header_bytes) > 2
+            # Shielded: sample members must always be complete JSON (_read_log
+            # parses every one eagerly, so a truncated member fails the whole
+            # log read). Without the shield, a cancellation delivered at one
+            # of the checkpoints below would let _zip_open_write's __exit__
+            # finalize a truncated member. Checkpoints still yield under the
+            # shield (liveness is retained); cancellation is simply deferred
+            # until this entry completes.
+            with anyio.CancelScope(shield=True):
+                filename = _sample_filename(sample.id, sample.epoch)
+                try:
+                    with self._zip_open_write(filename) as stream:
+                        # header always has fields (id/epoch), so stripping the
+                        # closing brace and continuing with comma-prefixed
+                        # fields is well-formed
+                        stream.write(header_bytes[:-1])
+                        await write_json_array_field(
+                            stream, "events", events, comma=True
+                        )
+                        await write_json_object_field(
+                            stream, "attachments", attachments, comma=True
+                        )
+                        await write_events_data_field(stream, events_data, comma=True)
+                        stream.write(b"}")
+                except BaseException:
+                    # the failed write already registered a truncated member,
+                    # which would make every sample unreadable (_read_log
+                    # parses each member eagerly); supersede it with the
+                    # event-less header (readers resolve duplicate names to
+                    # the last entry), then propagate. Timelines are dropped
+                    # too: their events serialize as UUID strings that cannot
+                    # rebind against the stub's empty events, which would fail
+                    # the read the stub exists to protect.
+                    header.pop("timelines", None)
+                    self._zip_writestr(filename, header)
+                    raise
 
             # evict a buffered prior record for the same (id, epoch): its
             # member would otherwise be flush-written *after* the streaming
@@ -1183,16 +1222,30 @@ class ZipLogFile:
             )
 
     @contextmanager
-    def _zip_open_write(self, filename: str) -> Generator[IO[bytes], None, None]:
+    def _zip_open_write(
+        self, filename: str
+    ) -> Generator[BinaryWriteStream, None, None]:
         """Open a ZIP entry for streaming writes.
 
         Returns a writable binary stream. The caller writes raw bytes
         (typically JSON) directly. The entry is finalized when the
-        context manager exits.
+        context manager exits. Repeated member names are deliberate
+        superseding (same rule as ``_zip_writestr``).
         """
         assert self._zip
-        with self._zip.open(filename, "w", force_zip64=True) as stream:
+        # the duplicate-name warning is emitted by ZipFile.open itself, so
+        # suppress it only there: catch_warnings mutates process-global state
+        # and must not span the caller's await checkpoints while the entry
+        # is open
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Duplicate name:", category=UserWarning
+            )
+            stream = self._zip.open(filename, "w", force_zip64=True)
+        try:
             yield stream
+        finally:
+            stream.close()
 
 
 def _sample_history_attachments(

--- a/src/inspect_ai/log/_recorders/json_write.py
+++ b/src/inspect_ai/log/_recorders/json_write.py
@@ -1,0 +1,142 @@
+"""Incremental JSON writers for zip log entries.
+
+Writers here emit a JSON object entry field-by-field, so whole-sample
+payloads never need a single monolithic jsonable tree + byte blob. The sync
+``write_json_field`` serves the filestore recovery writer
+(``_recover/_stream``); the async chunked writers serve the live streaming
+recorder (``buffer_sample_streaming``) — they checkpoint between chunks and
+so require an event loop, which only the live recorder has. Recovery's sync
+writer instead hand-rolls its events array and streams attachments via
+``_recover/_attachments``.
+"""
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+import anyio.lowlevel
+
+from inspect_ai._util.json import to_json_safe
+
+DEFAULT_JSON_CHUNK_SIZE = 100
+"""Items serialized per chunk when streaming arrays/objects.
+
+Bounds both the transient memory (one chunk's jsonable tree + bytes) and
+the time between event-loop checkpoints. A perf knob, not a correctness
+knob: any positive value produces identical JSON.
+"""
+
+
+class BinaryWriteStream(Protocol):
+    """Write-only binary sink.
+
+    A zip member write handle (``zipfile._ZipWriteFile``) raises on
+    read/seek/tell, so ``IO[bytes]`` would overpromise what callees may do.
+    """
+
+    def write(self, data: bytes, /) -> int: ...
+
+
+def write_json_field(
+    stream: BinaryWriteStream, name: str, value: object, *, comma: bool = False
+) -> None:
+    """Write a single JSON field (``"name": value``) to a binary stream.
+
+    Args:
+        stream: Writable binary stream.
+        name: JSON key.
+        value: Value to serialize via ``to_json_safe``.
+        comma: If True, prepend a comma separator.
+    """
+    if comma:
+        stream.write(b",")
+    stream.write(json.dumps(name).encode("utf-8"))
+    stream.write(b":")
+    stream.write(to_json_safe(value, indent=None))
+
+
+async def write_json_array_field(
+    stream: BinaryWriteStream,
+    name: str,
+    items: Sequence[object],
+    *,
+    comma: bool = False,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
+) -> None:
+    """Write ``"name": [...]``, serializing ``items`` in chunks.
+
+    Yields to the event loop between chunks so a large array cannot
+    monopolize it. Each chunk is serialized independently; the emitted
+    bytes parse identically to a monolithic serialization.
+    """
+    if comma:
+        stream.write(b",")
+    stream.write(json.dumps(name).encode("utf-8"))
+    stream.write(b":[")
+    for start in range(0, len(items), chunk_size):
+        if start:
+            stream.write(b",")
+        # strip the chunk's surrounding [] and splice into the outer array
+        stream.write(
+            to_json_safe(list(items[start : start + chunk_size]), indent=None)[1:-1]
+        )
+        await anyio.lowlevel.checkpoint()
+    stream.write(b"]")
+
+
+async def write_json_object_field(
+    stream: BinaryWriteStream,
+    name: str,
+    mapping: Mapping[str, object],
+    *,
+    comma: bool = False,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
+) -> None:
+    """Write ``"name": {...}``, serializing ``mapping`` in item chunks.
+
+    Materializes all of ``mapping``'s items up front, so it suits in-memory
+    mappings only; disk-backed stores stream one item at a time via
+    ``_recover/_attachments.write_attachments_field`` instead.
+    """
+    if comma:
+        stream.write(b",")
+    stream.write(json.dumps(name).encode("utf-8"))
+    stream.write(b":{")
+    items = list(mapping.items())
+    for start in range(0, len(items), chunk_size):
+        if start:
+            stream.write(b",")
+        stream.write(
+            to_json_safe(dict(items[start : start + chunk_size]), indent=None)[1:-1]
+        )
+        await anyio.lowlevel.checkpoint()
+    stream.write(b"}")
+
+
+async def write_events_data_field(
+    stream: BinaryWriteStream,
+    events_data: Mapping[str, object],
+    *,
+    comma: bool = False,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
+) -> None:
+    """Write the complete ``"events_data": {...}`` field, one chunked array per pool.
+
+    Iterates the mapping rather than hardcoding pool names so a pool added to
+    ``EventsData`` cannot be silently dropped (pool refs are positional, so a
+    dropped pool corrupts reads instead of failing cleanly), and so the caller
+    never owns the field's inner braces.
+
+    The value type is ``object`` rather than ``Sequence[object]`` because mypy
+    accepts a TypedDict (``EventsData``, the real caller's type) only against
+    ``Mapping[str, object]``; the isinstance assert restores the sequence type.
+    """
+    if comma:
+        stream.write(b",")
+    stream.write(b'"events_data":{')
+    for index, (name, items) in enumerate(events_data.items()):
+        assert isinstance(items, Sequence)
+        await write_json_array_field(
+            stream, name, items, comma=index > 0, chunk_size=chunk_size
+        )
+    stream.write(b"}")

--- a/src/inspect_ai/log/_recover/_attachments.py
+++ b/src/inspect_ai/log/_recover/_attachments.py
@@ -6,7 +6,8 @@ import json as json_module
 import os
 import shutil
 from collections.abc import Iterator, MutableMapping
-from typing import IO
+
+from inspect_ai.log._recorders.json_write import BinaryWriteStream
 
 
 class StreamingAttachmentStore(MutableMapping[str, str]):
@@ -75,10 +76,10 @@ class StreamingAttachmentStore(MutableMapping[str, str]):
 
 
 def write_attachments_field(
-    stream: IO[bytes],
+    stream: BinaryWriteStream,
     store: StreamingAttachmentStore,
     *,
-    comma: bool,
+    comma: bool = False,
 ) -> None:
     """Stream the `"attachments"` JSON field to `stream` from `store`.
 

--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -6,7 +6,7 @@ import json as json_module
 import re
 import tempfile
 from logging import getLogger
-from typing import IO, Any
+from typing import Any
 
 from pydantic import JsonValue
 
@@ -38,6 +38,7 @@ from inspect_ai.log._log import (
 )
 from inspect_ai.log._recorders.buffer.filestore import Manifest, SampleBufferFilestore
 from inspect_ai.log._recorders.eval import ZipLogFile, _sample_filename
+from inspect_ai.log._recorders.json_write import write_json_field
 from inspect_ai.model._chat_message import ChatMessage
 
 from ._attachments import StreamingAttachmentStore, write_attachments_field
@@ -49,24 +50,6 @@ from ._reconstruct import (
 )
 
 logger = getLogger(__name__)
-
-
-def _write_json_field(
-    stream: IO[bytes], name: str, value: object, comma: bool = False
-) -> None:
-    """Write a single JSON field (``"name": value``) to a binary stream.
-
-    Args:
-        stream: Writable binary stream.
-        name: JSON key.
-        value: Value to serialize via ``to_json_safe``.
-        comma: If True, prepend a comma separator.
-    """
-    if comma:
-        stream.write(b",")
-    stream.write(json_module.dumps(name).encode("utf-8"))
-    stream.write(b":")
-    stream.write(to_json_safe(value, indent=None))
 
 
 def _write_sample_streaming(
@@ -156,10 +139,10 @@ def _write_sample_streaming(
             stream.write(b"{")
 
             # Write scalar fields from summary (input written later after walking)
-            _write_json_field(stream, "id", summary.id)
-            _write_json_field(stream, "epoch", summary.epoch, comma=True)
-            _write_json_field(stream, "choices", summary.choices, comma=True)
-            _write_json_field(stream, "target", summary.target, comma=True)
+            write_json_field(stream, "id", summary.id)
+            write_json_field(stream, "epoch", summary.epoch, comma=True)
+            write_json_field(stream, "choices", summary.choices, comma=True)
+            write_json_field(stream, "target", summary.target, comma=True)
 
             collapser = EventVersionCollapser()
             read_count = 0
@@ -308,9 +291,9 @@ def _write_sample_streaming(
             )
 
             # Sample init-derived fields
-            _write_json_field(stream, "sandbox", sandbox_value, comma=True)
-            _write_json_field(stream, "files", files_value, comma=True)
-            _write_json_field(stream, "setup", setup_value, comma=True)
+            write_json_field(stream, "sandbox", sandbox_value, comma=True)
+            write_json_field(stream, "files", files_value, comma=True)
+            write_json_field(stream, "setup", setup_value, comma=True)
 
             # Summary-derived scalars
             if sample_metadata is None:
@@ -320,53 +303,51 @@ def _write_sample_streaming(
                     and sample_init.sample.metadata is not None
                     else summary.metadata
                 )
-            _write_json_field(stream, "metadata", sample_metadata, comma=True)
-            _write_json_field(stream, "scores", summary.scores, comma=True)
+            write_json_field(stream, "metadata", sample_metadata, comma=True)
+            write_json_field(stream, "scores", summary.scores, comma=True)
 
             # Store: parity with DB recovery path (defaults to {}).
-            _write_json_field(stream, "store", {}, comma=True)
+            write_json_field(stream, "store", {}, comma=True)
 
-            _write_json_field(stream, "model_usage", summary.model_usage, comma=True)
-            _write_json_field(stream, "role_usage", summary.role_usage, comma=True)
-            _write_json_field(
+            write_json_field(stream, "model_usage", summary.model_usage, comma=True)
+            write_json_field(stream, "role_usage", summary.role_usage, comma=True)
+            write_json_field(
                 stream, "model_fallbacks", summary.model_fallbacks, comma=True
             )
-            _write_json_field(stream, "turn_count", summary.turn_count, comma=True)
-            _write_json_field(stream, "token_limit", summary.token_limit, comma=True)
-            _write_json_field(
+            write_json_field(stream, "turn_count", summary.turn_count, comma=True)
+            write_json_field(stream, "token_limit", summary.token_limit, comma=True)
+            write_json_field(
                 stream, "token_limit_type", summary.token_limit_type, comma=True
             )
-            _write_json_field(
+            write_json_field(
                 stream, "token_limit_usage", summary.token_limit_usage, comma=True
             )
-            _write_json_field(
-                stream, "message_limit", summary.message_limit, comma=True
-            )
-            _write_json_field(stream, "time_limit", summary.time_limit, comma=True)
-            _write_json_field(stream, "started_at", summary.started_at, comma=True)
-            _write_json_field(stream, "completed_at", summary.completed_at, comma=True)
-            _write_json_field(stream, "total_time", summary.total_time, comma=True)
-            _write_json_field(stream, "working_time", summary.working_time, comma=True)
-            _write_json_field(stream, "uuid", summary.uuid, comma=True)
+            write_json_field(stream, "message_limit", summary.message_limit, comma=True)
+            write_json_field(stream, "time_limit", summary.time_limit, comma=True)
+            write_json_field(stream, "started_at", summary.started_at, comma=True)
+            write_json_field(stream, "completed_at", summary.completed_at, comma=True)
+            write_json_field(stream, "total_time", summary.total_time, comma=True)
+            write_json_field(stream, "working_time", summary.working_time, comma=True)
+            write_json_field(stream, "uuid", summary.uuid, comma=True)
 
             # Not reconstructable from buffer -- emit nulls.
-            _write_json_field(stream, "timelines", None, comma=True)
-            _write_json_field(stream, "invalidation", None, comma=True)
+            write_json_field(stream, "timelines", None, comma=True)
+            write_json_field(stream, "invalidation", None, comma=True)
 
-            _write_json_field(stream, "error", error, comma=True)
-            _write_json_field(stream, "error_retries", None, comma=True)
-            _write_json_field(stream, "limit", limit_value, comma=True)
+            write_json_field(stream, "error", error, comma=True)
+            write_json_field(stream, "error_retries", None, comma=True)
+            write_json_field(stream, "limit", limit_value, comma=True)
 
-            _write_json_field(stream, "input", walked_input, comma=True)
-            _write_json_field(stream, "messages", walked_messages, comma=True)
-            _write_json_field(stream, "output", output, comma=True)
+            write_json_field(stream, "input", walked_input, comma=True)
+            write_json_field(stream, "messages", walked_messages, comma=True)
+            write_json_field(stream, "output", output, comma=True)
             write_attachments_field(stream, attachments, comma=True)
 
             # Always emit events_data (null when pools empty / no events).
             events_data: EventsData | None = None
             if include_events and (message_pool or call_pool):
                 events_data = EventsData(messages=message_pool, calls=call_pool)
-            _write_json_field(stream, "events_data", events_data, comma=True)
+            write_json_field(stream, "events_data", events_data, comma=True)
 
             stream.write(b"}")
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,45 @@ def protect_registrations(
 
 
 @pytest.fixture
+def isolated_hooks_registry():
+    """Hide hooks registered elsewhere in the process for the test's duration.
+
+    Tests asserting that *no* enabled hook needs a full sample (the
+    ``needs_full_sample`` negatives) are assertions about the process-wide
+    hooks registry: a single always-enabled hook from an installed extension's
+    entry point (CI pre-installs ``tests/test_package``) or a leak from
+    another test flips them. Force entry-point loading *before* snapshotting —
+    with the registry emptied, the first ``get_all_hooks()`` in the test would
+    otherwise hit ``registry_find``'s empty-result fallback and re-register
+    every extension's hooks mid-test. Restore only what was removed and leave
+    hooks registered during the test in place: an entry-point hook deleted
+    here could never be re-registered, since ``ensure_entry_points`` only
+    re-imports and ``@hooks`` decorators don't re-run for a module already in
+    ``sys.modules`` (tests clean up their own registrations).
+    """
+    from inspect_ai._util import registry as registry_mod
+    from inspect_ai._util.entrypoints import ensure_entry_points
+
+    ensure_entry_points()
+    saved = {
+        key: value
+        for key, value in registry_mod._registry.items()
+        if key.startswith("hooks:")
+    }
+    for key in saved:
+        del registry_mod._registry[key]
+    try:
+        yield
+    finally:
+        registry_mod._registry.update(saved)
+        # Restoring via direct dict update bumps neither the registry version
+        # nor (when the test registered and removed hooks of its own) the
+        # length, so get_all_hooks()'s (version, len) cache can hold a stale
+        # list; bump the version so it re-walks.
+        registry_mod._registry_version += 1
+
+
+@pytest.fixture
 def no_model_copyreg_reducer():
     """Suspend any copyreg reducer registered for Model for the test's duration.
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -1,8 +1,11 @@
-from typing import Generator, Type, TypeVar
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Generator, Type, TypeVar
 from unittest.mock import patch
 
 import pytest
 
+import inspect_ai.hooks._hooks as hooks_module
 import inspect_ai.hooks._startup as hooks_startup_module
 from inspect_ai import eval
 from inspect_ai._eval.task.task import Task
@@ -10,6 +13,7 @@ from inspect_ai._util.environ import environ_var
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.registry import _registry, registry_info, registry_lookup
 from inspect_ai.dataset._dataset import Sample
+from inspect_ai.event import TimelineEvent, timeline_build
 from inspect_ai.hooks._hooks import (
     ApiKeyOverride,
     BeforeModelGenerate,
@@ -26,11 +30,16 @@ from inspect_ai.hooks._hooks import (
     SampleStart,
     TaskEnd,
     TaskStart,
+    any_hook_needs_full_sample,
     has_api_key_override,
     hooks,
     override_api_key,
 )
 from inspect_ai.hooks._startup import init_hooks
+from inspect_ai.log._file import read_eval_log
+from inspect_ai.log._log import EvalSample
+from inspect_ai.log._transcript import transcript
+from inspect_ai.model import ModelOutput, get_model
 from inspect_ai.solver._solver import Generate, Solver, solver
 from inspect_ai.solver._task_state import TaskState
 
@@ -587,9 +596,14 @@ def test_hooks_decorator_returns_class() -> None:
     class TestHooksClass(Hooks):
         pass
 
-    assert isinstance(TestHooksClass, type)
-    instance = TestHooksClass()
-    assert isinstance(instance, Hooks)
+    try:
+        assert isinstance(TestHooksClass, type)
+        instance = TestHooksClass()
+        assert isinstance(instance, Hooks)
+    finally:
+        # Registration is a side effect of the decorator, not under test here;
+        # clean it up so it doesn't leak into other tests via get_all_hooks().
+        del _registry["hooks:test_hooks_class"]
 
 
 def test_required_hooks_when_all_installed(
@@ -694,6 +708,303 @@ def _create_mock_hooks(name: str, hooks_class: Type[T]) -> Generator[T, None, No
     finally:
         # Remove the hook from the registry to avoid conflicts in other tests.
         del _registry[f"hooks:{name}"]
+
+
+@contextmanager
+def _hook_context(name: str, hooks_class: Type[T]) -> Generator[T, None, None]:
+    """`_create_mock_hooks` adapted for use as a `with` block in a test body."""
+    yield from _create_mock_hooks(name, hooks_class)
+
+
+@solver
+def _emitting_solver(n: int = 4) -> Solver:
+    """Emits enough transcript events to exceed a resident_tail of 1."""
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        for i in range(n):
+            transcript().info({"i": i})
+        return state
+
+    return solve
+
+
+@solver
+def _emitting_solver_with_model_response(n: int = 100) -> Solver:
+    """Emits filler events, then a real generate() call.
+
+    With a small resident tail, the filler events are evicted while the
+    trailing model-call events stay resident — the shape needed to exercise
+    a hook opt-out against a model response that's still in memory.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        for i in range(n):
+            transcript().info({"i": i})
+        return await generate(state)
+
+    return solve
+
+
+@solver
+def _timeline_adding_solver(n: int = 4) -> Solver:
+    """Emits enough events to exceed a resident_tail of 1, then adds a timeline.
+
+    The timeline wraps the still-resident transcript events, giving the
+    reduced path a `timelines` field whose leaves are real Event objects.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        for i in range(n):
+            transcript().info({"i": i})
+        transcript().add_timeline(
+            timeline_build(list(transcript().events), name="test-timeline")
+        )
+        return state
+
+    return solve
+
+
+class _RecordingHook(Hooks):
+    """Needs the full sample (the default) and records each on_sample_end."""
+
+    def __init__(self) -> None:
+        self.samples: list[EvalSample] = []
+
+    async def on_sample_end(self, data: SampleEnd) -> None:
+        self.samples.append(data.sample)
+
+
+class _SummaryOnlyRecordingHook(_RecordingHook):
+    """Opted out of full-sample materialization via needs_full_sample()."""
+
+    def needs_full_sample(self) -> bool:
+        return False
+
+
+def _run_evicted_sample_eval(
+    monkeypatch: pytest.MonkeyPatch, log_dir: str, solve: Solver | None = None
+) -> None:
+    """Run a one-sample eval whose transcript is bounded-evicted.
+
+    Asserts the eviction precondition (the sample was NOT logged from
+    memory): callers assert full-sample materialization, which holds
+    trivially on the resident path, so a silently broken eviction setup
+    (e.g. a renamed INSPECT_TRANSCRIPT_BOUNDED) would otherwise make those
+    tests pass vacuously.
+    """
+    import inspect_ai._eval.task.run as run_module
+
+    monkeypatch.setattr(run_module, "DEFAULT_RESIDENT_TAIL", 1)
+    monkeypatch.setenv("INSPECT_TRANSCRIPT_BOUNDED", "true")
+
+    from_memory_calls: list[bool] = []
+    original_log_sample = run_module.log_sample
+
+    async def spying_log_sample(*args: Any, **kwargs: Any) -> EvalSample:
+        # from_memory is keyword-only, so it is always present in kwargs
+        from_memory_calls.append(kwargs["from_memory"])
+        return await original_log_sample(*args, **kwargs)
+
+    monkeypatch.setattr(run_module, "log_sample", spying_log_sample)
+    eval(
+        Task(dataset=[Sample("sample_1")], solver=[solve or _emitting_solver()]),
+        model="mockllm/model",
+        log_dir=log_dir,
+        display="none",
+    )
+    assert from_memory_calls == [False], (
+        "eviction precondition not met: the sample was logged from memory"
+    )
+
+
+def test_opted_out_hook_receives_event_less_sample_when_evicted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    isolated_hooks_registry,
+) -> None:
+    """The opted-out hook's sample carries neither raw events nor attachments.
+
+    A >100-char model response inside the resident tail is the shape that
+    catches attachments leaking independently of events: attachments are
+    populated by the (still-resident) model event's condensing, not by the
+    evicted-vs-resident events list itself, so a scenario with no long
+    content can pass `attachments == {}` vacuously.
+
+    `isolated_hooks_registry` keeps the reduction assertion deterministic: an
+    installed extension's entry-point hook (whose `needs_full_sample()`
+    defaults to `True`) would otherwise force full materialization for
+    every hook, this one included.
+    """
+    import inspect_ai._eval.task.run as run_module
+
+    monkeypatch.setattr(run_module, "DEFAULT_RESIDENT_TAIL", 20)
+    monkeypatch.setenv("INSPECT_TRANSCRIPT_BOUNDED", "true")
+    # >100 chars: exceeds the condense threshold, so the response is pooled
+    # as an attachment rather than kept inline
+    long_response = "x" * 150
+
+    with _hook_context("summary_only_hook", _SummaryOnlyRecordingHook) as hook:
+        eval(
+            Task(
+                dataset=[Sample("sample_1")],
+                solver=[_emitting_solver_with_model_response()],
+            ),
+            model=get_model(
+                "mockllm/model",
+                custom_outputs=[
+                    ModelOutput.from_content("mockllm/model", long_response)
+                ],
+            ),
+            log_dir=str(tmp_path),
+            display="none",
+        )
+
+    assert len(hook.samples) == 1
+    sample = hook.samples[0]
+    assert sample.events == [] and sample.attachments == {}
+    # the fields a summary-only consumer actually reads remain intact
+    assert sample.output.completion == long_response
+    assert sample.messages
+    assert sample.total_time is not None
+
+
+def test_opted_out_hook_receives_timeline_less_sample_when_evicted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    isolated_hooks_registry,
+) -> None:
+    """The opted-out hook's sample carries no timelines, but the log keeps them.
+
+    `TimelineEvent.event` holds real Event objects (shared refs, not
+    copies), so timelines riding through the reduction would hand the hook
+    the full event tree that emptying `events` was meant to withhold — and
+    retaining the sample would pin that memory. The written log must be
+    unaffected: it draws timelines from the same `EvalSample` before the
+    reduction branch, so clearing them any earlier (e.g. in
+    `create_eval_sample`) would silently drop them from the log.
+    """
+    with _hook_context("timeline_summary_only_hook", _SummaryOnlyRecordingHook) as hook:
+        _run_evicted_sample_eval(
+            monkeypatch, str(tmp_path), solve=_timeline_adding_solver()
+        )
+
+    assert len(hook.samples) == 1
+    sample = hook.samples[0]
+    assert sample.events == []
+    assert sample.timelines is None
+
+    log = read_eval_log(str(next(tmp_path.glob("*.eval"))))
+    assert log.samples is not None
+    logged = log.samples[0]
+    assert logged.timelines is not None
+    assert logged.timelines[0].name == "test-timeline"
+    # the timeline's UUID refs rebind to the logged events on read-back
+    logged_event_ids = {event.uuid for event in logged.events}
+    timeline_event_ids = {
+        item.event.uuid
+        for item in logged.timelines[0].root.content
+        if isinstance(item, TimelineEvent)
+    }
+    assert timeline_event_ids and timeline_event_ids <= logged_event_ids
+
+
+def test_default_hook_still_receives_full_sample_when_evicted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    with _hook_context("full_sample_hook", _RecordingHook) as hook:
+        _run_evicted_sample_eval(monkeypatch, str(tmp_path))
+
+    assert len(hook.samples) == 1
+    assert len(hook.samples[0].events) > 0
+
+
+def test_mixed_hooks_both_receive_full_sample_when_one_needs_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One opted-out + one default hook: needs_full_sample() is a floor, not per-hook.
+
+    `materialize_full_sample` is computed once for the sample from all enabled hooks
+    combined (`any_hook_needs_full_sample()`), and every
+    hook is dispatched the same `SampleEnd.sample` object. So a single
+    full-sample hook forces materialization for everyone on the sample,
+    including hooks that opted out.
+    """
+    with (
+        _hook_context(
+            "mixed_summary_only_hook", _SummaryOnlyRecordingHook
+        ) as summary_hook,
+        _hook_context("mixed_full_sample_hook", _RecordingHook) as full_hook,
+    ):
+        _run_evicted_sample_eval(monkeypatch, str(tmp_path))
+
+    assert len(summary_hook.samples) == 1
+    assert len(full_hook.samples) == 1
+    assert len(summary_hook.samples[0].events) > 0
+    assert summary_hook.samples[0] is full_hook.samples[0]
+
+
+def test_any_hook_needs_full_sample_predicate(isolated_hooks_registry) -> None:
+    """Only hooks that are enabled and haven't opted out count."""
+
+    class OptedOutHook(Hooks):
+        def needs_full_sample(self) -> bool:
+            return False
+
+    class DisabledHook(Hooks):
+        def enabled(self) -> bool:
+            return False
+
+    class FullSampleHook(Hooks):
+        pass
+
+    assert not any_hook_needs_full_sample()
+    with _hook_context("predicate_opted_out_hook", OptedOutHook):
+        assert not any_hook_needs_full_sample()
+        with _hook_context("predicate_disabled_hook", DisabledHook):
+            assert not any_hook_needs_full_sample()
+            with _hook_context("predicate_full_sample_hook", FullSampleHook):
+                assert any_hook_needs_full_sample()
+
+
+class _RaisingEnabledHook(Hooks):
+    def enabled(self) -> bool:
+        raise RuntimeError("enabled() failed")
+
+
+class _RaisingNeedsFullSampleHook(Hooks):
+    def needs_full_sample(self) -> bool:
+        raise RuntimeError("needs_full_sample() failed")
+
+
+@pytest.mark.parametrize(
+    "hook_class",
+    [_RaisingEnabledHook, _RaisingNeedsFullSampleHook],
+    ids=["enabled", "needs_full_sample"],
+)
+def test_any_hook_needs_full_sample_guards_raising_hook(
+    isolated_hooks_registry, hook_class: type[Hooks]
+) -> None:
+    """A raising predicate method is logged and counted as needing the full sample."""
+    with _hook_context("predicate_raising_hook", hook_class):
+        with patch.object(hooks_module.logger, "warning") as warning:
+            assert any_hook_needs_full_sample()
+    assert hook_class.__name__ in str(warning.call_args)
+
+
+def test_opted_out_hook_unaffected_on_non_evicted_path(tmp_path: Path) -> None:
+    with _hook_context(
+        "summary_only_hook_non_evicted", _SummaryOnlyRecordingHook
+    ) as hook:
+        eval(
+            Task(dataset=[Sample("sample_1")]),
+            model="mockllm/model",
+            log_dir=str(tmp_path),
+        )
+
+    assert len(hook.samples) == 1
+    assert len(hook.samples[0].events) > 0
 
 
 @solver

--- a/tests/log/test_json_write.py
+++ b/tests/log/test_json_write.py
@@ -1,0 +1,98 @@
+"""Tests for the json_write incremental JSON field writers."""
+
+import io
+import json
+
+import pytest
+
+from inspect_ai._util.json import to_json_safe
+from inspect_ai.log._recorders.json_write import (
+    DEFAULT_JSON_CHUNK_SIZE,
+    write_events_data_field,
+    write_json_array_field,
+    write_json_field,
+    write_json_object_field,
+)
+from inspect_ai.model._chat_message import ChatMessageUser
+
+_HOSTILE = 'héllo 🎉 日本語 "quoted"'
+"""Multi-byte content plus an embedded quote, to pin the encode/escape split.
+
+Field names are escaped via ``json.dumps``, while mapping keys and values
+are serialized by ``to_json_safe`` inside the chunk byte splice; a refactor
+to e.g. ``f'"{name}"'.encode()`` breaks on exactly this content.
+"""
+
+
+@pytest.mark.parametrize(
+    "n_items",
+    [
+        0,
+        1,
+        DEFAULT_JSON_CHUNK_SIZE - 1,
+        DEFAULT_JSON_CHUNK_SIZE,
+        DEFAULT_JSON_CHUNK_SIZE + 1,
+        2 * DEFAULT_JSON_CHUNK_SIZE,
+    ],
+)
+async def test_streamed_fields_match_monolithic_serialization(n_items: int) -> None:
+    events = [
+        {"event": "info", "data": f"payload {i} {_HOSTILE}"} for i in range(n_items)
+    ]
+    attachments = {
+        f"hash{i} {_HOSTILE}": f"content {i} {_HOSTILE}" for i in range(n_items)
+    }
+    buf = io.BytesIO()
+    buf.write(b"{")
+    write_json_field(buf, "id", "s1")
+    write_json_field(buf, _HOSTILE, "hostile-field-name", comma=True)
+    await write_json_array_field(buf, "events", events, comma=True)
+    await write_json_object_field(buf, "attachments", attachments, comma=True)
+    buf.write(b"}")
+
+    expected = {
+        "id": "s1",
+        _HOSTILE: "hostile-field-name",
+        "events": events,
+        "attachments": attachments,
+    }
+    assert json.loads(buf.getvalue()) == json.loads(to_json_safe(expected, indent=None))
+
+
+async def test_streamed_array_serializes_pydantic_values() -> None:
+    # events_data message pools hold ChatMessage models, not plain dicts
+    messages = [ChatMessageUser(content=f"msg {i}") for i in range(5)]
+    buf = io.BytesIO()
+    buf.write(b"{")
+    await write_json_array_field(buf, "messages", messages, chunk_size=2)
+    buf.write(b"}")
+    assert json.loads(buf.getvalue()) == json.loads(
+        to_json_safe({"messages": messages}, indent=None)
+    )
+
+
+async def test_streamed_events_data_matches_monolithic_serialization() -> None:
+    events_data = {
+        "messages": [ChatMessageUser(content=f"msg {i}") for i in range(5)],
+        "calls": [{"request": {"messages": [f"call {i}"]}} for i in range(3)],
+    }
+    buf = io.BytesIO()
+    buf.write(b'{"id":"s1"')
+    await write_events_data_field(buf, events_data, comma=True, chunk_size=2)
+    buf.write(b"}")
+
+    expected = b'{"id":"s1","events_data":' + to_json_safe(events_data, indent=None)
+    assert buf.getvalue() == expected + b"}"
+
+
+async def test_streamed_events_data_writes_every_pool() -> None:
+    # a pool added to EventsData must not be silently dropped: events keep
+    # positional refs into it, so a dropped pool corrupts reads
+    events_data = {"messages": [], "calls": [], "futures": [{"x": 1}]}
+    buf = io.BytesIO()
+    buf.write(b"{")
+    await write_events_data_field(buf, events_data)
+    buf.write(b"}")
+    assert json.loads(buf.getvalue()) == {
+        "events_data": {"messages": [], "calls": [], "futures": [{"x": 1}]}
+    }

--- a/tests/log/test_streaming_completion.py
+++ b/tests/log/test_streaming_completion.py
@@ -1,11 +1,22 @@
-from collections.abc import Sequence
+import contextlib
+import re
+import warnings
+from collections.abc import Awaitable, Callable, Generator, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Literal
 
+import anyio
 import pytest
+from pydantic import JsonValue
 from test_helpers.task_logger import TaskLoggerShim
+from typing_extensions import assert_never
 
-from inspect_ai._eval.task.run import log_sample
+from inspect_ai import SampleSource, Task, TaskSource, eval
+from inspect_ai._eval.task.run import create_eval_sample, log_sample
+from inspect_ai._util.error import EvalError
+from inspect_ai._util.registry import _registry
+from inspect_ai.dataset import Sample
 from inspect_ai.event import (
     InfoEvent,
     ModelEvent,
@@ -13,22 +24,39 @@ from inspect_ai.event import (
     TimelineEvent,
     TimelineSpan,
 )
+from inspect_ai.hooks import Hooks, hooks
 from inspect_ai.log._condense import condense_sample
-from inspect_ai.log._file import read_eval_log_async
+from inspect_ai.log._file import read_eval_log, read_eval_log_async
 from inspect_ai.log._log import (
     EvalConfig,
     EvalDataset,
     EvalPlan,
     EvalResults,
     EvalSample,
+    EvalSampleLimit,
     EvalSpec,
     EvalStats,
 )
 from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
-from inspect_ai.log._recorders.eval import EvalRecorder
+from inspect_ai.log._recorders.buffer.history import SampleHistory
+from inspect_ai.log._recorders.eval import EvalRecorder, ZipLogFile, _sample_filename
 from inspect_ai.log._recorders.json import JSONRecorder
+from inspect_ai.log._recorders.json_write import (
+    DEFAULT_JSON_CHUNK_SIZE,
+    write_json_object_field,
+)
+from inspect_ai.log._recorders.streaming import materialize_streaming_sample
 from inspect_ai.log._recorders.types import SampleEvent
-from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput
+from inspect_ai.log._transcript import Transcript, init_transcript, transcript
+from inspect_ai.model import (
+    ChatMessageUser,
+    GenerateConfig,
+    ModelCall,
+    ModelName,
+    ModelOutput,
+)
+from inspect_ai.scorer import Score, Target
+from inspect_ai.solver import Generate, Solver, TaskState, solver
 
 
 def _model(uuid: str, content: str) -> ModelEvent:
@@ -71,12 +99,7 @@ async def test_log_sample_returns_materialized_streaming_sample(
     )
     recorder = EvalRecorder(str(tmp_path))
     spec = _eval_spec()
-    logger = TaskLoggerShim(db)
-    logger.recorder = recorder
-    logger.eval = spec
-    logger.flush_buffer = 1
-    logger.flush_pending = []
-    logger._samples_completed = 0
+    logger = _shim_logger(db, recorder, spec)
     await recorder.log_init(spec, str(tmp_path / "streaming.eval"), clean=True)
     await recorder.log_start(spec, EvalPlan())
 
@@ -85,6 +108,7 @@ async def test_log_sample_returns_materialized_streaming_sample(
         logger,
         log_images=True,
         from_memory=False,
+        materialize_full_sample=True,
     )
     await _finish_eval(recorder, spec)
 
@@ -120,16 +144,13 @@ async def test_log_sample_rebinds_timelines_to_materialized_events(tmp_path) -> 
     db.log_events([SampleEvent(id="sample", epoch=1, event=transcript_event)])
     recorder = EvalRecorder(str(tmp_path))
     spec = _eval_spec()
-    logger = TaskLoggerShim(db)
-    logger.recorder = recorder
-    logger.eval = spec
-    logger.flush_buffer = 1
-    logger.flush_pending = []
-    logger._samples_completed = 0
+    logger = _shim_logger(db, recorder, spec)
     await recorder.log_init(spec, str(tmp_path / "streaming.eval"), clean=True)
     await recorder.log_start(spec, EvalPlan())
 
-    returned = await log_sample(sample, logger, log_images=True, from_memory=False)
+    returned = await log_sample(
+        sample, logger, log_images=True, from_memory=False, materialize_full_sample=True
+    )
     await _finish_eval(recorder, spec)
 
     assert returned.timelines is not None
@@ -273,13 +294,37 @@ def _eval_spec() -> EvalSpec:
     )
 
 
-def _history(tmp_path):
-    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
-    db.start_sample(_sample().summary())
+def _history(
+    tmp_path: Path, name: str = "test"
+) -> contextlib.AbstractContextManager[SampleHistory]:
+    return _history_for(tmp_path, _sample(), name)
+
+
+def _history_for(
+    tmp_path: Path, sample: EvalSample, name: str
+) -> contextlib.AbstractContextManager[SampleHistory]:
+    db = SampleBufferDatabase(str(tmp_path / f"{name}.eval"), db_dir=tmp_path)
+    db.start_sample(sample.summary())
     db.log_events(
-        [SampleEvent(id="sample", epoch=1, event=_model("event-1", "answer"))]
+        [
+            SampleEvent(
+                id=sample.id, epoch=sample.epoch, event=_model("event-1", "answer")
+            )
+        ]
     )
-    return db.open_sample_history("sample", 1)
+    return db.open_sample_history(sample.id, sample.epoch)
+
+
+def _model_with_call(uuid: str, content: str, call_msgs: list[JsonValue]) -> ModelEvent:
+    """A ModelEvent whose ``call`` request populates the call pool.
+
+    ``condense_model_event_with_indices`` pools ``call.request["messages"]``
+    the same way it pools ``input`` — see ``_CALL_MESSAGE_KEYS`` in
+    ``inspect_ai.event._pool``.
+    """
+    return _model(uuid, content).model_copy(
+        update={"call": ModelCall(request={"messages": call_msgs}, response={})}
+    )
 
 
 def _buffer_db(
@@ -299,24 +344,36 @@ async def _start_eval_recorder(tmp_path: Path) -> tuple[EvalRecorder, EvalSpec]:
     return recorder, spec
 
 
-async def _log_sample_with_buffer(
-    tmp_path: Path,
-    sample: EvalSample,
-    events: Sequence[ModelEvent | InfoEvent],
-    *,
-    log_images: bool,
-) -> tuple[EvalSample, EvalSample]:
-    db = _buffer_db(tmp_path, events)
-    recorder, spec = await _start_eval_recorder(tmp_path)
+def _shim_logger(
+    db: SampleBufferDatabase, recorder: EvalRecorder, spec: EvalSpec
+) -> TaskLoggerShim:
     logger = TaskLoggerShim(db)
     logger.recorder = recorder
     logger.eval = spec
     logger.flush_buffer = 1
     logger.flush_pending = []
     logger._samples_completed = 0
+    return logger
+
+
+async def _log_sample_with_buffer(
+    tmp_path: Path,
+    sample: EvalSample,
+    events: Sequence[ModelEvent | InfoEvent],
+    *,
+    log_images: bool,
+    materialize_full_sample: bool = True,
+) -> tuple[EvalSample, EvalSample]:
+    db = _buffer_db(tmp_path, events)
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    logger = _shim_logger(db, recorder, spec)
 
     returned = await log_sample(
-        sample, logger, log_images=log_images, from_memory=False
+        sample,
+        logger,
+        log_images=log_images,
+        from_memory=False,
+        materialize_full_sample=materialize_full_sample,
     )
     await _finish_eval(recorder, spec)
 
@@ -359,14 +416,11 @@ async def test_log_sample_from_memory_writes_resident_events_without_buffer_read
     )
     db = _buffer_db(tmp_path, [_model("buffer-1", "answer")])
     recorder, spec = await _start_eval_recorder(tmp_path)
-    logger = TaskLoggerShim(db)
-    logger.recorder = recorder
-    logger.eval = spec
-    logger.flush_buffer = 1
-    logger.flush_pending = []
-    logger._samples_completed = 0
+    logger = _shim_logger(db, recorder, spec)
 
-    returned = await log_sample(sample, logger, log_images=False, from_memory=True)
+    returned = await log_sample(
+        sample, logger, log_images=False, from_memory=True, materialize_full_sample=True
+    )
     await _finish_eval(recorder, spec)
 
     logged_samples = (
@@ -399,6 +453,87 @@ async def test_log_sample_streaming_condenses_core_sample_fields_and_merges_hist
     assert logged_message.content.startswith("attachment://")
     assert event_content in logged.attachments.values()
     assert logged.events_data is None
+
+
+@pytest.mark.anyio
+async def test_log_sample_writes_restored_attachment_content_when_events_reduced(
+    tmp_path: Path,
+) -> None:
+    """Checkpoint-restored attachment content must reach the written log.
+
+    Even on the reduced/evicted finalization path (`materialize_full_sample=False`).
+    Simulates a resumed sample the way `_push_host_state`
+    (`inspect_ai/util/_checkpoint/hydrate.py`) does for a real checkpoint
+    resume: `Transcript._extend_restored_events` pushes a condensed event
+    carrying an `attachment://<hash>` ref together with the `{hash:
+    content}` mapping that resolves it. That mapping lives only in the
+    transcript's own attachment store -- the realtime buffer never captured
+    it, since it arrived already condensed rather than as raw content for
+    the buffer's own condenser to hash and store. `create_eval_sample` must
+    seed `EvalSample.attachments` from the transcript unconditionally (not
+    only when `include_events` is set) so the ref still resolves once
+    written, even though the buffer's own history has no content for it.
+
+    The no-eviction setup (`bounded=False`) is deliberate: it isolates the
+    one thing this code path could regress, the unconditional attachment
+    seeding. Bounded eviction dropping the restored mapping itself is a
+    pre-existing upstream bug tracked separately.
+    """
+    attachment_hash = "restoredhash"
+    restored_content = _long_content()
+    restored_ref = f"attachment://{attachment_hash}"
+
+    ts = Transcript(bounded=False)
+    ts._extend_restored_events(
+        [InfoEvent(uuid="restored", data={"content": restored_ref})],
+        {attachment_hash: restored_content},
+    )
+    init_transcript(ts)
+
+    eval_sample = create_eval_sample(
+        start_time=None,
+        sample=Sample(id="sample", input="question", target="answer"),
+        # epoch=1 matches the (id, epoch) key `_log_sample_with_buffer`'s
+        # buffer starts the sample under -- `log_sample` looks up the buffer
+        # history by this key.
+        state=TaskState(
+            model=ModelName("mockllm/model"),
+            sample_id="sample",
+            epoch=1,
+            input="question",
+            messages=[],
+            target=Target("answer"),
+            output=ModelOutput.from_content("mockllm/model", "answer"),
+        ),
+        scores={},
+        error=None,
+        limit=None,
+        error_retries=[],
+        time_limit=None,
+        include_events=False,
+    )
+
+    # The buffer's own history carries the same ref as a short literal
+    # string (as it would if the event were logged already condensed): well
+    # under the buffer's condensing threshold, so its own condenser passes
+    # it through untouched and never hashes/stores content for this ref.
+    # The seed above is the only place the content is available.
+    _returned, logged = await _log_sample_with_buffer(
+        tmp_path,
+        eval_sample,
+        [InfoEvent(uuid="buffered", data={"content": restored_ref})],
+        log_images=True,
+        materialize_full_sample=False,
+    )
+
+    logged_event = logged.events[0]
+    assert isinstance(logged_event, InfoEvent)
+    assert isinstance(logged_event.data, dict)
+    assert logged_event.data["content"] == restored_ref
+
+    assert logged.attachments.get(attachment_hash) == restored_content, (
+        "restored attachment content did not reach the written log: dangling ref"
+    )
 
 
 @pytest.mark.anyio
@@ -460,3 +595,533 @@ async def test_json_recorder_log_sample_streaming_includes_history_attachments(
     assert isinstance(logged_info_event.data, dict)
     assert logged_info_event.data["content"] == buffered_info_event.data["content"]
     assert long_content in log.samples[0].attachments.values()
+
+
+@pytest.mark.anyio
+async def test_streamed_sample_entry_round_trips(tmp_path: Path) -> None:
+    """The streamed zip entry reads back equal to the materialized sample.
+
+    Covers >1 chunk of events, non-empty message and call pools, an
+    attachment, a score, an error, and a limit - order-insensitive.
+    """
+    n_events = DEFAULT_JSON_CHUNK_SIZE + 50
+    events: list[ModelEvent | InfoEvent] = [
+        _model(f"event-{i}", _long_content()) for i in range(n_events)
+    ]
+    call_msgs: list[JsonValue] = [{"role": "user", "content": "call-pool message"}]
+    events[-1] = _model_with_call(f"event-{n_events - 1}", _long_content(), call_msgs)
+
+    sample = _sample().model_copy(
+        update={
+            "scores": {"accuracy": Score(value=1.0, answer="42")},
+            "error": EvalError(message="boom", traceback="tb", traceback_ansi="tb"),
+            "limit": EvalSampleLimit(type="message", limit=50.0),
+        }
+    )
+
+    returned, logged = await _log_sample_with_buffer(
+        tmp_path, sample, events, log_images=True
+    )
+
+    assert len(logged.events) == len(returned.events) == n_events
+    assert logged.events == returned.events
+    assert logged.attachments == returned.attachments
+    assert len(logged.attachments) > 0
+    assert logged.scores == returned.scores == sample.scores
+    assert logged.error == returned.error == sample.error
+    assert logged.limit == returned.limit == sample.limit
+    assert logged.events_data is None
+
+    first_event = logged.events[0]
+    assert isinstance(first_event, ModelEvent)
+    assert first_event.input[0].content == "question"
+
+    call_event = logged.events[-1]
+    assert isinstance(call_event, ModelEvent)
+    assert call_event.call is not None
+    assert call_event.call.request["messages"] == call_msgs
+
+
+@pytest.mark.anyio
+async def test_streamed_sample_entry_empty_events_edge(tmp_path: Path) -> None:
+    """A sample whose history has zero events still writes a valid entry."""
+    recorder, spec = await _start_eval_recorder(tmp_path)
+
+    db = SampleBufferDatabase(str(tmp_path / "empty.eval"), db_dir=tmp_path)
+    db.start_sample(_sample().summary())
+
+    with db.open_sample_history("sample", 1) as history:
+        await recorder.log_sample_streaming(spec, _sample(), history)
+
+    await _finish_eval(recorder, spec)
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+
+    assert log.samples is not None
+    logged = log.samples[0]
+    assert logged.events == []
+    assert logged.attachments == {}
+    assert logged.events_data is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "writer_name", ["write_json_array_field", "write_json_object_field"]
+)
+async def test_buffer_sample_streaming_shields_cancellation_mid_write(
+    writer_name: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cancellation delivered mid-entry-write must not truncate the member.
+
+    Deterministic stand-in for real task cancellation landing at one of the
+    checkpoints inside the entry write: monkeypatches the named writer (the
+    "events" array and the "attachments" object are distinct landing sites
+    within the same entry) to cancel the enclosing scope, so the cancellation
+    is pending at the checkpoint between chunks inside
+    ``buffer_sample_streaming``'s zip-entry write. Without shielding that
+    write, the checkpoint raises there and the mid-write failure repair
+    supersedes the truncated member with an event-less stub, so the
+    sample's events would be silently lost from the finished log.
+    """
+    import inspect_ai.log._recorders.eval as eval_module
+
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    events = [
+        _model(f"event-{i}", _long_content())
+        for i in range(DEFAULT_JSON_CHUNK_SIZE + 50)
+    ]
+    db = _buffer_db(tmp_path, events)
+
+    original_writer = getattr(eval_module, writer_name)
+    fired = {"done": False}
+
+    async def cancel_then_delegate(*args: Any, **kwargs: Any) -> None:
+        fired["done"] = True
+        # cancel() is idempotent, so no first-call guard is needed
+        scope.cancel()
+        await original_writer(*args, **kwargs)
+
+    with anyio.CancelScope() as scope:
+        monkeypatch.setattr(eval_module, writer_name, cancel_then_delegate)
+        with db.open_sample_history("sample", 1) as history:
+            await recorder.log_sample_streaming(spec, _sample(), history)
+        # The shield only defers cancellation past the entry write, it must
+        # not drop it: liveness is retained via the checkpoint below.
+        await anyio.lowlevel.checkpoint()
+
+    assert fired["done"], (
+        f"spy never fired: buffer_sample_streaming no longer routes"
+        f" through {writer_name}"
+    )
+    assert scope.cancelled_caught, "deferred cancellation was never delivered"
+
+    await _finish_eval(recorder, spec)
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+
+    assert log.samples is not None
+    assert len(log.samples[0].events) == len(events)
+
+
+def _fail_second_object_field_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the second sample's streamed entry raise mid-write (one object-field write per sample)."""
+    import inspect_ai.log._recorders.eval as eval_module
+
+    calls = {"n": 0}
+
+    async def failing_object_field(*args: Any, **kwargs: Any) -> None:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("serialization failed mid-write")
+        await write_json_object_field(*args, **kwargs)
+
+    monkeypatch.setattr(eval_module, "write_json_object_field", failing_object_field)
+
+
+@pytest.mark.anyio
+async def test_streamed_write_failure_leaves_log_readable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An exception mid-entry-write must not poison the whole log.
+
+    ``_zip_open_write``'s ``__exit__`` finalizes the zip member on any exit
+    path, so a raise between chunks would otherwise register a truncated
+    (invalid JSON) member — and ``_read_log`` parses every sample member
+    eagerly, so even healthy samples become unreadable. The recorder must
+    supersede the truncated member with a valid one before propagating.
+    """
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    _fail_second_object_field_write(monkeypatch)
+
+    sample_1 = EvalSample(id="s1", epoch=1, input="question", target="answer")
+    sample_2 = EvalSample(id="s2", epoch=1, input="question", target="answer")
+
+    with _history_for(tmp_path, sample_1, name="h1") as history:
+        await recorder.log_sample_streaming(spec, sample_1, history)
+    with pytest.raises(RuntimeError, match="serialization failed mid-write"):
+        with _history_for(tmp_path, sample_2, name="h2") as history:
+            await recorder.log_sample_streaming(spec, sample_2, history)
+
+    await _finish_eval(recorder, spec)
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+
+    assert log.samples is not None
+    by_id = {s.id: s for s in log.samples}
+    healthy = by_id["s1"]
+    assert [event.uuid for event in healthy.events] == ["event-1"]
+    # the failed sample is either absent or a valid event-less stub
+    if "s2" in by_id:
+        assert by_id["s2"].events == []
+        assert by_id["s2"].target == "answer"
+
+
+@pytest.mark.anyio
+async def test_streamed_write_failure_stub_drops_timelines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The repair stub must not retain timelines.
+
+    Timeline events serialize as event-UUID strings which are rebound against
+    ``sample.events`` on read; the stub's events are empty, so a retained
+    timeline fails validation — turning the repair stub itself into the
+    poisoned member it exists to prevent.
+    """
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    _fail_second_object_field_write(monkeypatch)
+
+    def _timeline_sample(id: str) -> EvalSample:
+        return EvalSample(
+            id=id,
+            epoch=1,
+            input="question",
+            target="answer",
+            timelines=[
+                Timeline(
+                    name="main",
+                    description="main timeline",
+                    root=TimelineSpan(
+                        id="root",
+                        name="root",
+                        content=[TimelineEvent(event=_model("event-1", "answer"))],
+                    ),
+                )
+            ],
+        )
+
+    sample_1 = _timeline_sample("s1")
+    sample_2 = _timeline_sample("s2")
+
+    with _history_for(tmp_path, sample_1, name="h1") as history:
+        await recorder.log_sample_streaming(spec, sample_1, history)
+    with pytest.raises(RuntimeError, match="serialization failed mid-write"):
+        with _history_for(tmp_path, sample_2, name="h2") as history:
+            await recorder.log_sample_streaming(spec, sample_2, history)
+
+    await _finish_eval(recorder, spec)
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+
+    assert log.samples is not None
+    by_id = {s.id: s for s in log.samples}
+    # the healthy streamed member keeps its timeline, rebound to its events
+    healthy = by_id["s1"]
+    assert [event.uuid for event in healthy.events] == ["event-1"]
+    assert healthy.timelines is not None
+    healthy_timeline_event = healthy.timelines[0].root.content[0]
+    assert isinstance(healthy_timeline_event, TimelineEvent)
+    assert healthy_timeline_event.event is healthy.events[0]
+    # the repaired stub drops timelines alongside its events/attachments
+    if "s2" in by_id:
+        assert by_id["s2"].events == []
+        assert by_id["s2"].timelines is None
+
+
+@pytest.mark.anyio
+async def test_streaming_path_never_serializes_whole_sample(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Guard: no whole-sample writestr on the streaming path."""
+    written: list[str] = []
+    original = ZipLogFile._zip_writestr
+
+    def recording(self: ZipLogFile, filename: str, data: Any) -> None:
+        written.append(filename)
+        return original(self, filename, data)
+
+    monkeypatch.setattr(ZipLogFile, "_zip_writestr", recording)
+
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    sample = _sample()
+    with _history(tmp_path) as history:
+        await recorder.log_sample_streaming(spec, sample, history)
+    await _finish_eval(recorder, spec)
+
+    # positive controls, so the guard can't pass vacuously: the spy did
+    # record the non-sample members, and the streamed sample itself landed
+    assert written, "spy recorded no writes at all: _zip_writestr patch inert"
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+    assert log.samples is not None
+    assert len(log.samples[0].events) == 1
+
+    assert _sample_filename(sample.id, sample.epoch) not in written, (
+        f"sample entry written via monolithic writestr: {written}"
+    )
+
+
+@pytest.mark.anyio
+async def test_streamed_sample_entry_relog_supersedes_with_no_warning(
+    tmp_path: Path,
+) -> None:
+    """A re-logged (id, epoch) supersedes cleanly with no zipfile warning."""
+    recorder, spec = await _start_eval_recorder(tmp_path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with _history(tmp_path, name="h1") as history:
+            await recorder.log_sample_streaming(
+                spec, _sample().model_copy(update={"target": "stale"}), history
+            )
+        with _history(tmp_path, name="h2") as history:
+            await recorder.log_sample_streaming(spec, _sample(), history)
+    # scoped to zipfile's duplicate-member warning: promoting *all* warnings
+    # to errors would fail on unrelated third-party deprecations
+    assert not [w for w in caught if "Duplicate name" in str(w.message)]
+
+    await _finish_eval(recorder, spec)
+    log = await read_eval_log_async(str(tmp_path / "streaming.eval"))
+
+    assert log.samples is not None and len(log.samples) == 1
+    assert log.samples[0].target == "answer"
+
+
+@pytest.mark.anyio
+async def test_zip_open_write_restores_warning_filters_before_yield(
+    tmp_path: Path,
+) -> None:
+    """The duplicate-name suppression must not span the open entry's lifetime.
+
+    ``warnings.catch_warnings`` mutates process-global filter state; holding
+    it while the entry is open spans every chunk checkpoint of the streamed
+    write, letting concurrent tasks (e.g. two eval_set tasks, each with its
+    own ``ZipLogFile``) run under -- or clobber -- the mutated filters. The
+    warning is emitted by ``ZipFile.open`` itself, so the suppression only
+    needs to wrap that call.
+    """
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    zip_log = recorder.data[recorder._log_file_key(spec)]
+
+    filters_before = warnings.filters
+    with zip_log._zip_open_write("samples/test.json") as stream:
+        assert warnings.filters is filters_before, (
+            "global warnings filters mutated while the zip entry is open"
+        )
+        stream.write(b"{}")
+
+
+@contextlib.contextmanager
+def _registered_hook(name: str, hook_class: type[Hooks]) -> Generator[None, None, None]:
+    """Register `hook_class` under `name` for the duration of the block."""
+    hooks(name, description=f"{name}-description")(hook_class)
+    try:
+        yield
+    finally:
+        del _registry[f"hooks:{name}"]
+
+
+class _FullSampleHook(Hooks):
+    pass
+
+
+class _OptedOutHook(Hooks):
+    def needs_full_sample(self) -> bool:
+        return False
+
+
+class _DisabledFullSampleHook(Hooks):
+    """Disabled hook that would need a full sample (the default) if enabled."""
+
+    def enabled(self) -> bool:
+        return False
+
+
+@solver
+def _attachment_emitting_solver(n: int = 4) -> Solver:
+    """Emits enough transcript events to exceed a resident_tail of 1.
+
+    Each event carries >100 chars of unique content so realtime condensing
+    turns it into an attachment, letting callers assert attachment integrity
+    in the written log non-vacuously. Registered at module level (and named
+    distinctly from test_hooks.py's ``_emitting_solver``): ``@solver``
+    registers by function name in the global registry, so a per-call
+    decoration would re-register on every use.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        for i in range(n):
+            transcript().info({"i": i, "content": f"{i} {_long_content()}"})
+        return state
+
+    return solve
+
+
+Consumer = Literal[
+    "none",
+    "hook_full",
+    "hook_opted_out",
+    "hook_disabled",
+    "scanner",
+    "task_source",
+    "sample_feed",
+]
+
+
+def _drive_evicted_eval(consumer: Consumer, log_dir: str) -> None:
+    """Run a one-sample eval whose transcript is bounded-evicted.
+
+    `consumer` selects which finalization consumer (if any) is wired up,
+    mirroring the branches the `materialize_full_sample` check in `task_run_sample`
+    covers: a hook (registered by the caller around this call), a scanner, a
+    `TaskSource`, or a `SampleSource`.
+    """
+    task = Task(
+        dataset=[Sample(input="question", target="answer")],
+        solver=[_attachment_emitting_solver()],
+    )
+
+    if consumer == "scanner":
+        pytest.importorskip("inspect_scout")
+        from inspect_scout import Result, Transcript
+        from inspect_scout import scanner as scout_scanner
+
+        @scout_scanner(messages="all")
+        def _echo_scanner() -> Callable[[Transcript], Awaitable[Result]]:
+            async def scan(transcript: Transcript) -> Result:
+                return Result(value="ok")
+
+            return scan
+
+        eval(
+            task,
+            scanner=[_echo_scanner()],
+            model="mockllm/model",
+            log_dir=log_dir,
+            display="none",
+        )
+    elif consumer == "task_source":
+
+        class _TaskSourceStub(TaskSource):
+            def initial_tasks(self) -> list[Task]:
+                return [task]
+
+        eval(_TaskSourceStub(), model="mockllm/model", log_dir=log_dir, display="none")
+    elif consumer == "sample_feed":
+
+        class _SampleSourceStub(SampleSource):
+            def initial_samples(self) -> list[Sample]:
+                return [Sample(input="question", target="answer")]
+
+        eval(
+            Task(dataset=_SampleSourceStub(), solver=[_attachment_emitting_solver()]),
+            model="mockllm/model",
+            log_dir=log_dir,
+            display="none",
+        )
+    elif (
+        consumer == "none"
+        or consumer == "hook_full"
+        or consumer == "hook_opted_out"
+        or consumer == "hook_disabled"
+    ):
+        eval(task, model="mockllm/model", log_dir=log_dir, display="none")
+    else:
+        assert_never(consumer)
+
+
+@pytest.mark.parametrize(
+    ("consumer", "expect_materialization"),
+    [
+        ("none", False),
+        ("hook_full", True),
+        ("hook_opted_out", False),
+        ("hook_disabled", False),
+        ("scanner", True),
+        ("task_source", True),
+        ("sample_feed", True),
+    ],
+)
+def test_materialization_is_conditional(
+    consumer: Consumer,
+    expect_materialization: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    isolated_hooks_registry,
+) -> None:
+    """materialize_streaming_sample runs iff some consumer needs events.
+
+    Drives a one-sample eval whose transcript is bounded-evicted
+    (DEFAULT_RESIDENT_TAIL patched to 1) for each finalization consumer kind,
+    and counts calls to materialize_streaming_sample. A plain `def` test:
+    `eval()` manages its own event loop and cannot be called from `async def`.
+
+    `isolated_hooks_registry` makes every row deterministic: the negative
+    rows assert that *no* enabled hook needs a full sample, which any
+    installed extension's entry-point hook would otherwise flip.
+    """
+    import inspect_ai._eval.task.run as run_module
+
+    calls = {"n": 0}
+
+    def counting(sample: EvalSample, history: SampleHistory) -> EvalSample:
+        calls["n"] += 1
+        return materialize_streaming_sample(sample, history)
+
+    monkeypatch.setattr(run_module, "materialize_streaming_sample", counting)
+    monkeypatch.setattr(run_module, "DEFAULT_RESIDENT_TAIL", 1)
+    monkeypatch.setenv("INSPECT_TRANSCRIPT_BOUNDED", "true")
+
+    hook_registration: contextlib.AbstractContextManager[None] = (
+        contextlib.nullcontext()
+    )
+    if consumer == "hook_full":
+        hook_registration = _registered_hook(
+            "materialization_hook_full", _FullSampleHook
+        )
+    elif consumer == "hook_opted_out":
+        hook_registration = _registered_hook(
+            "materialization_hook_opted_out", _OptedOutHook
+        )
+    elif consumer == "hook_disabled":
+        hook_registration = _registered_hook(
+            "materialization_hook_disabled", _DisabledFullSampleHook
+        )
+
+    with hook_registration:
+        _drive_evicted_eval(consumer, str(tmp_path))
+
+    assert (calls["n"] > 0) == expect_materialization
+    _assert_written_log_complete(tmp_path)
+
+
+def _assert_written_log_complete(log_dir: Path, n_info_events: int = 4) -> None:
+    """The written log is undamaged whether or not materialization ran.
+
+    Reads the eval log back and asserts the evicted events all landed and
+    that every `attachment://` ref in the sample resolves to attachment
+    content — the user-visible contract that skipping the in-memory
+    re-materialization does not alter what gets logged.
+    """
+    log = read_eval_log(str(next(log_dir.glob("*.eval"))))
+    assert log.status == "success"
+    assert log.samples is not None and len(log.samples) == 1
+    sample = log.samples[0]
+
+    info_indexes = [
+        event.data["i"]
+        for event in sample.events
+        if isinstance(event, InfoEvent)
+        and isinstance(event.data, dict)
+        and "i" in event.data
+    ]
+    assert info_indexes == list(range(n_info_events))
+
+    refs = set(re.findall(r"attachment://(\w+)", sample.model_dump_json()))
+    assert refs, "expected condensed event content to produce attachment refs"
+    assert refs <= set(sample.attachments), "dangling attachment ref in written log"
+    assert all(sample.attachments[ref] for ref in refs)


### PR DESCRIPTION
## This PR contains:

- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Finalizing long samples with realtime logging holds several copies of their history in memory and serializes each sample in one uninterrupted operation. This increases memory use and stalls other work on the event loop. The full typed history is reconstructed even when no finalization consumer needs it.

### What is the new behavior?

- Sample ZIP entries are serialized in chunks, with event-loop checkpoints between chunks.
- Full typed samples are reconstructed when required by scanners, sample sources, task sources, or enabled hooks. Summary-only hooks can override `Hooks.needs_full_sample()` to return `False`; the default remains `True`. Opting out permits empty `events` and `attachments` and `timelines=None`, but hooks must still accept full samples when another consumer needs them. The docs and MLflow example demonstrate this.
- Writes defer cancellation until the sample entry is complete. A serialization failure supersedes the partial entry with a readable stub, dropping timelines whose events cannot be resolved, before propagating the error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing hooks keep receiving full samples, and the log format is unchanged. Tests verify JSON byte parity and complete saved histories even when hooks receive reduced samples.

### Other information:

The original implementation benchmark (2,000 events × 20 KB; not rerun during cleanup) measured peak finalization memory falling from 2.20× to 1.21× serialized sample size, or 1.27× with a full-history consumer. Maximum event-loop stall fell from 122 ms to 64 ms; the remaining stall comes from loading buffered history eagerly.

The full-PR cleanup removes repetitive comments and consolidates 21 added test functions into eight, preserving all 51 upstream test functions in the affected files. Added test/source lines fall from 1,169/390 (3.00×) to 591/252 (2.35×).

The restored-attachment regression test covers content still resident in the transcript. Eviction of restored attachment content was identified during original validation as a separate restore-path issue and is not covered by this fix.

Validation after cleanup:

```sh
uv run --no-sync make check
TMPDIR=/mnt/data/scratch/cleanup-4879 PYTEST_ADDOPTS='-n 8 --timeout=180 --timeout-method=thread --color=no' uv run --no-sync make test
```

- `make check` passed, including mypy on 1,486 files and the suppression ledger.
- Full suite: **12,718 passed, 5,591 skipped**, 42 warnings. This local run temporarily applied the separately committed `ln` error-message portability fix (`14ab71ddd`) because this host uses uutils rather than GNU coreutils. The patch was restored afterward and is excluded from this PR.

### Slow tests

```sh
TMPDIR=/mnt/data/scratch/cleanup-4879 uv run --no-sync pytest tests/log/test_json_write.py tests/log/test_streaming_completion.py tests/hooks/test_hooks.py -q --color=no
TMPDIR=/mnt/data/scratch/cleanup-4879 uv run --no-sync pytest tests/log/test_json_write.py tests/log/test_streaming_completion.py tests/hooks/test_hooks.py -q --color=no --runtrio
```

- Default run: **65 passed, 20 skipped** (trio variants).
- Trio run: **20 passed, 65 skipped** (non-trio cases), including streaming cancellation and failure repair.
- No live-provider or Docker tests ran for this cleanup; the affected gated coverage is trio. Skipped tests did not run.

### Agent review

- Cleanup authored with Codex. One Codex review in a fresh context, using the same model as the cleanup author: **no findings**. Verified production AST equivalence apart from removal of a redundant assertion, retention of upstream tests, and coverage for saved data, hook delivery, cancellation and repair.
- Earlier implementation review, as recorded before cleanup: Claude Fable 5 task and whole-branch reviews; five thematic fresh-context agents; an independent GPT-5.6-sol review at xhigh reasoning in a fresh context; follow-up fix reviews and two whole-wave passes. Fixed cancellation truncation, restored-attachment seeding, hook fixture contamination, failure repair and timeline rebinding, warning-filter scope, and pool iteration.
- Earlier dismissed findings: cancellation bookkeeping reproduced on `main` and recovered on retry; hook enablement is documented to remain stable during a sample; chunk sizes bound items rather than bytes, with eager buffer loading remaining a separate limitation.
