### PR TITLE
Make provider HTTP connect timeouts configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 - Model roles can now be bound to a list of models (e.g. `model_roles={"grader": [...]}`), with model-graded scorers grading by majority vote across the list.
 - Checkpointing: Sandbox snapshots now support selectable strategies (per sandbox, settable at the sample, task, or eval layer) — incremental restic (default) or self-contained per-checkpoint archives captured with in-image tools only.
 - Bugfix: Resuming a sample from a checkpoint no longer restarts its token, cost, turn, time, and working budgets from zero.
-- Models: OpenAI, OpenAI-compatible, Anthropic and Groq now allow 60s rather than 5s for connection setup, so a busy event loop is much less likely to cause `APIConnectionError`.
+- Models: Provider HTTP connection settings are now tunable with `INSPECT_HTTP_*` environment variables, and connection setup gets 60s rather than the SDKs' 5s.
 
 ## 0.3.260 (21 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Checkpointing: Sandbox snapshots now support selectable strategies (per sandbox, settable at the sample, task, or eval layer) — incremental restic (default) or self-contained per-checkpoint archives captured with in-image tools only.
 - Bugfix: Resuming a sample from a checkpoint no longer restarts its token, cost, turn, time, and working budgets from zero.
 - Models: Provider HTTP connection settings are now tunable with `INSPECT_HTTP_*` environment variables, and connection setup gets 60s rather than the SDKs' 5s.
+- Mistral: Requests are no longer capped at the SDK's flat 5s timeout, which cut off generations that took longer.
 
 ## 0.3.260 (21 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Model roles can now be bound to a list of models (e.g. `model_roles={"grader": [...]}`), with model-graded scorers grading by majority vote across the list.
 - Checkpointing: Sandbox snapshots now support selectable strategies (per sandbox, settable at the sample, task, or eval layer) — incremental restic (default) or self-contained per-checkpoint archives captured with in-image tools only.
 - Bugfix: Resuming a sample from a checkpoint no longer restarts its token, cost, turn, time, and working budgets from zero.
+- Models: OpenAI, OpenAI-compatible, Anthropic and Groq now allow 60s rather than 5s for connection setup, so a busy event loop is much less likely to cause `APIConnectionError`.
 
 ## 0.3.260 (21 August 2026)
 

--- a/docs/models-concurrency.qmd
+++ b/docs/models-concurrency.qmd
@@ -179,6 +179,39 @@ Increasing the max connections might yield better performance due to higher para
 Since it can be difficult to tune this value (especially across different times of day), you are generally much better off using [Adaptive Connections](#adaptive-connections) which will dynamically find the maximum throughput that can be supported.
 
 
+## HTTP Client Settings
+
+The settings above govern how many requests Inspect has in flight. Separately, the HTTP client underneath each provider has its own connection settings, tunable by environment variable so a deployment can adjust them without a release.
+
+The defaults differ from the provider SDKs' in one respect that matters for long-running evals. SDK defaults assume a responsive event loop, but an eval's loop is held for seconds at a time by CPU-bound work, and a connect deadline that expires during one of those pauses fails a connection the kernel had already completed. Inspect therefore allows 60s for connection setup rather than the 5s most SDKs use, and retries connection establishment once.
+
+| Variable | Default | Effect |
+|-----------------|-----------------|--------------------------------------|
+| `INSPECT_HTTP_CONNECT_TIMEOUT` | 60 | Seconds allowed to establish a connection. |
+| `INSPECT_HTTP_REQUEST_TIMEOUT` | 600 | Seconds allowed for the rest of a request. |
+| `INSPECT_HTTP_POOL_CONNECTIONS` | 1000 | Sockets in the HTTP connection pool. Distinct from `--max-connections`, which bounds requests in flight. |
+| `INSPECT_HTTP_POOL_KEEPALIVE_CONNECTIONS` | the connection pool size | Idle connections kept for reuse. |
+| `INSPECT_HTTP_KEEPALIVE_EXPIRY` | 5 | Seconds an idle connection is kept. |
+| `INSPECT_HTTP_CONNECT_RETRIES` | 1 | Retries of connection establishment. Only the connect is retried, never the request, so this is safe for non-idempotent calls. Unavailable through a proxy, which httpx does not retry. |
+
+Two of these interact with settings a provider may already have:
+
+- A request budget you set yourself, via `-M client_timeout`, `-M timeout` or `service_tier="flex"`, is kept. `INSPECT_HTTP_CONNECT_TIMEOUT` acts as a floor alongside it: it raises a connect deadline shorter than the floor, and leaves a longer one alone.
+
+- A provider whose SDK default is deliberately different keeps that default until you set the variable. Groq, for example, uses a tighter request budget and an unbounded connection pool; setting `INSPECT_HTTP_REQUEST_TIMEOUT` or `INSPECT_HTTP_POOL_CONNECTIONS` overrides it.
+
+These settings reach the OpenAI, OpenAI-compatible (including vLLM, SGLang, Ollama, OpenRouter, Together and the other `openai-api/` services), Anthropic and Groq providers.
+
+Google under Trio gets the pool and connect-retry settings but not the deadlines: it applies its own overall budget to every request, which is already far longer than the connect floor.
+
+They do not reach the remaining providers, which are on other HTTP stacks and are not exposed to the problem these defaults address:
+
+- Bedrock and SageMaker have their own connection deadline, already 60s, set per model with `-M connect_timeout`. Azure AI likewise uses its own, which is longer still.
+
+- Google on asyncio applies a single overall budget with no separate connection deadline, so there is none to outlast. (Under Trio it uses a different HTTP stack, which is why the settings apply there.)
+
+- Grok speaks gRPC and establishes connections off the event loop, where the pause that motivates these defaults cannot affect it.
+
 ## Learning More
 
 - [Parallelism](parallelism.qmd): running multiple tasks or models in parallel, sandbox container concurrency, and writing parallel custom code.

--- a/docs/models-concurrency.qmd
+++ b/docs/models-concurrency.qmd
@@ -200,7 +200,7 @@ Two of these interact with settings a provider may already have:
 
 - A provider whose SDK default is deliberately different keeps that default until you set the variable. Groq, for example, uses a tighter request budget and an unbounded connection pool; setting `INSPECT_HTTP_REQUEST_TIMEOUT` or `INSPECT_HTTP_POOL_CONNECTIONS` overrides it.
 
-These settings reach the OpenAI, OpenAI-compatible (including vLLM, SGLang, Ollama, OpenRouter, Together and the other `openai-api/` services), Anthropic and Groq providers.
+These settings reach the OpenAI, OpenAI-compatible (including vLLM, SGLang, Ollama, OpenRouter, Together and the other `openai-api/` services), Anthropic, Groq and Mistral providers.
 
 Google under Trio gets the pool and connect-retry settings but not the deadlines: it applies its own overall budget to every request, which is already far longer than the connect floor.
 

--- a/src/inspect_ai/_util/http_defaults.py
+++ b/src/inspect_ai/_util/http_defaults.py
@@ -1,0 +1,245 @@
+"""Shared HTTP client defaults for provider SDK clients.
+
+The SDK defaults are tuned for a caller whose event loop is responsive. An
+inspect runner's loop is not: long CPU-bound sections (payload transforms,
+transcript scans) hold it for seconds at a time, and a connect deadline that
+expires during one of those blocks fails a connection that the kernel already
+completed — anyio's cancellation lands on the first checkpoint after the loop
+resumes, so a finished connect is no defence.
+
+Three defaults follow, all overridable by environment variable:
+
+* ``connect`` at 60s rather than 5s. A partial raise buys nothing (a 26s block
+  failed 75% at 5s and 76.7% at 15s, 0% at 30s), and the deadline has to clear
+  *several* blocks: a connect that misses its window waits out whole blocks, so
+  failure latency quantises to multiples of the block length (a 3s block
+  against a 5s deadline failed 77% of the time, median 6.1s). The cost is that
+  a dead endpoint takes 120s to detect, since the retry below gives it a second
+  full deadline; httpcore charges the deadline separately to the TCP connect
+  and the TLS handshake, so a slow-then-stalling endpoint can reach 4x, and an
+  SDK that retries multiplies that again.
+
+* ``max_keepalive_connections`` at the connection limit rather than 100. Above
+  the cap every connection is destroyed the moment it goes idle, stepping the
+  new-connection rate ~20x once concurrency passes ~120, and only new
+  connections run the connect path at all.
+
+* One connection-establishment retry. httpcore retries the connect only and
+  never re-sends the request, so it is safe for non-idempotent calls. It needs
+  the loop running again by the time it fires, so it rescues a lightly loaded
+  caller and does little for a saturated one.
+
+The transport also carries the TCP keepalive socket options the Anthropic SDK
+sets on its own, since they live on the transport and supplying one drops them.
+Supplying a transport likewise turns off httpx's environment proxy discovery,
+so the proxy mounts are rebuilt here and given the same settings.
+
+``keepalive_expiry`` stays at httpx's 5s default: raising it past an
+intermediary's idle timeout (an ALB commonly defaults to 60s) trades these
+failures for stale-connection ones. Note this leaves the
+``max_keepalive_connections`` raise inert whenever blocks outlast the expiry,
+which is the case that motivated it (at a 6s block, 100 versus 1000 changed
+nothing, both failing every request). A deployment that knows its own topology
+should raise the expiry alongside the cap.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Any, overload
+
+import httpx
+
+
+def _no_environment_proxies() -> dict[str, str | None]:
+    return {}
+
+
+try:
+    # Private to httpx, but replicating its NO_PROXY rules would drift; the
+    # anthropic SDK vendors a copy for the same reason. Degrade to no mounts
+    # rather than failing to import if httpx moves it.
+    from httpx._utils import get_environment_proxies as _get_environment_proxies
+except ImportError:  # pragma: no cover - httpx moved its internals
+    _get_environment_proxies = _no_environment_proxies
+
+DEFAULT_CONNECT_TIMEOUT = 60.0
+DEFAULT_REQUEST_TIMEOUT = 600.0
+DEFAULT_POOL_CONNECTIONS = 1000
+DEFAULT_KEEPALIVE_EXPIRY = 5.0
+DEFAULT_CONNECT_RETRIES = 1
+
+CONNECT_TIMEOUT_ENV = "INSPECT_HTTP_CONNECT_TIMEOUT"
+REQUEST_TIMEOUT_ENV = "INSPECT_HTTP_REQUEST_TIMEOUT"
+POOL_CONNECTIONS_ENV = "INSPECT_HTTP_POOL_CONNECTIONS"
+POOL_KEEPALIVE_CONNECTIONS_ENV = "INSPECT_HTTP_POOL_KEEPALIVE_CONNECTIONS"
+KEEPALIVE_EXPIRY_ENV = "INSPECT_HTTP_KEEPALIVE_EXPIRY"
+CONNECT_RETRIES_ENV = "INSPECT_HTTP_CONNECT_RETRIES"
+
+
+def _env_float(name: str, fallback: float) -> float:
+    """A non-negative float from the environment, `fallback` on unset or junk."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return fallback
+    try:
+        value = float(raw)
+    except ValueError:
+        return fallback
+    return value if value >= 0 else fallback
+
+
+@overload
+def _env_int(name: str, fallback: int) -> int: ...
+
+
+@overload
+def _env_int(name: str, fallback: None) -> int | None: ...
+
+
+def _env_int(name: str, fallback: int | None) -> int | None:
+    """A non-negative int from the environment, `fallback` on unset or junk."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return fallback
+    try:
+        value = int(raw)
+    except ValueError:
+        return fallback
+    return value if value >= 0 else fallback
+
+
+def connect_timeout() -> float:
+    return _env_float(CONNECT_TIMEOUT_ENV, DEFAULT_CONNECT_TIMEOUT)
+
+
+def default_timeout(
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> httpx.Timeout:
+    """Timeouts, with the environment overriding `request_timeout`.
+
+    The argument is only the fallback, so a provider whose SDK has a budget of
+    its own can pass it and keep it until an operator sets the variable.
+    """
+    return httpx.Timeout(
+        timeout=_env_float(REQUEST_TIMEOUT_ENV, request_timeout),
+        connect=connect_timeout(),
+    )
+
+
+def default_limits(
+    max_connections: int | None = DEFAULT_POOL_CONNECTIONS,
+) -> httpx.Limits:
+    """Pool limits, with the environment overriding `max_connections`.
+
+    The argument is only the fallback, so a provider whose pool is deliberately
+    uncapped can pass None and keep it until an operator sets the variable.
+    """
+    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections)
+    return httpx.Limits(
+        max_connections=connections,
+        # Tracks the pool size unless set outright, so lowering the limit
+        # cannot leave a keepalive cap above it.
+        max_keepalive_connections=_env_int(POOL_KEEPALIVE_CONNECTIONS_ENV, connections),
+        keepalive_expiry=_env_float(KEEPALIVE_EXPIRY_ENV, DEFAULT_KEEPALIVE_EXPIRY),
+    )
+
+
+def _default_socket_options() -> list[tuple[int, int, int]]:
+    """TCP keepalive options matching the ones the Anthropic SDK installs."""
+    options: list[tuple[int, int, int]] = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
+    ]
+    # Not every knob exists on every platform.
+    for name, value in (
+        ("TCP_KEEPINTVL", 60),
+        ("TCP_KEEPCNT", 5),
+        ("TCP_KEEPIDLE", 60),
+    ):
+        option = getattr(socket, name, None)
+        if isinstance(option, int):
+            options.append((socket.IPPROTO_TCP, option, value))
+    return options
+
+
+async def _floor_connect_timeout(request: httpx.Request) -> None:
+    """Stop a scalar SDK timeout from shortening the connect deadline.
+
+    SDKs stamp their own per-request timeout over whatever the client was built
+    with, and httpx expands a bare float to all four phases, so an overall
+    budget such as `-M client_timeout=30` would become the connect deadline
+    too. Only ever raises it, leaving a longer deadline and a `None` (no limit)
+    alone.
+    """
+    extension = request.extensions.get("timeout")
+    if not isinstance(extension, dict):
+        return
+    # Safe to mutate: httpx.Timeout.as_dict() builds this fresh per request.
+    timeout: dict[str, float | None] = extension
+    connect = timeout.get("connect")
+    floor = connect_timeout()
+    if connect is not None and connect < floor:
+        timeout["connect"] = floor
+
+
+def _transport_kwargs(
+    limits: httpx.Limits, overrides: dict[str, Any]
+) -> dict[str, Any]:
+    """Settings httpx would apply itself if it were building the transport."""
+    kwargs: dict[str, Any] = {
+        "retries": _env_int(CONNECT_RETRIES_ENV, DEFAULT_CONNECT_RETRIES),
+        "limits": limits,
+        "socket_options": _default_socket_options(),
+    }
+    # httpx applies these only to a transport it builds itself, so a caller
+    # passing verify=... would otherwise have it silently dropped.
+    kwargs.update(
+        {
+            arg: overrides[arg]
+            for arg in ("verify", "cert", "trust_env", "http1", "http2")
+            if arg in overrides
+        }
+    )
+    return kwargs
+
+
+def default_client_kwargs(**overrides: Any) -> dict[str, Any]:
+    """`httpx.AsyncClient` kwargs carrying these defaults; caller overrides win."""
+    kwargs = dict(overrides)
+    # `limits` resolves first because httpx applies `limits=` only to a
+    # transport it builds itself, so the transport has to bake them in.
+    limits = kwargs.setdefault("limits", default_limits())
+    kwargs.setdefault("timeout", default_timeout())
+    kwargs.setdefault("follow_redirects", True)
+
+    if "transport" not in kwargs:
+        transport_kwargs = _transport_kwargs(limits, kwargs)
+        # Supplying a transport turns off httpx's environment proxy discovery,
+        # so rebuild the mounts with the same settings rather than losing
+        # either the proxy or the retry and keepalive options. httpx itself
+        # gates that discovery on `trust_env`, so mirror that here rather than
+        # rebuilding proxy mounts a caller explicitly asked us not to.
+        environment_proxies = (
+            _get_environment_proxies()
+            if kwargs.get("trust_env", True) is not False
+            else {}
+        )
+        mounts: dict[str, httpx.AsyncBaseTransport | None] = {
+            key: None
+            if url is None
+            else httpx.AsyncHTTPTransport(proxy=httpx.Proxy(url), **transport_kwargs)
+            for key, url in environment_proxies.items()
+        }
+        mounts.update(kwargs.get("mounts") or {})
+        kwargs["mounts"] = mounts
+        kwargs["transport"] = httpx.AsyncHTTPTransport(**transport_kwargs)
+
+    hooks = dict(kwargs.get("event_hooks") or {})
+    hooks["request"] = [_floor_connect_timeout, *hooks.get("request", [])]
+    kwargs["event_hooks"] = hooks
+    return kwargs
+
+
+def default_async_client(**overrides: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(**default_client_kwargs(**overrides))

--- a/src/inspect_ai/_util/http_defaults.py
+++ b/src/inspect_ai/_util/http_defaults.py
@@ -47,9 +47,14 @@ from __future__ import annotations
 
 import os
 import socket
+from logging import getLogger
 from typing import Any, overload
 
 import httpx
+
+from inspect_ai._util.logger import warn_once
+
+logger = getLogger(__name__)
 
 
 def _no_environment_proxies() -> dict[str, str | None]:
@@ -78,6 +83,11 @@ KEEPALIVE_EXPIRY_ENV = "INSPECT_HTTP_KEEPALIVE_EXPIRY"
 CONNECT_RETRIES_ENV = "INSPECT_HTTP_CONNECT_RETRIES"
 
 
+def _ignored(name: str, raw: str, reason: str, fallback: object) -> None:
+    # Silence would leave an operator believing a setting took effect.
+    warn_once(logger, f"Ignoring {name}={raw!r} ({reason}); using {fallback} instead.")
+
+
 def _env_float(name: str, fallback: float) -> float:
     """A non-negative float from the environment, `fallback` on unset or junk."""
     raw = os.environ.get(name)
@@ -86,28 +96,36 @@ def _env_float(name: str, fallback: float) -> float:
     try:
         value = float(raw)
     except ValueError:
+        _ignored(name, raw, "not a number", fallback)
         return fallback
-    return value if value >= 0 else fallback
+    if value < 0:
+        _ignored(name, raw, "must be >= 0", fallback)
+        return fallback
+    return value
 
 
 @overload
-def _env_int(name: str, fallback: int) -> int: ...
+def _env_int(name: str, fallback: int, *, minimum: int = 0) -> int: ...
 
 
 @overload
-def _env_int(name: str, fallback: None) -> int | None: ...
+def _env_int(name: str, fallback: None, *, minimum: int = 0) -> int | None: ...
 
 
-def _env_int(name: str, fallback: int | None) -> int | None:
-    """A non-negative int from the environment, `fallback` on unset or junk."""
+def _env_int(name: str, fallback: int | None, *, minimum: int = 0) -> int | None:
+    """A whole number >= `minimum` from the environment, `fallback` on unset or junk."""
     raw = os.environ.get(name)
     if raw is None or not raw.strip():
         return fallback
     try:
         value = int(raw)
     except ValueError:
+        _ignored(name, raw, "not a whole number", fallback)
         return fallback
-    return value if value >= 0 else fallback
+    if value < minimum:
+        _ignored(name, raw, f"must be >= {minimum}", fallback)
+        return fallback
+    return value
 
 
 def connect_timeout() -> float:
@@ -136,7 +154,8 @@ def default_limits(
     The argument is only the fallback, so a provider whose pool is deliberately
     uncapped can pass None and keep it until an operator sets the variable.
     """
-    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections)
+    # A zero-connection pool can never issue a request, so it is junk not a setting.
+    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections, minimum=1)
     return httpx.Limits(
         max_connections=connections,
         # Tracks the pool size unless set outright, so lowering the limit

--- a/src/inspect_ai/_util/http_defaults_httpx2.py
+++ b/src/inspect_ai/_util/http_defaults_httpx2.py
@@ -1,0 +1,245 @@
+"""Shared HTTP client defaults for provider SDK clients.
+
+The SDK defaults are tuned for a caller whose event loop is responsive. An
+inspect runner's loop is not: long CPU-bound sections (payload transforms,
+transcript scans) hold it for seconds at a time, and a connect deadline that
+expires during one of those blocks fails a connection that the kernel already
+completed — anyio's cancellation lands on the first checkpoint after the loop
+resumes, so a finished connect is no defence.
+
+Three defaults follow, all overridable by environment variable:
+
+* ``connect`` at 60s rather than 5s. A partial raise buys nothing (a 26s block
+  failed 75% at 5s and 76.7% at 15s, 0% at 30s), and the deadline has to clear
+  *several* blocks: a connect that misses its window waits out whole blocks, so
+  failure latency quantises to multiples of the block length (a 3s block
+  against a 5s deadline failed 77% of the time, median 6.1s). The cost is that
+  a dead endpoint takes 120s to detect, since the retry below gives it a second
+  full deadline; httpcore charges the deadline separately to the TCP connect
+  and the TLS handshake, so a slow-then-stalling endpoint can reach 4x, and an
+  SDK that retries multiplies that again.
+
+* ``max_keepalive_connections`` at the connection limit rather than 100. Above
+  the cap every connection is destroyed the moment it goes idle, stepping the
+  new-connection rate ~20x once concurrency passes ~120, and only new
+  connections run the connect path at all.
+
+* One connection-establishment retry. httpcore retries the connect only and
+  never re-sends the request, so it is safe for non-idempotent calls. It needs
+  the loop running again by the time it fires, so it rescues a lightly loaded
+  caller and does little for a saturated one.
+
+The transport also carries the TCP keepalive socket options the Anthropic SDK
+sets on its own, since they live on the transport and supplying one drops them.
+Supplying a transport likewise turns off httpx's environment proxy discovery,
+so the proxy mounts are rebuilt here and given the same settings.
+
+``keepalive_expiry`` stays at httpx's 5s default: raising it past an
+intermediary's idle timeout (an ALB commonly defaults to 60s) trades these
+failures for stale-connection ones. Note this leaves the
+``max_keepalive_connections`` raise inert whenever blocks outlast the expiry,
+which is the case that motivated it (at a 6s block, 100 versus 1000 changed
+nothing, both failing every request). A deployment that knows its own topology
+should raise the expiry alongside the cap.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Any, overload
+
+import httpx2
+
+
+def _no_environment_proxies() -> dict[str, str | None]:
+    return {}
+
+
+try:
+    # Private to httpx, but replicating its NO_PROXY rules would drift; the
+    # anthropic SDK vendors a copy for the same reason. Degrade to no mounts
+    # rather than failing to import if httpx moves it.
+    from httpx2._utils import get_environment_proxies as _get_environment_proxies
+except ImportError:  # pragma: no cover - httpx moved its internals
+    _get_environment_proxies = _no_environment_proxies
+
+DEFAULT_CONNECT_TIMEOUT = 60.0
+DEFAULT_REQUEST_TIMEOUT = 600.0
+DEFAULT_POOL_CONNECTIONS = 1000
+DEFAULT_KEEPALIVE_EXPIRY = 5.0
+DEFAULT_CONNECT_RETRIES = 1
+
+CONNECT_TIMEOUT_ENV = "INSPECT_HTTP_CONNECT_TIMEOUT"
+REQUEST_TIMEOUT_ENV = "INSPECT_HTTP_REQUEST_TIMEOUT"
+POOL_CONNECTIONS_ENV = "INSPECT_HTTP_POOL_CONNECTIONS"
+POOL_KEEPALIVE_CONNECTIONS_ENV = "INSPECT_HTTP_POOL_KEEPALIVE_CONNECTIONS"
+KEEPALIVE_EXPIRY_ENV = "INSPECT_HTTP_KEEPALIVE_EXPIRY"
+CONNECT_RETRIES_ENV = "INSPECT_HTTP_CONNECT_RETRIES"
+
+
+def _env_float(name: str, fallback: float) -> float:
+    """A non-negative float from the environment, `fallback` on unset or junk."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return fallback
+    try:
+        value = float(raw)
+    except ValueError:
+        return fallback
+    return value if value >= 0 else fallback
+
+
+@overload
+def _env_int(name: str, fallback: int) -> int: ...
+
+
+@overload
+def _env_int(name: str, fallback: None) -> int | None: ...
+
+
+def _env_int(name: str, fallback: int | None) -> int | None:
+    """A non-negative int from the environment, `fallback` on unset or junk."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return fallback
+    try:
+        value = int(raw)
+    except ValueError:
+        return fallback
+    return value if value >= 0 else fallback
+
+
+def connect_timeout() -> float:
+    return _env_float(CONNECT_TIMEOUT_ENV, DEFAULT_CONNECT_TIMEOUT)
+
+
+def default_timeout(
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> httpx2.Timeout:
+    """Timeouts, with the environment overriding `request_timeout`.
+
+    The argument is only the fallback, so a provider whose SDK has a budget of
+    its own can pass it and keep it until an operator sets the variable.
+    """
+    return httpx2.Timeout(
+        timeout=_env_float(REQUEST_TIMEOUT_ENV, request_timeout),
+        connect=connect_timeout(),
+    )
+
+
+def default_limits(
+    max_connections: int | None = DEFAULT_POOL_CONNECTIONS,
+) -> httpx2.Limits:
+    """Pool limits, with the environment overriding `max_connections`.
+
+    The argument is only the fallback, so a provider whose pool is deliberately
+    uncapped can pass None and keep it until an operator sets the variable.
+    """
+    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections)
+    return httpx2.Limits(
+        max_connections=connections,
+        # Tracks the pool size unless set outright, so lowering the limit
+        # cannot leave a keepalive cap above it.
+        max_keepalive_connections=_env_int(POOL_KEEPALIVE_CONNECTIONS_ENV, connections),
+        keepalive_expiry=_env_float(KEEPALIVE_EXPIRY_ENV, DEFAULT_KEEPALIVE_EXPIRY),
+    )
+
+
+def _default_socket_options() -> list[tuple[int, int, int]]:
+    """TCP keepalive options matching the ones the Anthropic SDK installs."""
+    options: list[tuple[int, int, int]] = [
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
+    ]
+    # Not every knob exists on every platform.
+    for name, value in (
+        ("TCP_KEEPINTVL", 60),
+        ("TCP_KEEPCNT", 5),
+        ("TCP_KEEPIDLE", 60),
+    ):
+        option = getattr(socket, name, None)
+        if isinstance(option, int):
+            options.append((socket.IPPROTO_TCP, option, value))
+    return options
+
+
+async def _floor_connect_timeout(request: httpx2.Request) -> None:
+    """Stop a scalar SDK timeout from shortening the connect deadline.
+
+    SDKs stamp their own per-request timeout over whatever the client was built
+    with, and httpx expands a bare float to all four phases, so an overall
+    budget such as `-M client_timeout=30` would become the connect deadline
+    too. Only ever raises it, leaving a longer deadline and a `None` (no limit)
+    alone.
+    """
+    extension = request.extensions.get("timeout")
+    if not isinstance(extension, dict):
+        return
+    # Safe to mutate: httpx2.Timeout.as_dict() builds this fresh per request.
+    timeout: dict[str, float | None] = extension
+    connect = timeout.get("connect")
+    floor = connect_timeout()
+    if connect is not None and connect < floor:
+        timeout["connect"] = floor
+
+
+def _transport_kwargs(
+    limits: httpx2.Limits, overrides: dict[str, Any]
+) -> dict[str, Any]:
+    """Settings httpx would apply itself if it were building the transport."""
+    kwargs: dict[str, Any] = {
+        "retries": _env_int(CONNECT_RETRIES_ENV, DEFAULT_CONNECT_RETRIES),
+        "limits": limits,
+        "socket_options": _default_socket_options(),
+    }
+    # httpx applies these only to a transport it builds itself, so a caller
+    # passing verify=... would otherwise have it silently dropped.
+    kwargs.update(
+        {
+            arg: overrides[arg]
+            for arg in ("verify", "cert", "trust_env", "http1", "http2")
+            if arg in overrides
+        }
+    )
+    return kwargs
+
+
+def default_client_kwargs(**overrides: Any) -> dict[str, Any]:
+    """`httpx2.AsyncClient` kwargs carrying these defaults; caller overrides win."""
+    kwargs = dict(overrides)
+    # `limits` resolves first because httpx applies `limits=` only to a
+    # transport it builds itself, so the transport has to bake them in.
+    limits = kwargs.setdefault("limits", default_limits())
+    kwargs.setdefault("timeout", default_timeout())
+    kwargs.setdefault("follow_redirects", True)
+
+    if "transport" not in kwargs:
+        transport_kwargs = _transport_kwargs(limits, kwargs)
+        # Supplying a transport turns off httpx's environment proxy discovery,
+        # so rebuild the mounts with the same settings rather than losing
+        # either the proxy or the retry and keepalive options. httpx itself
+        # gates that discovery on `trust_env`, so mirror that here rather than
+        # rebuilding proxy mounts a caller explicitly asked us not to.
+        environment_proxies = (
+            _get_environment_proxies()
+            if kwargs.get("trust_env", True) is not False
+            else {}
+        )
+        mounts: dict[str, httpx2.AsyncBaseTransport | None] = {
+            key: None
+            if url is None
+            else httpx2.AsyncHTTPTransport(proxy=httpx2.Proxy(url), **transport_kwargs)
+            for key, url in environment_proxies.items()
+        }
+        mounts.update(kwargs.get("mounts") or {})
+        kwargs["mounts"] = mounts
+        kwargs["transport"] = httpx2.AsyncHTTPTransport(**transport_kwargs)
+
+    hooks = dict(kwargs.get("event_hooks") or {})
+    hooks["request"] = [_floor_connect_timeout, *hooks.get("request", [])]
+    kwargs["event_hooks"] = hooks
+    return kwargs
+
+
+def default_async_client(**overrides: Any) -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(**default_client_kwargs(**overrides))

--- a/src/inspect_ai/_util/http_defaults_httpx2.py
+++ b/src/inspect_ai/_util/http_defaults_httpx2.py
@@ -47,9 +47,14 @@ from __future__ import annotations
 
 import os
 import socket
+from logging import getLogger
 from typing import Any, overload
 
 import httpx2
+
+from inspect_ai._util.logger import warn_once
+
+logger = getLogger(__name__)
 
 
 def _no_environment_proxies() -> dict[str, str | None]:
@@ -78,6 +83,11 @@ KEEPALIVE_EXPIRY_ENV = "INSPECT_HTTP_KEEPALIVE_EXPIRY"
 CONNECT_RETRIES_ENV = "INSPECT_HTTP_CONNECT_RETRIES"
 
 
+def _ignored(name: str, raw: str, reason: str, fallback: object) -> None:
+    # Silence would leave an operator believing a setting took effect.
+    warn_once(logger, f"Ignoring {name}={raw!r} ({reason}); using {fallback} instead.")
+
+
 def _env_float(name: str, fallback: float) -> float:
     """A non-negative float from the environment, `fallback` on unset or junk."""
     raw = os.environ.get(name)
@@ -86,28 +96,36 @@ def _env_float(name: str, fallback: float) -> float:
     try:
         value = float(raw)
     except ValueError:
+        _ignored(name, raw, "not a number", fallback)
         return fallback
-    return value if value >= 0 else fallback
+    if value < 0:
+        _ignored(name, raw, "must be >= 0", fallback)
+        return fallback
+    return value
 
 
 @overload
-def _env_int(name: str, fallback: int) -> int: ...
+def _env_int(name: str, fallback: int, *, minimum: int = 0) -> int: ...
 
 
 @overload
-def _env_int(name: str, fallback: None) -> int | None: ...
+def _env_int(name: str, fallback: None, *, minimum: int = 0) -> int | None: ...
 
 
-def _env_int(name: str, fallback: int | None) -> int | None:
-    """A non-negative int from the environment, `fallback` on unset or junk."""
+def _env_int(name: str, fallback: int | None, *, minimum: int = 0) -> int | None:
+    """A whole number >= `minimum` from the environment, `fallback` on unset or junk."""
     raw = os.environ.get(name)
     if raw is None or not raw.strip():
         return fallback
     try:
         value = int(raw)
     except ValueError:
+        _ignored(name, raw, "not a whole number", fallback)
         return fallback
-    return value if value >= 0 else fallback
+    if value < minimum:
+        _ignored(name, raw, f"must be >= {minimum}", fallback)
+        return fallback
+    return value
 
 
 def connect_timeout() -> float:
@@ -136,7 +154,8 @@ def default_limits(
     The argument is only the fallback, so a provider whose pool is deliberately
     uncapped can pass None and keep it until an operator sets the variable.
     """
-    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections)
+    # A zero-connection pool can never issue a request, so it is junk not a setting.
+    connections = _env_int(POOL_CONNECTIONS_ENV, max_connections, minimum=1)
     return httpx2.Limits(
         max_connections=connections,
         # Tracks the pool size unless set outright, so lowering the limit

--- a/src/inspect_ai/_util/images.py
+++ b/src/inspect_ai/_util/images.py
@@ -12,6 +12,7 @@ import httpcore
 import httpx
 
 from .file import file as open_file
+from .http_defaults import connect_timeout, default_async_client
 from .url import (
     data_uri_mime_type,
     data_uri_to_base64,
@@ -124,7 +125,12 @@ async def file_as_data(file: str, mime_type: str | None = None) -> tuple[bytes, 
 
         # handle url or file
         if is_http_url(file):
-            async with httpx.AsyncClient(follow_redirects=True) as client:
+            # Fetched on the eval loop alongside model requests, so it needs
+            # the same connect deadline — but not the 600s request budget a
+            # provider call gets; 30s matches the web-search tool clients.
+            async with default_async_client(
+                timeout=httpx.Timeout(30.0, connect=connect_timeout())
+            ) as client:
                 response = await client.get(file)
                 response.raise_for_status()
                 file_bytes = response.content

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -140,6 +140,7 @@ from inspect_ai._util.http import (
     parse_retry_after_from_exception,
 )
 from inspect_ai._util.http_defaults_httpx2 import (
+    DEFAULT_REQUEST_TIMEOUT,
     default_async_client,
     default_timeout,
 )
@@ -347,9 +348,21 @@ class AnthropicAPI(ModelAPI):
             return model_args
         # Handing httpx objects to an httpx2-based SDK is what broke every
         # OpenAI request under openai 3.0.
-        if not isinstance(getattr(anthropic, "DEFAULT_TIMEOUT", None), httpx2.Timeout):
+        sdk_timeout = getattr(anthropic, "DEFAULT_TIMEOUT", None)
+        if not isinstance(sdk_timeout, httpx2.Timeout):
             return model_args
-        model_args.setdefault("timeout", default_timeout())
+        # The SDK gates its "streaming is required for long requests" guard on
+        # `client.timeout == DEFAULT_TIMEOUT`, so hand back that exact object
+        # unless an operator overrode the budget. Substituting an equivalent
+        # timeout turns an immediate ValueError into a request that stalls to
+        # the read deadline and then retries. The connect floor still reaches
+        # the wire: the event hook raises the deadline the SDK stamps.
+        timeout = default_timeout(
+            request_timeout=sdk_timeout.read or DEFAULT_REQUEST_TIMEOUT
+        )
+        model_args.setdefault(
+            "timeout", sdk_timeout if timeout.read == sdk_timeout.read else timeout
+        )
         model_args["http_client"] = default_async_client()
         return model_args
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -17,6 +17,8 @@ from typing import (
     cast,
 )
 
+import anthropic
+import httpx2
 from anthropic import (
     APIConnectionError,
     APIStatusError,
@@ -136,6 +138,10 @@ from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.http import (
     is_retryable_http_status,
     parse_retry_after_from_exception,
+)
+from inspect_ai._util.http_defaults_httpx2 import (
+    default_async_client,
+    default_timeout,
 )
 from inspect_ai._util.images import inline_media_data, inline_media_data_uri
 from inspect_ai._util.json import to_json_str_safe
@@ -325,6 +331,28 @@ class AnthropicAPI(ModelAPI):
         self.model_args = model_args
         self.initialize()
 
+    def _http_default_args(self) -> dict[str, Any]:
+        """Model args with the shared HTTP defaults filled in.
+
+        A caller's own `http_client` is left alone. A caller's `timeout` is
+        kept as the request budget but still gets our client, so the connect
+        floor and pool settings apply.
+        """
+        # A copy, so every initialize() builds a fresh client: aclose() then
+        # initialize() is the auth-retry path in _model.py's before_retry, and
+        # a closed client fails every later request with the error class these
+        # defaults exist to prevent.
+        model_args = dict(self.model_args)
+        if "http_client" in model_args:
+            return model_args
+        # Handing httpx objects to an httpx2-based SDK is what broke every
+        # OpenAI request under openai 3.0.
+        if not isinstance(getattr(anthropic, "DEFAULT_TIMEOUT", None), httpx2.Timeout):
+            return model_args
+        model_args.setdefault("timeout", default_timeout())
+        model_args["http_client"] = default_async_client()
+        return model_args
+
     def _create_client(
         self,
     ) -> (
@@ -333,6 +361,7 @@ class AnthropicAPI(ModelAPI):
         | AsyncAnthropicVertex
         | AsyncAnthropicFoundry
     ):
+        model_args = self._http_default_args()
         if self.is_bedrock():
             base_url = model_base_url(
                 self.base_url,
@@ -349,7 +378,7 @@ class AnthropicAPI(ModelAPI):
                 return AsyncAnthropicBedrock(
                     base_url=base_url,
                     aws_region=aws_region,
-                    **self.model_args,
+                    **model_args,
                 )
             except ValueError as ex:
                 # anthropic >= 1.0 raises when no AWS region is resolvable
@@ -366,7 +395,7 @@ class AnthropicAPI(ModelAPI):
                 region=region,
                 project_id=project_id,
                 base_url=base_url,
-                **self.model_args,
+                **model_args,
             )
         elif self.is_azure():
             # resolve base_url (required for Azure)
@@ -388,7 +417,7 @@ class AnthropicAPI(ModelAPI):
             return AsyncAnthropicFoundry(
                 base_url=base_url,
                 api_key=self.api_key,
-                **self.model_args,
+                **model_args,
             )
         else:
             base_url = model_base_url(self.base_url, "ANTHROPIC_BASE_URL")
@@ -405,7 +434,7 @@ class AnthropicAPI(ModelAPI):
                     default_headers={
                         "anthropic-beta": "oauth-2025-04-20",
                     },
-                    **self.model_args,
+                    **model_args,
                 )
             # resolve api_key
             if not self.api_key:
@@ -415,7 +444,7 @@ class AnthropicAPI(ModelAPI):
             return AsyncAnthropic(
                 base_url=base_url,
                 api_key=self.api_key,
-                **self.model_args,
+                **model_args,
             )
 
     @override

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -13,7 +13,6 @@ from typing import Any, Literal, NamedTuple, cast
 # SDK Docs: https://googleapis.github.io/python-genai/
 import aiohttp
 import anyio
-import httpx
 from google.genai import Client
 from google.genai.errors import APIError, ClientError
 from google.genai.types import (
@@ -74,6 +73,7 @@ from inspect_ai._util.http import (
     is_retryable_http_status,
     parse_retry_after_from_exception,
 )
+from inspect_ai._util.http_defaults import default_async_client
 from inspect_ai._util.images import inline_media_data
 from inspect_ai._util.kvstore import inspect_kvstore
 from inspect_ai._util.logger import warn_once
@@ -959,12 +959,14 @@ class GoogleGenAIAPI(ModelAPI):
             base_url=self.base_url,
             api_version=self.api_version,
         )
-        # aiohttp requires asyncio; use httpx under trio for compatibility
+        # aiohttp requires asyncio; use httpx under trio for compatibility.
+        # Only this path gets the shared HTTP defaults: the aiohttp path sets no
+        # connect deadline at all, so there is none there to be outlasted.
         if (
             current_async_backend() == "trio"
             and http_options.httpx_async_client is None
         ):
-            http_options.httpx_async_client = httpx.AsyncClient()
+            http_options.httpx_async_client = default_async_client()
         api_key = self.api_key
         if self._oauth and self._credentials is not None:
             # The dev-endpoint client requires a non-empty api_key; pass a

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -5,7 +5,9 @@ from functools import partial
 from logging import getLogger
 from typing import Any, Dict, Iterable, List, Optional
 
-import httpx
+from groq import (
+    DEFAULT_TIMEOUT as GROQ_DEFAULT_TIMEOUT,
+)
 from groq import (
     APIStatusError,
     APITimeoutError,
@@ -34,6 +36,12 @@ from inspect_ai._util.content import Content, ContentReasoning, ContentText
 from inspect_ai._util.http import (
     is_retryable_http_status,
     parse_retry_after_from_exception,
+)
+from inspect_ai._util.http_defaults import (
+    DEFAULT_REQUEST_TIMEOUT,
+    default_async_client,
+    default_limits,
+    default_timeout,
 )
 from inspect_ai._util.images import inline_media_data_uri
 from inspect_ai.log._samples import set_active_model_event_call
@@ -100,11 +108,23 @@ class GroqAPI(ModelAPI):
         self.initialize()
 
     def _create_client(self) -> AsyncGroq:
+        model_args = dict(self.model_args)
+        if "http_client" not in model_args:
+            # Raise the connect deadline but keep the SDK's tighter request
+            # budget and this provider's uncapped pool, unless an operator
+            # overrides them. The SDK's read, write and pool deadlines are one
+            # shared value.
+            timeout = default_timeout(
+                request_timeout=GROQ_DEFAULT_TIMEOUT.read or DEFAULT_REQUEST_TIMEOUT
+            )
+            model_args.setdefault("timeout", timeout)
+            model_args["http_client"] = default_async_client(
+                timeout=timeout, limits=default_limits(max_connections=None)
+            )
         return AsyncGroq(
             api_key=self.api_key,
             base_url=model_base_url(self.base_url, "GROQ_BASE_URL"),
-            **self.model_args,
-            http_client=httpx.AsyncClient(limits=httpx.Limits(max_connections=None)),
+            **model_args,
         )
 
     def initialize(self) -> None:

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -58,6 +58,7 @@ from inspect_ai.model._reasoning import parse_content_with_reasoning
 from inspect_ai.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo
 from inspect_ai.util._json import json_schema_dump
 
+from ..._util.http_defaults import default_async_client
 from ..._util.httpx import httpx_classify_retry
 from .._call_tools import parse_tool_call
 from .._chat_message import (
@@ -160,6 +161,17 @@ class MistralAPI(ModelAPI):
     def is_azure(self) -> bool:
         return self.service == "azure"
 
+    def _http_default_args(self) -> dict[str, Any]:
+        """Model args with the shared HTTP defaults filled in.
+
+        The SDK's own client applies a flat 5s to every phase, which is both a
+        connect deadline a blocked loop outlasts and a request budget far too
+        short for a generation.
+        """
+        model_args = dict(self.model_args)
+        model_args.setdefault("async_client", default_async_client())
+        return model_args
+
     async def generate(
         self,
         input: list[ChatMessage],
@@ -168,7 +180,7 @@ class MistralAPI(ModelAPI):
         config: GenerateConfig,
     ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
         # create client
-        with Mistral(api_key=self.api_key, **self.model_args) as client:
+        with Mistral(api_key=self.api_key, **self._http_default_args()) as client:
             # create time tracker
             http_hooks = HttpxHooks(client.sdk_configuration.async_client, api=self)
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -21,6 +21,7 @@ from openai.types.responses import Response
 from openai.types.shared_params.reasoning import Reasoning
 from typing_extensions import override
 
+from inspect_ai._util.http_defaults_httpx2 import default_client_kwargs
 from inspect_ai._util.logger import warn_once
 from inspect_ai.model._generate_config import has_image_output, normalized_batch_config
 from inspect_ai.model._providers.openai_completions import (
@@ -261,8 +262,8 @@ class OpenAIAPI(ModelAPI):
                 )
 
         # extract http_client and api_version before storing model_args
-        self.http_client = (
-            model_args.pop("http_client", None) or DefaultAsyncHttpxClient()
+        self.http_client = model_args.pop("http_client", None) or (
+            DefaultAsyncHttpxClient(**default_client_kwargs())
         )
         if self.is_azure():
             # resolve version
@@ -338,7 +339,7 @@ class OpenAIAPI(ModelAPI):
         super().initialize()
 
         if self.http_client.is_closed:
-            self.http_client = DefaultAsyncHttpxClient()
+            self.http_client = DefaultAsyncHttpxClient(**default_client_kwargs())
 
         self.client = self._create_client()
 

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -38,6 +38,7 @@ from inspect_ai.model._providers.util.llama31 import Llama31Handler
 from inspect_ai.tool import ToolChoice, ToolInfo
 from inspect_ai.util._json import JSON_SCHEMA_EXTENDED_FIELDS
 
+from ..._util.http_defaults_httpx2 import connect_timeout, default_client_kwargs
 from .._chat_message import ChatMessage, ChatMessageTool
 from .._generate_config import GenerateConfig
 from .._model import ModelAPI, RetryDecision
@@ -160,16 +161,22 @@ class OpenAICompatibleAPI(ModelAPI):
 
     def _create_http_client(self) -> DefaultAsyncHttpxClient:
         # DefaultAsyncHttpxClient is the SDK's own httpx2.AsyncClient with
-        # OpenAI's recommended defaults (timeout, connection limits, redirect
-        # and proxy handling). Source the client from the SDK rather than
-        # hand-building an httpx client with equivalent defaults: a client and
-        # its config objects must be the same httpx flavor — a mismatch
-        # silently corrupts the timeout config (#4837).
+        # OpenAI's recommended defaults. Source the client from the SDK rather
+        # than hand-building one: a client and its config objects must be the
+        # same httpx flavor — a mismatch silently corrupts the timeout config
+        # (#4837). Our kwargs win over its setdefaults.
         if self.client_timeout is not None:
+            # client_timeout is the overall budget and must not shorten the
+            # connect deadline.
             return DefaultAsyncHttpxClient(
-                timeout=httpx2.Timeout(timeout=self.client_timeout, connect=5.0)
+                **default_client_kwargs(
+                    timeout=httpx2.Timeout(
+                        timeout=self.client_timeout,
+                        connect=max(self.client_timeout, connect_timeout()),
+                    )
+                )
             )
-        return DefaultAsyncHttpxClient()
+        return DefaultAsyncHttpxClient(**default_client_kwargs())
 
     def _create_client(self) -> AsyncOpenAI:
         return AsyncOpenAI(

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from inspect_ai._util.http_defaults import (
+    CONNECT_RETRIES_ENV,
+    CONNECT_TIMEOUT_ENV,
+    KEEPALIVE_EXPIRY_ENV,
+    POOL_CONNECTIONS_ENV,
+    POOL_KEEPALIVE_CONNECTIONS_ENV,
+    REQUEST_TIMEOUT_ENV,
+)
+
+HTTP_ENV_VARS = (
+    CONNECT_TIMEOUT_ENV,
+    REQUEST_TIMEOUT_ENV,
+    POOL_CONNECTIONS_ENV,
+    POOL_KEEPALIVE_CONNECTIONS_ENV,
+    KEEPALIVE_EXPIRY_ENV,
+    CONNECT_RETRIES_ENV,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_http_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ambient HTTP settings out of every provider test in this tree.
+
+    One exported variable is enough to fail an assertion about an SDK default.
+    Proxy variables are left alone: `providers/test_openai_proxy.py` sets its
+    own.
+    """
+    for var in HTTP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -271,7 +271,9 @@ def test_client_timeout_sets_http_timeout() -> None:
     assert timeout.read == 1800.0
     assert timeout.write == 1800.0
     assert timeout.pool == 1800.0
-    assert timeout.connect == 5.0
+    # The connect deadline is floored at the shared default rather than pinned
+    # to it, so a budget already above the floor carries through unchanged.
+    assert timeout.connect == 1800.0
 
 
 def test_client_timeout_default_uses_sdk_default() -> None:
@@ -297,7 +299,7 @@ async def test_client_timeout_preserved_after_reinitialize() -> None:
     api.initialize()
     assert not api.http_client.is_closed
     assert api.http_client.timeout.read == 1800.0
-    assert api.http_client.timeout.connect == 5.0
+    assert api.http_client.timeout.connect == 1800.0
 
 
 def test_user_supplied_http_client_not_overridden() -> None:

--- a/tests/model/test_http_defaults.py
+++ b/tests/model/test_http_defaults.py
@@ -33,6 +33,12 @@ from inspect_ai.model._providers.groq import GroqAPI
 from inspect_ai.model._providers.openai import OpenAIAPI
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 
+# Most tests need only the module under test; FLAVORS is for the few that also
+# construct flavor-typed objects, whose classes are unrelated across the two.
+DEFAULT_MODULES = [
+    pytest.param(http_defaults, id="httpx"),
+    pytest.param(http_defaults_httpx2, id="httpx2"),
+]
 FLAVORS = [
     pytest.param(http_defaults, httpx, id="httpx"),
     pytest.param(http_defaults_httpx2, httpx2, id="httpx2"),
@@ -60,11 +66,7 @@ def clean_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def timeout_of(client: Any) -> Any:
-    """The SDK client's timeout, which it types as `float | Timeout | None`.
-
-    Returns `Any` because the two httpx flavors' `Timeout` classes are
-    unrelated, and which one a provider yields depends on its SDK.
-    """
+    """The SDK client's timeout, which it types as `float | Timeout | None`."""
     timeout = client.timeout
     assert isinstance(timeout, (httpx.Timeout, httpx2.Timeout))
     return timeout
@@ -73,10 +75,9 @@ def timeout_of(client: Any) -> Any:
 def pool_of(transport: Any) -> Any:
     """The httpcore pool behind a transport (httpx or httpx2).
 
-    httpx publishes no accessor for retries, limits or socket options, and is
-    unpinned here, so keep the one reach-through in a single place with a
-    diagnosable failure. Untyped because it also has to accept httpx2's
-    transport types, which share no base class with httpx's.
+    httpx publishes no accessor for retries, limits or socket options and is
+    unpinned here, so the one reach-through lives here with a diagnosable
+    failure.
     """
     pool = getattr(transport, "_pool", None)
     if pool is None:
@@ -134,17 +135,17 @@ def test_both_flavors_export_the_same_names() -> None:
     assert names(http_defaults_httpx2) == names(http_defaults)
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
-def test_the_connect_deadline_is_sixty_seconds(defaults: Any, httpx_mod: Any) -> None:
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
+def test_the_connect_deadline_is_sixty_seconds(defaults: Any) -> None:
     # 5s failed 75% of connects behind a 26s loop block and 15s failed 76.7%;
     # 30s was the first value that cleared it. Changing this needs new data.
     assert defaults.DEFAULT_CONNECT_TIMEOUT == 60.0
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 @pytest.mark.parametrize("limit", [None, "50"], ids=["default", "lowered"])
 def test_keepalive_tracks_the_connection_limit(
-    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any
 ) -> None:
     # Below the cap every connection is destroyed the moment it goes idle,
     # stepping the new-connection rate ~20x once concurrency passes ~120. Two
@@ -158,9 +159,9 @@ def test_keepalive_tracks_the_connection_limit(
     assert limits.max_keepalive_connections == expected
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 def test_keepalive_can_still_be_set_below_the_connection_limit(
-    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, defaults: Any
 ) -> None:
     monkeypatch.setenv(POOL_KEEPALIVE_CONNECTIONS_ENV, "7")
     limits = defaults.default_limits()
@@ -168,10 +169,10 @@ def test_keepalive_can_still_be_set_below_the_connection_limit(
     assert limits.max_keepalive_connections == 7
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 @pytest.mark.parametrize("limit", [None, "200"], ids=["unset", "explicit"])
 def test_an_uncapped_caller_default_yields_only_to_an_explicit_limit(
-    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any
 ) -> None:
     if limit is not None:
         monkeypatch.setenv(POOL_CONNECTIONS_ENV, limit)
@@ -181,7 +182,7 @@ def test_an_uncapped_caller_default_yields_only_to_an_explicit_limit(
     assert limits.max_keepalive_connections == expected
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 @pytest.mark.parametrize(
     "value,expected",
     [
@@ -198,16 +199,15 @@ def test_connect_timeout_env_override(
     value: str,
     expected: float,
     defaults: Any,
-    httpx_mod: Any,
 ) -> None:
     monkeypatch.setenv(CONNECT_TIMEOUT_ENV, value)
     assert defaults.default_timeout().connect == expected
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 @pytest.mark.parametrize("value", ["garbage", "-1"], ids=["junk", "negative"])
 def test_an_unusable_env_value_keeps_the_caller_default(
-    monkeypatch: pytest.MonkeyPatch, value: str, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, value: str, defaults: Any
 ) -> None:
     # Falling back to the module default instead would silently widen a
     # provider's tighter budget or cap a pool it deliberately left uncapped.
@@ -234,27 +234,20 @@ def test_keepalive_expiry_left_alone_unless_asked(
 # --- the transport ----------------------------------------------------------
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
+@pytest.mark.parametrize(
+    "env,expected", [(None, DEFAULT_CONNECT_RETRIES), ("4", 4)], ids=["default", "env"]
+)
 def test_transport_retries_connection_establishment(
-    defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, env: str | None, expected: int, defaults: Any
 ) -> None:
-    assert pool_of(defaults.default_async_client()._transport)._retries == (
-        DEFAULT_CONNECT_RETRIES
-    )
+    if env is not None:
+        monkeypatch.setenv(CONNECT_RETRIES_ENV, env)
+    assert pool_of(defaults.default_async_client()._transport)._retries == expected
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
-def test_connect_retries_env_override(
-    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
-) -> None:
-    monkeypatch.setenv(CONNECT_RETRIES_ENV, "4")
-    assert pool_of(defaults.default_async_client()._transport)._retries == 4
-
-
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
-def test_transport_keeps_the_sdk_tcp_keepalive_options(
-    defaults: Any, httpx_mod: Any
-) -> None:
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
+def test_transport_keeps_the_sdk_tcp_keepalive_options(defaults: Any) -> None:
     # Socket options live on the transport, so supplying one drops those the
     # SDK installs and a reaped connection then hangs to the read deadline
     # instead of being surfaced by the kernel.
@@ -314,7 +307,7 @@ async def test_the_floor_hook_survives_httpx_hooks_on_httpx2() -> None:
 # --- proxies ----------------------------------------------------------------
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 @pytest.mark.parametrize(
     "var,proxied",
     [
@@ -329,7 +322,6 @@ def test_a_proxy_variable_is_mounted_for_every_spelling(
     var: str,
     proxied: bool,
     defaults: Any,
-    httpx_mod: Any,
 ) -> None:
     # httpx matches `<scheme>_proxy` case-insensitively but mounts only
     # http/https/all, so an ftp proxy must not produce a mount.
@@ -337,9 +329,9 @@ def test_a_proxy_variable_is_mounted_for_every_spelling(
     assert bool(defaults.default_async_client()._mounts) is proxied
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 def test_a_proxy_mount_keeps_the_keepalive_options(
-    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, defaults: Any
 ) -> None:
     # Supplying a transport turns off httpx's proxy discovery. Rebuilding the
     # mounts is what stops a proxied deployment from silently losing the kernel
@@ -356,9 +348,9 @@ def test_a_proxy_mount_keeps_the_keepalive_options(
     assert pool_of(client._transport)._retries == DEFAULT_CONNECT_RETRIES
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 def test_no_proxy_excludes_a_host(
-    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, defaults: Any
 ) -> None:
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
     monkeypatch.setenv("NO_PROXY", "localhost")
@@ -369,9 +361,9 @@ def test_no_proxy_excludes_a_host(
     )
 
 
-@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
 def test_trust_env_false_disables_proxy_mounts(
-    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+    monkeypatch: pytest.MonkeyPatch, defaults: Any
 ) -> None:
     # httpx itself gates environment proxy discovery on `trust_env`
     # (`allow_env_proxies = trust_env and transport is None`); rebuilding the
@@ -384,8 +376,8 @@ def test_trust_env_false_disables_proxy_mounts(
 def test_openai_sdk_client_takes_our_proxy_mounts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Answers whether DefaultAsyncHttpxClient builds proxy mounts of its own
-    # that ours would replace.
+    # DefaultAsyncHttpxClient may build proxy mounts of its own, which ours
+    # would replace wholesale.
     from openai import DefaultAsyncHttpxClient
 
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
@@ -687,12 +679,9 @@ def test_google_uses_the_defaults_on_its_httpx_path(
     # Google reaches httpx only under trio, and CI never passes --runtrio, so
     # drive the branch directly rather than depending on the live backend.
     #
-    # Only the transport-level settings apply here: google stamps its own
-    # scalar timeout onto every request (`_api_client.py` passes
-    # `timeout=http_request.timeout` to `build_request`), which is 3600s by
-    # default, so the connect floor never binds and the client's own timeout
-    # never reaches the wire. Asserting that would be asserting the wrong
-    # object.
+    # Only transport-level settings apply: google stamps its own scalar timeout
+    # (3600s by default) onto every request, so the connect floor never binds
+    # and the client's own timeout never reaches the wire.
     monkeypatch.setattr(_async_backend, "current_async_backend", lambda: "trio")
     client = google_api().model_client()._api_client._async_httpx_client
     assert client is not None

--- a/tests/model/test_http_defaults.py
+++ b/tests/model/test_http_defaults.py
@@ -1,0 +1,713 @@
+"""Provider HTTP client defaults (connect deadline, pooling, connect retries)."""
+
+import os
+import socket
+import urllib.request
+from typing import Any, NamedTuple
+
+import anthropic
+import groq
+import httpx
+import httpx._utils
+import httpx2._utils
+import pytest
+from test_helpers.utils import skip_if_trio
+
+import inspect_ai._util._async as _async_backend
+from inspect_ai._util import http_defaults, http_defaults_httpx2
+from inspect_ai._util.http_defaults import (
+    CONNECT_RETRIES_ENV,
+    CONNECT_TIMEOUT_ENV,
+    DEFAULT_CONNECT_RETRIES,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_POOL_CONNECTIONS,
+    KEEPALIVE_EXPIRY_ENV,
+    POOL_CONNECTIONS_ENV,
+    POOL_KEEPALIVE_CONNECTIONS_ENV,
+    REQUEST_TIMEOUT_ENV,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._providers.anthropic import AnthropicAPI
+from inspect_ai.model._providers.google import GoogleGenAIAPI
+from inspect_ai.model._providers.groq import GroqAPI
+from inspect_ai.model._providers.openai import OpenAIAPI
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+
+FLAVORS = [
+    pytest.param(http_defaults, httpx, id="httpx"),
+    pytest.param(http_defaults_httpx2, httpx2, id="httpx2"),
+]
+
+
+@pytest.fixture(autouse=True)
+def clean_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin proxy resolution to the environment, then clear it.
+
+    `HTTPS_PROXY` is exported on many CI runners and changes how the transport
+    is built; a macOS or Windows system proxy would do the same. The
+    `INSPECT_HTTP_*` variables are cleared by the fixture in `conftest.py`.
+    """
+    for var in [name for name in os.environ if name.lower().endswith("_proxy")]:
+        monkeypatch.delenv(var, raising=False)
+    # httpx binds `getproxies` at import, so patch the name it actually calls;
+    # this also keeps a developer's macOS system proxy out of the assertions.
+    monkeypatch.setattr(
+        httpx._utils, "getproxies", urllib.request.getproxies_environment
+    )
+    monkeypatch.setattr(
+        httpx2._utils, "getproxies", urllib.request.getproxies_environment
+    )
+
+
+def timeout_of(client: Any) -> Any:
+    """The SDK client's timeout, which it types as `float | Timeout | None`.
+
+    Returns `Any` because the two httpx flavors' `Timeout` classes are
+    unrelated, and which one a provider yields depends on its SDK.
+    """
+    timeout = client.timeout
+    assert isinstance(timeout, (httpx.Timeout, httpx2.Timeout))
+    return timeout
+
+
+def pool_of(transport: Any) -> Any:
+    """The httpcore pool behind a transport (httpx or httpx2).
+
+    httpx publishes no accessor for retries, limits or socket options, and is
+    unpinned here, so keep the one reach-through in a single place with a
+    diagnosable failure. Untyped because it also has to accept httpx2's
+    transport types, which share no base class with httpx's.
+    """
+    pool = getattr(transport, "_pool", None)
+    if pool is None:
+        raise AssertionError(
+            f"{type(transport).__module__}.{type(transport).__name__} has no "
+            "_pool; these tests read pool internals to verify transport "
+            "configuration"
+        )
+    return pool
+
+
+def anthropic_api(**model_args: Any) -> AnthropicAPI:
+    return AnthropicAPI(
+        model_name="claude-haiku-4-5-20251001", api_key="sk-test", **model_args
+    )
+
+
+def openai_api(**model_args: Any) -> OpenAIAPI:
+    return OpenAIAPI(model_name="gpt-4o", api_key="sk-test", **model_args)
+
+
+def openai_compatible_api(**model_args: Any) -> OpenAICompatibleAPI:
+    return OpenAICompatibleAPI(
+        model_name="svc/model",
+        base_url="https://example.invalid",
+        api_key="sk-test",
+        service="svc",
+        **model_args,
+    )
+
+
+def google_api() -> GoogleGenAIAPI:
+    return GoogleGenAIAPI(
+        model_name="gemini-2.0-flash",
+        base_url=None,
+        api_key="test",
+        config=GenerateConfig(),
+    )
+
+
+# --- the values themselves --------------------------------------------------
+
+
+def test_both_flavors_export_the_same_names() -> None:
+    # Edit http_defaults.py, then mirror to http_defaults_httpx2.py. The
+    # parametrized tests below catch a changed function that was not mirrored;
+    # only this catches an added one, because no test references it yet.
+    def names(module: object) -> set[str]:
+        return {
+            n
+            for n in dir(module)
+            if not n.startswith("__") and n not in ("httpx", "httpx2")
+        }
+
+    assert names(http_defaults_httpx2) == names(http_defaults)
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_the_connect_deadline_is_sixty_seconds(defaults: Any, httpx_mod: Any) -> None:
+    # 5s failed 75% of connects behind a 26s loop block and 15s failed 76.7%;
+    # 30s was the first value that cleared it. Changing this needs new data.
+    assert defaults.DEFAULT_CONNECT_TIMEOUT == 60.0
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("limit", [None, "50"], ids=["default", "lowered"])
+def test_keepalive_tracks_the_connection_limit(
+    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any, httpx_mod: Any
+) -> None:
+    # Below the cap every connection is destroyed the moment it goes idle,
+    # stepping the new-connection rate ~20x once concurrency passes ~120. Two
+    # independent defaults would also let the cap sit above the limit.
+    expected = DEFAULT_POOL_CONNECTIONS
+    if limit is not None:
+        monkeypatch.setenv(POOL_CONNECTIONS_ENV, limit)
+        expected = int(limit)
+    limits = defaults.default_limits()
+    assert limits.max_connections == expected
+    assert limits.max_keepalive_connections == expected
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_keepalive_can_still_be_set_below_the_connection_limit(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    monkeypatch.setenv(POOL_KEEPALIVE_CONNECTIONS_ENV, "7")
+    limits = defaults.default_limits()
+    assert limits.max_connections == DEFAULT_POOL_CONNECTIONS
+    assert limits.max_keepalive_connections == 7
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("limit", [None, "200"], ids=["unset", "explicit"])
+def test_an_uncapped_caller_default_yields_only_to_an_explicit_limit(
+    monkeypatch: pytest.MonkeyPatch, limit: str | None, defaults: Any, httpx_mod: Any
+) -> None:
+    if limit is not None:
+        monkeypatch.setenv(POOL_CONNECTIONS_ENV, limit)
+    limits = defaults.default_limits(max_connections=None)
+    expected = int(limit) if limit is not None else None
+    assert limits.max_connections == expected
+    assert limits.max_keepalive_connections == expected
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("12.5", 12.5),
+        ("0", 0.0),
+        ("", DEFAULT_CONNECT_TIMEOUT),
+        ("   ", DEFAULT_CONNECT_TIMEOUT),
+        ("garbage", DEFAULT_CONNECT_TIMEOUT),
+        ("-1", DEFAULT_CONNECT_TIMEOUT),
+    ],
+)
+def test_connect_timeout_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+    expected: float,
+    defaults: Any,
+    httpx_mod: Any,
+) -> None:
+    monkeypatch.setenv(CONNECT_TIMEOUT_ENV, value)
+    assert defaults.default_timeout().connect == expected
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize("value", ["garbage", "-1"], ids=["junk", "negative"])
+def test_an_unusable_env_value_keeps_the_caller_default(
+    monkeypatch: pytest.MonkeyPatch, value: str, defaults: Any, httpx_mod: Any
+) -> None:
+    # Falling back to the module default instead would silently widen a
+    # provider's tighter budget or cap a pool it deliberately left uncapped.
+    monkeypatch.setenv(REQUEST_TIMEOUT_ENV, value)
+    monkeypatch.setenv(POOL_CONNECTIONS_ENV, value)
+    assert defaults.default_timeout(request_timeout=60.0).read == 60.0
+    assert defaults.default_limits(max_connections=None).max_connections is None
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_keepalive_expiry_left_alone_unless_asked(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    # Raising it past an intermediary's idle timeout trades these failures for
+    # stale-connection ones, so it only moves when a deployment sets it.
+    assert (
+        defaults.default_limits().keepalive_expiry
+        == httpx_mod.Limits().keepalive_expiry
+    )
+    monkeypatch.setenv(KEEPALIVE_EXPIRY_ENV, "45")
+    assert defaults.default_limits().keepalive_expiry == 45.0
+
+
+# --- the transport ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_transport_retries_connection_establishment(
+    defaults: Any, httpx_mod: Any
+) -> None:
+    assert pool_of(defaults.default_async_client()._transport)._retries == (
+        DEFAULT_CONNECT_RETRIES
+    )
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_connect_retries_env_override(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    monkeypatch.setenv(CONNECT_RETRIES_ENV, "4")
+    assert pool_of(defaults.default_async_client()._transport)._retries == 4
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_transport_keeps_the_sdk_tcp_keepalive_options(
+    defaults: Any, httpx_mod: Any
+) -> None:
+    # Socket options live on the transport, so supplying one drops those the
+    # SDK installs and a reaped connection then hangs to the read deadline
+    # instead of being surfaced by the kernel.
+    pool = pool_of(defaults.default_async_client()._transport)
+    sdk_pool = pool_of(anthropic.DefaultAsyncHttpxClient()._transport)
+    assert sorted(pool._socket_options) == sorted(sdk_pool._socket_options)
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in pool._socket_options
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_a_caller_transport_is_left_alone(defaults: Any, httpx_mod: Any) -> None:
+    supplied = httpx_mod.AsyncHTTPTransport()
+    assert defaults.default_async_client(transport=supplied)._transport is supplied
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+async def test_a_caller_request_hook_still_runs(defaults: Any, httpx_mod: Any) -> None:
+    seen: list[str] = []
+
+    async def caller_hook(request: httpx.Request) -> None:
+        seen.append("caller")
+
+    client = defaults.default_async_client(
+        transport=httpx_mod.MockTransport(lambda request: httpx_mod.Response(200)),
+        event_hooks={"request": [caller_hook]},
+    )
+    await client.get("https://example.invalid")
+    assert seen == ["caller"]
+
+
+async def test_the_floor_hook_survives_httpx_hooks_on_httpx2() -> None:
+    import httpx2
+
+    from inspect_ai.model._providers.util.hooks import HttpxHooks
+
+    # A client whose own connect deadline is BELOW the floor, so the hook has
+    # something to raise and its absence is observable.
+    client = http_defaults_httpx2.default_async_client(
+        timeout=httpx2.Timeout(30.0, connect=5.0),
+        transport=httpx2.MockTransport(lambda request: httpx2.Response(200)),
+    )
+    # Appends its own request hook after ours; must not displace it.
+    HttpxHooks(client)
+
+    seen: dict[str, float] = {}
+
+    async def record(request: httpx2.Request) -> None:
+        seen.update(request.extensions.get("timeout") or {})
+
+    client.event_hooks["request"].append(record)
+    await client.get("https://example.invalid")
+
+    assert seen["connect"] == http_defaults_httpx2.DEFAULT_CONNECT_TIMEOUT
+    assert seen["read"] == 30.0
+
+
+# --- proxies ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize(
+    "var,proxied",
+    [
+        ("HTTPS_PROXY", True),
+        ("Https_Proxy", True),
+        ("https_proxy", True),
+        ("FTP_PROXY", False),
+    ],
+)
+def test_a_proxy_variable_is_mounted_for_every_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+    var: str,
+    proxied: bool,
+    defaults: Any,
+    httpx_mod: Any,
+) -> None:
+    # httpx matches `<scheme>_proxy` case-insensitively but mounts only
+    # http/https/all, so an ftp proxy must not produce a mount.
+    monkeypatch.setenv(var, "http://proxy.example:3128")
+    assert bool(defaults.default_async_client()._mounts) is proxied
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_a_proxy_mount_keeps_the_keepalive_options(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    # Supplying a transport turns off httpx's proxy discovery. Rebuilding the
+    # mounts is what stops a proxied deployment from silently losing the kernel
+    # keepalive probes, which is what the SDK's own client would have carried.
+    # httpx's proxy pool takes no `retries`, so the connect retry is genuinely
+    # unavailable behind a proxy.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    client = defaults.default_async_client()
+    mounted = [t for t in client._mounts.values() if t is not None]
+    assert mounted, "expected a proxy mount"
+    for transport in mounted:
+        pool = pool_of(transport)
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in pool._socket_options
+    assert pool_of(client._transport)._retries == DEFAULT_CONNECT_RETRIES
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_no_proxy_excludes_a_host(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setenv("NO_PROXY", "localhost")
+    mounts = defaults.default_async_client()._mounts
+    assert any(
+        transport is None and "localhost" in pattern.pattern
+        for pattern, transport in mounts.items()
+    )
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+def test_trust_env_false_disables_proxy_mounts(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any, httpx_mod: Any
+) -> None:
+    # httpx itself gates environment proxy discovery on `trust_env`
+    # (`allow_env_proxies = trust_env and transport is None`); rebuilding the
+    # mounts unconditionally would silently ignore a caller's opt-out.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    assert defaults.default_async_client()._mounts
+    assert defaults.default_async_client(trust_env=False)._mounts == {}
+
+
+def test_openai_sdk_client_takes_our_proxy_mounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Answers whether DefaultAsyncHttpxClient builds proxy mounts of its own
+    # that ours would replace.
+    from openai import DefaultAsyncHttpxClient
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    bare = DefaultAsyncHttpxClient()
+    ours = DefaultAsyncHttpxClient(**http_defaults_httpx2.default_client_kwargs())
+
+    # If the SDK builds its own mounts, ours must not lose any of its keys.
+    assert {k.pattern for k in bare._mounts} <= {k.pattern for k in ours._mounts}
+    mounted = [t for t in ours._mounts.values() if t is not None]
+    assert mounted, "expected a proxy mount"
+    for transport in mounted:
+        pool = pool_of(transport)
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in pool._socket_options
+
+
+def test_openai_sdk_client_respects_explicit_arguments() -> None:
+    import httpx2
+    from openai import DefaultAsyncHttpxClient
+
+    client = DefaultAsyncHttpxClient(
+        **http_defaults_httpx2.default_client_kwargs(
+            timeout=httpx2.Timeout(timeout=1.0, connect=2.0)
+        )
+    )
+    assert client.timeout.connect == 2.0
+
+
+# --- the connect floor ------------------------------------------------------
+
+
+@pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
+@pytest.mark.parametrize(
+    "connect,expected",
+    [
+        (5.0, DEFAULT_CONNECT_TIMEOUT),
+        (DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+        (900.0, 900.0),
+        (None, None),
+    ],
+    ids=["raised", "unchanged", "longer-kept", "no-deadline-kept"],
+)
+async def test_the_floor_only_ever_raises_the_connect_deadline(
+    connect: float | None, expected: float | None, defaults: Any, httpx_mod: Any
+) -> None:
+    request = httpx_mod.Request(
+        "POST",
+        "https://example.invalid",
+        extensions={"timeout": {"connect": connect, "read": 30.0}},
+    )
+    await defaults._floor_connect_timeout(request)
+    assert request.extensions["timeout"] == {"connect": expected, "read": 30.0}
+
+
+_CHAT_COMPLETION = {
+    "id": "x",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "m",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "hi"},
+            "finish_reason": "stop",
+        }
+    ],
+}
+
+
+def capture_timeout(
+    client: Any, payload: dict[str, Any], httpx_mod: Any = httpx
+) -> dict[str, float]:
+    """Swap in a mock transport and record the deadlines it is handed.
+
+    The client's own `timeout` reads correct even when a connect deadline has
+    collapsed, so it is the wrong thing to assert on. Event hooks are client
+    level, so they still run. `httpx_mod` must match the client's flavor: a
+    mock from the other flavor fails inside the client.
+    """
+    seen: dict[str, float] = {}
+
+    def handler(request: Any) -> Any:
+        seen.update(request.extensions.get("timeout") or {})
+        return httpx_mod.Response(200, json=payload)
+
+    client._transport = httpx_mod.MockTransport(handler)
+    return seen
+
+
+async def transport_timeout(api: Any) -> dict[str, float]:
+    seen = capture_timeout(api.client._client, _CHAT_COMPLETION, httpx2)
+    await api.client.chat.completions.create(
+        model="m", messages=[{"role": "user", "content": "hi"}]
+    )
+    return seen
+
+
+@pytest.mark.parametrize(
+    "api_factory",
+    [openai_api, openai_compatible_api],
+    ids=["openai", "openai-compatible"],
+)
+async def test_a_scalar_client_timeout_does_not_shorten_the_connect_deadline(
+    api_factory: Any,
+) -> None:
+    # The SDK stamps client_timeout into every request as a bare float, which
+    # httpx expands to all four deadlines, so without the floor an overall
+    # budget silently becomes the connect deadline.
+    seen = await transport_timeout(api_factory(client_timeout=30.0))
+    assert seen["connect"] == DEFAULT_CONNECT_TIMEOUT
+    assert seen["read"] == 30.0
+
+
+@pytest.mark.parametrize(
+    "api_factory",
+    [openai_api, openai_compatible_api],
+    ids=["openai", "openai-compatible"],
+)
+async def test_default_connect_deadline_reaches_the_transport(
+    api_factory: Any,
+) -> None:
+    assert (await transport_timeout(api_factory()))["connect"] == (
+        DEFAULT_CONNECT_TIMEOUT
+    )
+
+
+async def test_a_longer_connect_deadline_is_left_alone() -> None:
+    # service_tier="flex" sets a 900s budget with no user flag; the floor only
+    # ever raises, so a deployment that wants a long deadline keeps it.
+    assert (await transport_timeout(openai_api(service_tier="flex")))["connect"] == (
+        900.0
+    )
+
+
+# --- providers --------------------------------------------------------------
+
+
+_MESSAGE = {
+    "id": "msg_1",
+    "type": "message",
+    "role": "assistant",
+    "model": "m",
+    "content": [{"type": "text", "text": "hi"}],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 1, "output_tokens": 1},
+}
+
+
+async def anthropic_transport_timeout(api: AnthropicAPI) -> dict[str, float]:
+    seen = capture_timeout(api.client._client, _MESSAGE, httpx2)
+    await api.client.messages.create(
+        model="m", max_tokens=1, messages=[{"role": "user", "content": "hi"}]
+    )
+    return seen
+
+
+class TestAnthropicDefaults:
+    def test_client_gets_the_defaults(self) -> None:
+        # This provider passes no timeout of its own, so without this it
+        # inherits the SDK's connect=5s.
+        client = anthropic_api().client
+        assert timeout_of(client).connect == DEFAULT_CONNECT_TIMEOUT
+        pool = pool_of(client._client._transport)
+        assert pool._max_keepalive_connections == DEFAULT_POOL_CONNECTIONS
+        assert pool._retries == DEFAULT_CONNECT_RETRIES
+
+    async def test_a_caller_timeout_keeps_the_connect_floor(self) -> None:
+        # The caller's budget is theirs, but it must not drag the connect
+        # deadline down with it — the failure this module exists to fix.
+        seen = await anthropic_transport_timeout(anthropic_api(timeout=3.0))
+        assert seen["read"] == 3.0
+        assert seen["connect"] == DEFAULT_CONNECT_TIMEOUT
+
+    def test_caller_http_client_wins(self) -> None:
+        supplied = httpx2.AsyncClient()
+        assert anthropic_api(http_client=supplied).client._client is supplied
+
+    def test_skipped_when_sdk_is_not_httpx_based(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The SDK's own default timeout is our flavor sentinel: if anthropic
+        # ever moves off httpx2, it would reject the httpx2 objects we build,
+        # which is exactly how openai 3.0 broke every OpenAI-compatible request.
+        sdk_default = anthropic.DEFAULT_TIMEOUT
+        monkeypatch.setattr(anthropic, "DEFAULT_TIMEOUT", object())
+        assert timeout_of(anthropic_api().client).connect == sdk_default.connect
+
+
+class TestAnthropicClientLifetime:
+    """`aclose()` + `initialize()` is the auth-retry path (_model.py before_retry)."""
+
+    async def test_reinitialize_rebuilds_our_closed_client(self) -> None:
+        # Reusing a closed client fails every later request with
+        # APIConnectionError — the error class these defaults exist to remove,
+        # and one inspect treats as transient, so the model retries forever.
+        api = anthropic_api()
+        first = api.client._client
+        await api.aclose()
+        assert first.is_closed
+
+        api.initialize()
+        second = api.client._client
+        assert second is not first
+        assert not second.is_closed
+        assert second.timeout.connect == DEFAULT_CONNECT_TIMEOUT
+
+    async def test_reinitialize_never_replaces_a_caller_client(self) -> None:
+        # Only that we leave it alone. The SDK closes a caller-supplied client
+        # on `aclose()` and the caller owns rebuilding it; that predates this
+        # module, so do not read this as the client still being usable.
+        supplied = httpx2.AsyncClient()
+        api = anthropic_api(http_client=supplied)
+        await api.aclose()
+        api.initialize()
+        assert api.client._client is supplied
+
+
+class GroqSettings(NamedTuple):
+    connect: float | None
+    read: float | None
+    max_connections: int | None
+    max_keepalive: int | None
+    keepalive_expiry: float | None
+    retries: int
+    socket_options: Any
+
+
+def groq_settings(**model_args: Any) -> GroqSettings:
+    api = GroqAPI(
+        model_name="llama-3.3-70b-versatile", api_key="gsk-test", **model_args
+    )
+    timeout = timeout_of(api.client)
+    pool = pool_of(api.client._client._transport)
+    return GroqSettings(
+        connect=timeout.connect,
+        read=timeout.read,
+        max_connections=pool._max_connections,
+        max_keepalive=pool._max_keepalive_connections,
+        keepalive_expiry=pool._keepalive_expiry,
+        retries=pool._retries,
+        socket_options=pool._socket_options,
+    )
+
+
+class TestGroqDefaults:
+    """Groq supplies its own client, so it needs the defaults applied by hand."""
+
+    def test_connect_deadline_is_raised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Use a value distinct from groq's own 60s read budget: otherwise
+        # `connect == 60` is equally satisfied by connect merely inheriting it.
+        monkeypatch.setenv(CONNECT_TIMEOUT_ENV, "77")
+        settings = groq_settings()
+        assert settings.connect == 77.0
+        assert settings.read == groq.DEFAULT_TIMEOUT.read
+        assert settings.retries == DEFAULT_CONNECT_RETRIES
+        assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in (
+            settings.socket_options
+        )
+
+    def test_provider_defaults_are_kept(self) -> None:
+        # Widening the read budget would take a stalled response from ~3 to ~30
+        # minutes, since the SDK retries twice and groq honours no inspect
+        # timeout; the uncapped pool is likewise deliberate.
+        settings = groq_settings()
+        assert settings.read == groq.DEFAULT_TIMEOUT.read
+        assert settings.max_connections is not None
+        assert settings.max_connections > DEFAULT_POOL_CONNECTIONS
+
+    @pytest.mark.parametrize(
+        "var,value,setting,expected",
+        [
+            (REQUEST_TIMEOUT_ENV, "123", "read", 123.0),
+            (KEEPALIVE_EXPIRY_ENV, "42", "keepalive_expiry", 42.0),
+            (POOL_CONNECTIONS_ENV, "200", "max_connections", 200),
+            (POOL_CONNECTIONS_ENV, "200", "max_keepalive", 200),
+        ],
+    )
+    def test_an_operator_override_beats_a_provider_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        var: str,
+        value: str,
+        setting: str,
+        expected: float,
+    ) -> None:
+        # Those defaults are a starting point, not a refusal to be configured,
+        # and this is the provider most likely to exhaust a descriptor limit.
+        monkeypatch.setenv(var, value)
+        assert getattr(groq_settings(), setting) == expected
+
+    def test_caller_http_client_wins(self) -> None:
+        supplied = httpx.AsyncClient()
+        api = GroqAPI(model_name="m", api_key="gsk-test", http_client=supplied)
+        assert api.client._client is supplied
+
+
+def test_google_uses_the_defaults_on_its_httpx_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Google reaches httpx only under trio, and CI never passes --runtrio, so
+    # drive the branch directly rather than depending on the live backend.
+    #
+    # Only the transport-level settings apply here: google stamps its own
+    # scalar timeout onto every request (`_api_client.py` passes
+    # `timeout=http_request.timeout` to `build_request`), which is 3600s by
+    # default, so the connect floor never binds and the client's own timeout
+    # never reaches the wire. Asserting that would be asserting the wrong
+    # object.
+    monkeypatch.setattr(_async_backend, "current_async_backend", lambda: "trio")
+    client = google_api().model_client()._api_client._async_httpx_client
+    assert client is not None
+    pool = pool_of(client._transport)
+    assert pool._retries == DEFAULT_CONNECT_RETRIES
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in pool._socket_options
+
+
+@skip_if_trio
+async def test_google_leaves_its_aiohttp_path_alone() -> None:
+    # Deliberately uncovered: that path sets no connect deadline at all, so
+    # there is none there for a blocked loop to outlast. Drives model_client()
+    # under the real (unmocked) asyncio backend: our defaults only apply under
+    # trio, so the SDK's own default httpx client — recognisable by its
+    # retries, which it never sets — must be the one that comes back.
+    client = google_api().model_client()._api_client._async_httpx_client
+    assert client is not None
+    assert pool_of(client._transport)._retries == 0

--- a/tests/model/test_http_defaults.py
+++ b/tests/model/test_http_defaults.py
@@ -14,6 +14,7 @@ import pytest
 from test_helpers.utils import skip_if_trio
 
 import inspect_ai._util._async as _async_backend
+import inspect_ai._util.logger as logger_module
 from inspect_ai._util import http_defaults, http_defaults_httpx2
 from inspect_ai._util.http_defaults import (
     CONNECT_RETRIES_ENV,
@@ -215,6 +216,36 @@ def test_an_unusable_env_value_keeps_the_caller_default(
     monkeypatch.setenv(POOL_CONNECTIONS_ENV, value)
     assert defaults.default_timeout(request_timeout=60.0).read == 60.0
     assert defaults.default_limits(max_connections=None).max_connections is None
+
+
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
+def test_a_zero_connection_pool_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, defaults: Any
+) -> None:
+    # A pool of zero can never issue a request, so it is junk rather than a
+    # deliberately tiny setting.
+    monkeypatch.setenv(POOL_CONNECTIONS_ENV, "0")
+    assert defaults.default_limits().max_connections == DEFAULT_POOL_CONNECTIONS
+
+
+@pytest.mark.parametrize("defaults", DEFAULT_MODULES)
+@pytest.mark.parametrize(
+    "var,value", [(CONNECT_TIMEOUT_ENV, "60s"), (POOL_CONNECTIONS_ENV, "0")]
+)
+def test_an_ignored_env_value_is_warned_about(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    var: str,
+    value: str,
+    defaults: Any,
+) -> None:
+    # Falling back silently leaves an operator believing their setting took.
+    monkeypatch.setattr(logger_module, "_warned", [])
+    monkeypatch.setenv(var, value)
+    with caplog.at_level("WARNING"):
+        defaults.default_limits()
+        defaults.default_timeout()
+    assert any(var in r.message and value in r.message for r in caplog.records)
 
 
 @pytest.mark.parametrize("defaults,httpx_mod", FLAVORS)
@@ -535,10 +566,7 @@ async def anthropic_transport_timeout(api: AnthropicAPI) -> dict[str, float]:
 
 class TestAnthropicDefaults:
     def test_client_gets_the_defaults(self) -> None:
-        # This provider passes no timeout of its own, so without this it
-        # inherits the SDK's connect=5s.
         client = anthropic_api().client
-        assert timeout_of(client).connect == DEFAULT_CONNECT_TIMEOUT
         pool = pool_of(client._client._transport)
         assert pool._max_keepalive_connections == DEFAULT_POOL_CONNECTIONS
         assert pool._retries == DEFAULT_CONNECT_RETRIES
@@ -553,6 +581,31 @@ class TestAnthropicDefaults:
     def test_caller_http_client_wins(self) -> None:
         supplied = httpx2.AsyncClient()
         assert anthropic_api(http_client=supplied).client._client is supplied
+
+    async def test_the_sdk_long_request_guard_still_fires(self) -> None:
+        # The SDK runs this check only while `client.timeout` is its own
+        # DEFAULT_TIMEOUT. Substituting an equivalent timeout would turn an
+        # immediate ValueError into a request that stalls to the read deadline
+        # and then retries — the failure this module exists to remove.
+        api = anthropic_api()
+        # The guard fires before any request, so this transport should never be
+        # reached — it is here so a regression fails offline instead of calling
+        # the live API.
+        capture_timeout(api.client._client, _MESSAGE, httpx2)
+        with pytest.raises(ValueError, match="Streaming is required"):
+            await api.client.messages.create(
+                model="m",
+                max_tokens=100_000,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    def test_an_operator_budget_still_reaches_the_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Overriding the budget necessarily gives up the SDK guard above; the
+        # operator asked for it, so their value must win.
+        monkeypatch.setenv(REQUEST_TIMEOUT_ENV, "123")
+        assert timeout_of(anthropic_api().client).read == 123.0
 
     def test_skipped_when_sdk_is_not_httpx_based(
         self, monkeypatch: pytest.MonkeyPatch
@@ -671,6 +724,28 @@ class TestGroqDefaults:
         supplied = httpx.AsyncClient()
         api = GroqAPI(model_name="m", api_key="gsk-test", http_client=supplied)
         assert api.client._client is supplied
+
+
+def test_mistral_gets_the_defaults() -> None:
+    # The SDK client it replaces applies a flat 5s to every phase.
+    from inspect_ai.model._providers.mistral import MistralAPI
+
+    api = MistralAPI(model_name="mistral-large-latest", api_key="test")
+    client = api._http_default_args()["async_client"]
+    assert client.timeout.connect == DEFAULT_CONNECT_TIMEOUT
+    pool = pool_of(client._transport)
+    assert pool._retries == DEFAULT_CONNECT_RETRIES
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True) in pool._socket_options
+
+
+def test_mistral_caller_async_client_wins() -> None:
+    from inspect_ai.model._providers.mistral import MistralAPI
+
+    supplied = httpx.AsyncClient()
+    api = MistralAPI(
+        model_name="mistral-large-latest", api_key="test", async_client=supplied
+    )
+    assert api._http_default_args()["async_client"] is supplied
 
 
 def test_google_uses_the_defaults_on_its_httpx_path(

--- a/tests/util/test_media_resolver.py
+++ b/tests/util/test_media_resolver.py
@@ -6,6 +6,7 @@ import tempfile
 from collections.abc import AsyncIterator
 from contextvars import Token
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -355,11 +356,12 @@ class TestFileAsDataHttp:
 
         client_type = httpx.AsyncClient
 
-        def client_factory(*, follow_redirects: bool) -> httpx.AsyncClient:
-            return client_type(
-                transport=httpx.MockTransport(handler),
-                follow_redirects=follow_redirects,
-            )
+        def client_factory(**kwargs: Any) -> httpx.AsyncClient:
+            # the fetch builds its client from the shared HTTP defaults, so
+            # take those kwargs as given and own only the transport
+            kwargs.pop("transport", None)
+            kwargs.pop("mounts", None)
+            return client_type(transport=httpx.MockTransport(handler), **kwargs)
 
         with patch(
             "inspect_ai._util.images.httpx.AsyncClient",


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The HTTP client under each provider is built with whatever its SDK hardcodes, and inspect exposes none of it. There is no way to change the connect deadline, the pool size or the keepalive behaviour short of hand-building an `http_client` per provider through `-M`.

That is a problem because the SDK defaults assume a caller whose event loop is responsive, and an eval runner's is not always that. Long CPU-bound sections (payload transforms, transcript scans) can hold the loop for seconds at a time, and a 5s connect deadline that expires during one of those blocks fails a connection the kernel had already completed: anyio's cancellation lands on the first checkpoint after the loop resumes, so finishing the handshake in time is no defence. The result is `APIConnectionError`, which inspect classifies as transient and retries, so the symptom is a mysteriously slow eval rather than an obvious failure. One production run logged 6,833 ConnectTimeouts over 11.7 hours with roughly a third of model calls failing terminally, while every host-level CPU signal read clean.

A deployment that hits this today has no lever to pull.

### What is the new behavior?

Six environment variables tune the HTTP client underneath the OpenAI, OpenAI-compatible, Anthropic and Groq providers, so an operator can adjust connection behaviour for their own topology without waiting for a release:

| Variable | Default |
|---|---|
| `INSPECT_HTTP_CONNECT_TIMEOUT` | 60 |
| `INSPECT_HTTP_REQUEST_TIMEOUT` | 600 |
| `INSPECT_HTTP_POOL_CONNECTIONS` | 1000 |
| `INSPECT_HTTP_POOL_KEEPALIVE_CONNECTIONS` | the connection pool size |
| `INSPECT_HTTP_KEEPALIVE_EXPIRY` | 5 |
| `INSPECT_HTTP_CONNECT_RETRIES` | 1 |

The defaults that come with them also move off the SDKs': 60s for connection setup rather than 5s, a keepalive pool as large as the connection limit, one connection-establishment retry, and the TCP keepalive socket options the Anthropic SDK sets on its own. `docs/models-concurrency.qmd` documents the variables and exactly which providers they reach; `_util/http_defaults` carries the rationale and measurements behind each value.

A partial raise buys nothing, which is why the connect default is 60 and not 30: a 26s block failed 75% of connects at a 5s deadline and 76.7% at 15s, reaching 0% only at 30s. The deadline also has to clear *several* blocks rather than one — a connect that misses its free window waits out whole blocks, so failure latency lands on integer multiples of the block length (a 3s block against a 5s deadline still failed 77% of the time, at a 6.1s median).

Settings a caller already chose are preserved rather than overwritten. A request budget you set yourself (`-M client_timeout`, `-M timeout`, `service_tier="flex"`) is kept, with the connect deadline floored alongside it rather than pinned to it; a provider whose SDK default is deliberately different — Groq's tighter request budget and uncapped pool — keeps it until the matching variable is set.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No API change, but one behavioural trade-off worth stating: a genuinely dead endpoint now takes ~120s to detect rather than 5s, because the retry gives it a second full deadline. httpcore charges the deadline separately to the TCP connect and the TLS handshake, so an endpoint that accepts slowly and then stalls can reach 4x. After that the caller's own backoff dominates, so the asymmetry strongly favours the raise — but anyone relying on fast failure against an unreachable host will notice, and can set `INSPECT_HTTP_CONNECT_TIMEOUT` back down.

### Other information:

**Two httpx flavors.** Since #4875 the openai SDK is built on the separate `httpx2` package, and anthropic 1.0.0 has since done the same; a client must not be mixed with another flavor's config objects or the timeout config is silently corrupted (#4837). Those providers therefore feed these kwargs into the SDK's own `DefaultAsyncHttpxClient` and source their values from `_util/http_defaults_httpx2.py` — a mirror of `_util/http_defaults.py` that is identical apart from the module name. Groq, Google under trio and the image fetches stay on httpx.

The duplication is deliberate rather than a shared flavor-agnostic core. httpx v1 is unmaintained and the endstate is a single module, so a copy deletes as a rename while an abstraction built for a second flavor would outlive its reason. Drift is caught by tests rather than review discipline: the module-level tests run against both flavors, and a name added to one and not the other fails `test_both_flavors_export_the_same_names`.

**Providers left untouched are excluded deliberately.** Bedrock, SageMaker and Azure AI have their own connection deadlines already at or above 60s; Google on asyncio passes `aiohttp.ClientTimeout(total=...)` per request, which carries no connect deadline at all (under trio it uses httpx, which is why the settings apply there); and Grok speaks gRPC, establishing connections off the event loop where the block cannot reach it.

**Proxies.** Supplying a transport disables httpx's environment proxy discovery (`allow_env_proxies = trust_env and transport is None`), so the environment's proxy mounts are rebuilt here and given the same settings — otherwise a proxied deployment would silently lose the kernel keepalive probes the SDK client used to carry. `trust_env=False` suppresses the rebuild, matching httpx. httpx's proxy pool takes no `retries`, so the connect retry is genuinely unavailable behind a proxy; the docs say so rather than implying otherwise. httpx also applies `verify`, `cert`, `trust_env`, `http1` and `http2` only to a transport it builds itself, so those are forwarded rather than silently dropped.

**`keepalive_expiry` deliberately stays at httpx's 5s.** Raising it past an intermediary's idle timeout trades these failures for stale-connection ones — but note this leaves the `max_keepalive_connections` raise inert whenever blocks run longer than the expiry, which is the motivating case. A deployment that knows its own topology should raise both together.

### Agent review

- Authored with Claude Opus 5. Reviewed across three rounds, each in a fresh context.
- **Round 1** (pre-#4875 version of this change): five parallel Claude Opus 5 reviewers (type safety, bug hunting, simplification, structure, test quality) plus one independent pass from OpenAI gpt-5.6-sol via Codex. 6 confirmed defects, all fixed: the type-check job was red (the new test file's one annotated helper was the only body mypy checked); a malformed env value replaced a provider's own default with the global one; Anthropic behind a proxy lost the SDK's TCP keepalive options; `-M timeout` on Anthropic bypassed the connect floor; the Google test never ran in CI because no workflow passes `--runtrio`; and one variable was enough to fail a test in a neighbouring file.
- **Round 2** (the httpx2 split): each of six implementation tasks reviewed by a fresh Claude Opus 5 reviewer, then one whole-branch review. Reviewers were asked to mutation-test rather than read — several findings came only from that. 1 Critical: a test intended to pin hook ordering could not fail, proven by two mutations that both left it green; rewritten and re-verified. 1 Important: routing image fetches through the shared client had widened their read budget from 5s to 600s as a side effect; fixed with an explicit 30s budget. 2 Minor fixed (`trust_env` ignored when rebuilding proxy mounts; a near-tautological Google test).
- **Round 3** (cleanup): dropped an unused parameter from 13 flavor-parametrized tests, folded two retry cases into one, and trimmed docstrings and comments that described the investigation rather than the behaviour. Also caught, while verifying an earlier claim, that a full-suite run reported as green had taken its exit code from a trailing `tail` rather than from pytest — it was hiding a real failure in `test_redirect_is_followed`, since fixed.
- **Dismissed with reasons:** `connect=max(client_timeout, connect_timeout())` in `openai_compatible` is inert for real requests — the SDK stamps its own scalar and the event hook corrects it regardless — but it is harmless belt-and-braces and removing it costs more than it buys. Three cosmetic findings (a bare-`httpx` type annotation in a parametrized test, an import-style split, one stale comment) were left.
- Full suite 9686 passed / 0 failed; `mypy --exclude tests/test_package src tests` clean on 1398 files.
