### PR TITLE
fix(anthropic): forward a client-supplied fallbacks directive verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
+- Anthropic: A client-supplied `fallbacks` directive is now forwarded to the API verbatim instead of being dropped (skipped on bedrock/vertex/azure, which reject the field).
 
 ## 0.3.262 (02 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Sandbox Tools: Binaries downloaded from S3 that fail SHA256 verification or lack a pinned digest are now rejected instead of run with a warning; `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` has been removed.
 - Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.
 - Docker: Timed commands no longer run an agent-planted timeout executable from the sandbox's PATH with elevated privileges.
+- Anthropic: Client-supplied `fallbacks` directives now reach the API verbatim, except for unsupported batch, Bedrock, Vertex, and Azure requests.
 
 ## 0.3.263 (03 September 2026)
 
@@ -43,7 +44,6 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
-- Anthropic: A client-supplied `fallbacks` directive is now forwarded to the API verbatim instead of being dropped (skipped on bedrock/vertex/azure, which reject the field).
 
 ## 0.3.262 (02 September 2026)
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -317,6 +317,19 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
     for field in anthropic_extra_body_fields():
         if field in json_data:
             extra_body[field] = json_data[field]
+
+    # Forward a client-supplied server-side fallback directive VERBATIM. Claude
+    # Code sends `fallbacks` (plus the matching `server-side-fallback` beta) so
+    # the API can serve a refused request with another model. Dropping it turns
+    # a refusal that production would transparently hand off into a dead turn:
+    # the client sees stop_reason=refusal with an empty completion, retries the
+    # same model, and the sample lands scored-but-empty. We do not reinterpret it
+    # into `fallback_models` -- that would re-serialize to `[{"model": ...}]` and
+    # drop any other field the client sent, and it is subject to Inspect's own
+    # warn-and-ignore gating. The response side records the handoff regardless
+    # (see `serving_model` / `ModelFallback` in the anthropic provider).
+    if (fallbacks := json_data.get("fallbacks")) is not None:
+        extra_body["fallbacks"] = fallbacks
     if len(extra_body) > 0:
         config.extra_body = extra_body
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1144,13 +1144,14 @@ class AnthropicAPI(ModelAPI):
             # this key, so an explicit Inspect-level setting wins; otherwise the
             # client's directive is honoured untouched. The beta is appended here
             # rather than relying on the caller's `anthropic-beta` header, so the
-            # directive cannot be silently ignored by the API. Skipped on
-            # bedrock/vertex/azure, which do not accept the field at all (the same
-            # endpoints `fallback_models` warns about above) -- forwarding it
-            # there would fail the request rather than degrade gracefully.
+            # directive cannot be silently ignored by the API. Skipped on batch
+            # requests and bedrock/vertex/azure, which do not accept the field
+            # (the same conditions `fallback_models` guards above); forwarding
+            # it would fail the request rather than degrade gracefully.
             if (
                 FALLBACKS_FIELD in config.extra_body
                 and FALLBACKS_FIELD not in extra_body
+                and not normalized_batch_config(config.batch)
                 and not (self.is_bedrock() or self.is_vertex() or self.is_azure())
             ):
                 extra_body[FALLBACKS_FIELD] = config.extra_body[FALLBACKS_FIELD]

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1138,6 +1138,24 @@ class AnthropicAPI(ModelAPI):
             # pass through context_management for compaction
             if CONTEXT_MANAGEMENT in config.extra_body:
                 extra_body[CONTEXT_MANAGEMENT] = config.extra_body[CONTEXT_MANAGEMENT]
+            # Pass through a caller-supplied `fallbacks` directive verbatim (the
+            # agent bridge forwards Claude Code's own server-side fallback
+            # request this way). `config.fallback_models` above already wrote
+            # this key, so an explicit Inspect-level setting wins; otherwise the
+            # client's directive is honoured untouched. The beta is appended here
+            # rather than relying on the caller's `anthropic-beta` header, so the
+            # directive cannot be silently ignored by the API. Skipped on
+            # bedrock/vertex/azure, which do not accept the field at all (the same
+            # endpoints `fallback_models` warns about above) -- forwarding it
+            # there would fail the request rather than degrade gracefully.
+            if (
+                FALLBACKS_FIELD in config.extra_body
+                and FALLBACKS_FIELD not in extra_body
+                and not (self.is_bedrock() or self.is_vertex() or self.is_azure())
+            ):
+                extra_body[FALLBACKS_FIELD] = config.extra_body[FALLBACKS_FIELD]
+                if FALLBACK_BETA not in betas:
+                    betas.append(FALLBACK_BETA)
 
         # return config
         return params, extra_body, headers, betas
@@ -4055,6 +4073,9 @@ EXTRA_BODY = "extra_body"
 CONTEXT_MANAGEMENT = "context_management"
 MIN_COMPACTION_TOKENS = 50000  # Anthropic API minimum trigger value
 FALLBACK_BETA = "server-side-fallback-2026-06-01"
+# Request-body field carrying a server-side refusal fallback directive. Routed
+# via extra_body because the SDK only exposes it on client.beta.messages.create.
+FALLBACKS_FIELD = "fallbacks"
 
 
 def _add_edit_compaction(

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -208,6 +208,44 @@ def test_anthropic_adaptive_thinking_effort_forwarded():
     assert config.effort == "high"
 
 
+def test_anthropic_fallbacks_forwarded_verbatim():
+    """A client `fallbacks` directive must survive the bridge untouched.
+
+    Claude Code sends `fallbacks` so the API can serve a safety-refused request
+    with another model. The bridge previously dropped it, so a refusal that
+    production hands off transparently became a dead turn (stop_reason=refusal,
+    empty completion, sample scored 0/0 with no tool calls).
+
+    Forwarded VERBATIM into extra_body -- not reinterpreted into
+    `fallback_models`, which would re-serialize to `[{"model": ...}]` and drop
+    any other field the client sent.
+    """
+    fallbacks = [{"model": "claude-opus-4-8"}]
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 64000,
+        "fallbacks": fallbacks,
+    }
+
+    config = generate_config_from_anthropic(json_data)
+    assert config.extra_body is not None
+    # byte-for-byte the client's structure, not a remapping
+    assert config.extra_body["fallbacks"] == fallbacks
+    # and NOT laundered through Inspect's own knob (which is gated/lossy)
+    assert config.fallback_models is None
+
+    # a fallback directive is not a generation-tuning param, so declining to
+    # forward client generation params must not strip it
+    clear_generation_params(config)
+    assert config.extra_body["fallbacks"] == fallbacks
+
+
+def test_anthropic_no_fallbacks_key_when_client_sends_none():
+    """Absent `fallbacks` must not synthesize the key (no behavior change)."""
+    config = generate_config_from_anthropic({"model": "inspect", "max_tokens": 100})
+    assert config.extra_body is None or "fallbacks" not in config.extra_body
+
+
 def test_google_forward_then_clear():
     generation_config = {
         "temperature": 0.8,

--- a/tests/model/providers/test_anthropic_fallback.py
+++ b/tests/model/providers/test_anthropic_fallback.py
@@ -141,6 +141,18 @@ def test_fallback_ignored_in_batch_mode(monkeypatch: pytest.MonkeyPatch) -> None
     assert any("Batches" in w for w in warnings)
 
 
+def test_client_fallback_ignored_in_batch_mode() -> None:
+    api = AnthropicAPI(model_name=REQUESTED_MODEL, api_key="test-key")
+    config = GenerateConfig(
+        max_tokens=64,
+        batch=True,
+        extra_body={"fallbacks": [{"model": FALLBACK_MODEL}]},
+    )
+    _params, extra_body, _headers, betas = api.completion_config(config)
+    assert "fallbacks" not in extra_body
+    assert FALLBACK_BETA not in betas
+
+
 # ---------------------------------------------------------------------------
 # response side: detection, serving model, metadata, usage
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Continuation of #4674 (moved from the org fork to a personal fork so 'Allow edits by maintainers' can be enabled; prior review history there).

## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

A `fallbacks` directive supplied by the client (the agent bridge forwards Claude Code's server-side fallback request this way, via `extra_body`) is dropped by the Anthropic provider unless an Inspect-level `fallback_models` setting is also configured, so the client's fallback request silently never reaches the API.

### What is the new behavior?

A client-supplied `fallbacks` directive is forwarded to the API verbatim, with the required beta flag appended so the API cannot silently ignore it. For supported non-batch Anthropic requests, an explicit Inspect-level `fallback_models` setting takes precedence. Forwarding is skipped for Anthropic batch requests and bedrock/vertex/azure, which do not support the field. Covered by provider-boundary tests in `tests/model/providers/test_anthropic_fallback.py` and bridge parser tests in `tests/agent/test_bridge_generation_config.py`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Complementary to #4706 (bridge model resolution); no source or test-file overlap.

Rebased onto current upstream `main`; the fix and its tests are unchanged from the original patch (the only conflict was `CHANGELOG.md` placement, resolved by keeping this entry alongside `main`'s current `## Unreleased` list).

### Slow tests

Gated tests covering this PR's Anthropic provider and bridge changes, run locally with `ANTHROPIC_API_KEY` set:

- `pytest --runapi --runslow tests/model/providers/test_anthropic*.py`: 433 passed, 99 skipped (trio variants, run separately below).
- `pytest tests/agent/test_bridge_generation_config.py`: 120 passed, 5 skipped (trio variants, run separately below).
- `pytest tests/agent/test_bridge_generation_config.py --runtrio`: 5 passed, 120 skipped (the non-trio variants already covered above).
- `pytest --runslow --runapi tests/agent/ --ignore=tests/agent/test_agent_human.py`: 1984 passed, 808 skipped (trio variants), 1 failed — `test_sandbox_agent_bridge_media.py::test_sandbox_bridge_cannot_read_host_media`. That test exercises a Docker sandbox media-isolation boundary through `mockllm/model`; it touches no Anthropic or bridge-forwarding code, is unchanged since 2026-06-26, and reproduces identically run standalone, so it is unrelated to this change.
- `pytest --runapi tests/agent/test_agent_human.py` (without `--runslow`): 2 passed, 4 skipped. Could not run: the file's three Docker-backed `test_human_cli[...]` cases and `test_human_cli_submit_no_answer` — each ran well past its own internal 20s completion timeout without finishing container setup, consistent with Docker-daemon contention from concurrent unrelated work on this host. That file covers the human-CLI submission path, which this fix does not touch.
- Not run: live Bedrock/Vertex/Azure Anthropic requests (no credentials configured in this environment). The fix's skip condition for those backends is exercised locally in `test_anthropic_fallback.py`, included above.

### Agent review
- Reviewer: Fable 5 via independent reviewer subagent (fresh context), 1 pass
- Findings: 3, fixed: 3 (missing disclosure, batch-mode raw fallback forwarding, stale file-overlap claim); dismissed: 0

Written by Claude, acting for Sami (@sjawhar).
