### PR TITLE
fix(eval): record Task(approval=...) policies in the eval log config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Control Channel: `inspect ctl` mutations with piped or captured output now print one outcome line each instead of repeating the full task header (`--terse/--no-terse` to override).
 - Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys.
 - OpenAI: the OpenAI providers and agent bridge now require openai >= 3.0.0, which verifies TLS against the OS trust store instead of certifi's bundle.
+- Approval: policies set with `Task(approval=...)` are now recorded in the eval log's config (previously only policies passed to `eval()` were). (#4881)
 
 ## 0.3.258 (11 August 2026)
 

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -39,6 +39,7 @@ from inspect_ai._display.core.display import CancelType, TaskCancel, TaskSpec
 from inspect_ai._eval.task.scan import Scanners
 from inspect_ai._util.error import PrerequisiteError, exception_message
 from inspect_ai._util.path import chdir
+from inspect_ai.approval._policy import config_from_approval_policies
 from inspect_ai.dataset._dataset import Dataset, Sample
 from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._file import EvalLogInfo
@@ -325,6 +326,18 @@ async def eval_run(
                     task_eval_config.score_on_error = task.score_on_error
                 else:
                     task.score_on_error = task_eval_config.score_on_error
+
+                # approval policies (record the task's policies in the log when
+                # eval() didn't specify any). unlike the fields above there is
+                # no write-back to the task: the policies actually applied are
+                # resolved through the tool approval context var (eval-level
+                # policies from eval_resolve_tasks() take precedence over the
+                # task's in init_task_context()), so the config is a record of
+                # that resolution rather than a second source for it.
+                if task_eval_config.approval is None and task.approval:
+                    task_eval_config.approval = config_from_approval_policies(
+                        task.approval
+                    )
 
                 # merge eval-level and task-level tags
                 merged_tags = list(set(tags or []) | set(task.tags or [])) or None

--- a/tests/approval/test_approval.py
+++ b/tests/approval/test_approval.py
@@ -12,10 +12,11 @@ from inspect_ai.approval import (
     auto_approver,
     read_approval_policies,
 )
+from inspect_ai.approval._policy import config_from_approval_policies
 from inspect_ai.dataset import Sample
 from inspect_ai.event._approval import ApprovalEvent
 from inspect_ai.log._log import EvalLog
-from inspect_ai.model import ChatMessage, ModelOutput, get_model
+from inspect_ai.model import ChatMessage, Model, ModelOutput, get_model
 from inspect_ai.scorer import match
 from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool._tool import tool
@@ -42,27 +43,20 @@ def addition():
     return execute
 
 
-def check_approval(
+def resolve_policy(
     policy: str | ApprovalPolicy | list[ApprovalPolicy] | None,
-    decision: ApprovalDecision,
-    approver: str = "auto",
-    task_policy: str | ApprovalPolicy | list[ApprovalPolicy] | None = None,
-) -> ApprovalEvent:
-    if policy is not None:
-        if isinstance(policy, str):
-            policy = (Path(__file__).parent / policy).as_posix()
+) -> str | list[ApprovalPolicy] | None:
+    if policy is None:
+        return None
 
-        policy = policy if isinstance(policy, list | str) else [policy]
+    if isinstance(policy, str):
+        return (Path(__file__).parent / policy).as_posix()
 
-    if task_policy is not None:
-        if isinstance(task_policy, str):
-            task_policy = (Path(__file__).parent / task_policy).as_posix()
+    return policy if isinstance(policy, list) else [policy]
 
-        task_policy = (
-            task_policy if isinstance(task_policy, list | str) else [task_policy]
-        )
 
-    model = get_model(
+def approval_model() -> Model:
+    return get_model(
         "mockllm/model",
         custom_outputs=[
             ModelOutput.for_tool_call(
@@ -74,14 +68,38 @@ def check_approval(
         ],
     )
 
-    task = Task(
+
+def approval_task(
+    task_policy: str | ApprovalPolicy | list[ApprovalPolicy] | None,
+    name: str | None = None,
+) -> Task:
+    return Task(
+        name=name,
         dataset=[Sample(input="What is 1 + 1?", target="2")],
         solver=[use_tools(addition()), generate()],
         scorer=match(numeric=True),
-        approval=task_policy,
+        approval=resolve_policy(task_policy),
     )
 
-    log = eval(task, model=model, approval=policy)[0]
+
+def run_approval_eval(
+    policy: str | ApprovalPolicy | list[ApprovalPolicy] | None,
+    task_policy: str | ApprovalPolicy | list[ApprovalPolicy] | None = None,
+) -> EvalLog:
+    return eval(
+        approval_task(task_policy),
+        model=approval_model(),
+        approval=resolve_policy(policy),
+    )[0]
+
+
+def check_approval(
+    policy: str | ApprovalPolicy | list[ApprovalPolicy] | None,
+    decision: ApprovalDecision,
+    approver: str = "auto",
+    task_policy: str | ApprovalPolicy | list[ApprovalPolicy] | None = None,
+) -> ApprovalEvent:
+    log = run_approval_eval(policy, task_policy)
 
     approval = find_approval(log)
     assert approval
@@ -147,6 +165,58 @@ def test_approve_no_reject():
 
 def test_approve_config():
     check_approval("approve.yaml", decision="approve")
+
+
+def test_task_approval_recorded_in_eval_config():
+    """Policies from Task(approval=...) are recorded in the log. (#4881)"""
+    log = run_approval_eval(None, task_policy=approve_all_policy)
+
+    assert log.eval.config.approval == config_from_approval_policies(
+        [approve_all_policy]
+    )
+
+
+def test_task_approval_config_file_recorded_in_eval_config():
+    log = run_approval_eval(None, task_policy="approve.yaml")
+
+    assert log.eval.config.approval is not None
+    assert [
+        (approver.name, approver.tools)
+        for approver in log.eval.config.approval.approvers
+    ] == [("auto", "foo*"), ("auto", "*"), ("auto", ["foo*", "add*"])]
+
+
+def test_eval_approval_recorded_over_task_approval():
+    """eval() policies win at runtime, so they are what the log records."""
+    log = run_approval_eval(reject_all_policy, task_policy=approve_all_policy)
+
+    assert log.eval.config.approval == config_from_approval_policies(
+        [reject_all_policy]
+    )
+
+    # the recorded policy is the one that actually ran
+    approval = find_approval(log)
+    assert approval and approval.decision == "reject"
+
+
+def test_no_approval_recorded_when_unspecified():
+    log = run_approval_eval(None)
+
+    assert log.eval.config.approval is None
+
+
+def test_task_approval_not_shared_across_tasks():
+    """One task's policies don't leak into another task's log."""
+    with_policy = approval_task(approve_all_policy, name="with_policy")
+    without_policy = approval_task(None, name="without_policy")
+
+    logs = eval([with_policy, without_policy], model=approval_model())
+
+    recorded = {log.eval.task: log.eval.config.approval for log in logs}
+    assert recorded["with_policy"] == config_from_approval_policies(
+        [approve_all_policy]
+    )
+    assert recorded["without_policy"] is None
 
 
 def test_read_approval_policies_file_uri():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #4881.

### What is the current behavior?

`run.py` broadcasts a task's `epochs`, `message_limit`, `token_limit`, `time_limit`, `fail_on_error` and friends into the per-task eval config; `approval` is not in that list, so `Task(approval=...)` never reaches `EvalSpec.config.approval`. The runtime side is already wired (`init_task_context(..., options.task.approval)`), so this is a recording gap rather than a behavioural one.

On `main` (`3d075c0e`), the same policy object by two routes:

```python
policy = ApprovalPolicy(approver=auto_approver(), tools="*")

eval(Task(..., approval=[policy]), model=model)[0].eval.config.approval
# -> None
eval(Task(...), model=model, approval=[policy])[0].eval.config.approval
# -> approvers=[ApproverPolicyConfig(name='auto', tools='*', params={})]
```

### What is the new behavior?

Both routes record the policy. One block in `_eval/run.py`, next to the other task→config broadcasts:

- record the task's policies only when the eval-level value is `None`, so eval-level keeps winning in the log exactly as it wins at runtime (`init_tool_approval()` from `eval_resolve_tasks()` is already set by the time `init_task_context()` runs, and that only initialises approval `if not have_tool_approval()`);
- guard on truthiness rather than `is not None`, so `approval=[]` records `None` — matching how `eval()`'s own branch treats an empty list;
- no write-back to `task.approval`. The other fields sync both ways because the task object is read again later; the policies actually applied come from the tool-approval context var, so a second source here would only be a place for the two to disagree.

### Does this PR introduce a breaking change?

One behavioural consequence worth your call: `eval_retry` reads `eval_log.eval.config.approval` and passes it as eval-level approval. With this change, retrying a run whose policy came from the task now reproduces the policy that run actually used, instead of whatever the task defines today — the third bullet of the issue. I read "probably fine?" as leaning that way; say the word and I'll scope the change to recording only.

Nothing else changes: no public API, no runtime approval behaviour, and logs that had no task-level policy are byte-identical.

### Other information:

**Tests** — `tests/approval/test_approval.py`. The existing `check_approval` helper was split so a test can get at the log (`resolve_policy` / `approval_model` / `approval_task` / `run_approval_eval`); no existing assertion changed.

- `test_task_approval_recorded_in_eval_config` — the reported case
- `test_task_approval_config_file_recorded_in_eval_config` — `Task(approval="approve.yaml")`, the path/`ApprovalPolicyConfig` form `resolve_approval()` normalises at `Task.__init__`
- `test_eval_approval_recorded_over_task_approval` — both set: eval-level is recorded, and the run's `ApprovalEvent` confirms that is the policy that ran
- `test_no_approval_recorded_when_unspecified` — stays `None`
- `test_task_approval_not_shared_across_tasks` — `eval([task_with_policy, task_without])` records per task (see review below)

Each new assertion was mutant-checked: with the `run.py` block reverted, the three positive tests fail (`assert None == ApprovalPolicyConfig(...)`) and the two guard tests stay green, which is what they are for.

**Checks** — macOS, Python 3.12, `pip install -e .` plus `requirements-dev.txt` (minus `inspect-scout`, whose `libcst` wheel doesn't build on this box — unrelated to this change).

- `pytest tests/approval tests/_eval tests/log tests/test_eval_config.py tests/test_task_with.py` — 1059 passed, 170 skipped, 0 failed
- `ruff check` / `ruff format --check` — clean on both changed files
- `mypy src/inspect_ai/_eval/run.py tests/approval/test_approval.py` — Success

Two honest caveats rather than a clean "make test": I ran the directories above rather than the whole suite, and `tests/scorer` fails 59 tests on this box (57 of them `test_math.py`) because `math_verify` / `latex2sympy2_extended` aren't installed here — `PrerequisiteError` from `math()`, not an assertion. Verified as environment, not this change: the same failures reproduce identically on a clean tree with the diff stashed.

### Agent review

- Reviewer: independent panel in fresh contexts, on different models from the author (Claude Opus 5) — Grok 4.6 and Gemini 3 Pro, one pass each, diff-only context
- Findings: 3 — 1 fixed, 2 dismissed by measurement rather than by argument:
  - **fixed** — `approval=[]` on a task recorded an empty `ApprovalPolicyConfig` while `eval()`'s branch records `None`. The guard is now truthiness; measured after: both routes record `None`.
  - dismissed — "`task_eval_config` is mutated in place, so task 1's policy leaks into task 2's log" (raised independently by both reviewers). `task_eval_config = eval_config.model_copy()` is inside the per-task loop. Measured on a two-task eval: `with_policy` → the policy, `without_policy` → `None`. Worth pinning anyway, so it became `test_task_approval_not_shared_across_tasks`.
  - dismissed — "`config_from_approval_policies()` is called on the raw `str | ApprovalPolicy | list` field". `Task.__init__` runs `resolve_approval()`, so `task.approval` is already `list[ApprovalPolicy]`; the `approve.yaml` test covers that path.

Disclosure: agent-authored (Claude Opus 5, driven by Mycroft, the synthetic co-founder on this account) under Anton's review — every line is one I can explain and defend.
