### PR TITLE
Fix mypy CI failure: unused type ignores in agent bridge tests under google-genai 2.x

### DIFF
--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -598,12 +598,10 @@ def google_agent(tools: bool) -> Agent:
 
             await client.aio.models.generate_content(
                 model="inspect",
-                contents=[  # type: ignore[arg-type]
-                    {
-                        "role": "user",
-                        "parts": [{"text": user_prompt(state.messages).text}],
-                    }
-                ],
+                contents=genai.types.Content(
+                    role="user",
+                    parts=[genai.types.Part(text=user_prompt(state.messages).text)],
+                ),
                 config=genai.types.GenerateContentConfig(
                     tools=tools_param(),
                     tool_config=tool_config,  # type: ignore[arg-type]
@@ -624,12 +622,10 @@ def google_web_search_agent() -> Agent:
 
             await client.aio.models.generate_content(
                 model="inspect",
-                contents=[  # type: ignore[arg-type]
-                    {
-                        "role": "user",
-                        "parts": [{"text": user_prompt(state.messages).text}],
-                    }
-                ],
+                contents=genai.types.Content(
+                    role="user",
+                    parts=[genai.types.Part(text=user_prompt(state.messages).text)],
+                ),
                 config=genai.types.GenerateContentConfig(
                     tools=[{"google_search": {}}],  # type: ignore[list-item]
                 ),
@@ -648,12 +644,10 @@ def google_code_execution_agent() -> Agent:
 
             await client.aio.models.generate_content(
                 model="inspect",
-                contents=[  # type: ignore[arg-type]
-                    {
-                        "role": "user",
-                        "parts": [{"text": user_prompt(state.messages).text}],
-                    }
-                ],
+                contents=genai.types.Content(
+                    role="user",
+                    parts=[genai.types.Part(text=user_prompt(state.messages).text)],
+                ),
                 config=genai.types.GenerateContentConfig(
                     tools=[{"code_execution": {}}],  # type: ignore[list-item]
                 ),
@@ -672,12 +666,10 @@ def google_computer_agent() -> Agent:
 
             await client.aio.models.generate_content(
                 model="inspect",
-                contents=[  # type: ignore[arg-type]
-                    {
-                        "role": "user",
-                        "parts": [{"text": user_prompt(state.messages).text}],
-                    }
-                ],
+                contents=genai.types.Content(
+                    role="user",
+                    parts=[genai.types.Part(text=user_prompt(state.messages).text)],
+                ),
                 config=genai.types.GenerateContentConfig(
                     tools=[{"computerUse": {}}],  # type: ignore[list-item]
                 ),
@@ -696,12 +688,10 @@ def google_streaming_agent() -> Agent:
 
             stream = await client.aio.models.generate_content_stream(
                 model="inspect",
-                contents=[  # type: ignore[arg-type]
-                    {
-                        "role": "user",
-                        "parts": [{"text": user_prompt(state.messages).text}],
-                    }
-                ],
+                contents=genai.types.Content(
+                    role="user",
+                    parts=[genai.types.Part(text=user_prompt(state.messages).text)],
+                ),
             )
             async for _ in stream:
                 pass


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The mypy CI job (which installs latest deps) fails with 5 `unused-ignore` errors in `tests/agent/test_agent_bridge.py`: google-genai 2.x widened the `contents` typing to accept the dict form, making the `# type: ignore[arg-type]` comments unused. Simply deleting the ignores would break mypy under google-genai 1.x (the repo floor is `>=1.69.0`), where the dict form fails `arg-type` and `list[Content]` also fails due to list invariance in the union annotation.

### What is the new behavior?

The 5 call sites pass a single typed `genai.types.Content` as `contents`, which type-checks with no ignores under both google-genai 1.x and 2.x. Verified mypy clean under 1.70.0 and 2.18.1; the non-`--runapi` tests exercising the modified agents pass.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Test-only change, no CHANGELOG entry.

### Agent review
- Author: Claude Fable 5 (Claude Code). Reviewer: Claude Fable 5 in a fresh context (same model as author), 1 pass.
- Findings: 1 info-level, dismissed — `src/inspect_sandbox_tools/tests/agent_bridge/test_model_proxy.py` uses the same dict-form `contents=[{...}]`, but that tree is excluded from mypy so it can't cause this CI failure; fixing it would be an unrelated drive-by. No must-fix issues. Reviewer independently verified semantic equivalence (google-genai's `t_contents` normalizes old and new forms to identical requests) and that mypy/ruff pass.
