### PR TITLE
fix(agent/bridge): preserve Anthropic system block boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Agent Bridge: Bridged Anthropic requests now preserve `system` block boundaries, so instruction blocks are no longer silently discarded by the API.
 - OpenAI: Chat Completions usage now preserves prompt-cache read and write tokens for accurate cache-aware costing.
 - Scoring: `model_graded_qa`/`model_graded_fact` no longer score a malformed multi-character verdict such as `GRADE: CI` as correct; such verdicts now leave the sample unscored with `grade_parse_failure` recorded.
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -140,14 +140,25 @@ async def inspect_anthropic_api_request_impl(
     await validate_bridge_media(bridge, messages)
     debug_log("INSPECT MESSAGES", messages)
 
-    # extract generate config (hoist instructions into system_message)
+    # extract generate config (hoist instructions into system messages)
     config = generate_config_from_anthropic(json_data)
     if not bridge.forward_generation_config:
         clear_generation_params(config)
     config.extra_headers = headers
-    if config.system_message is not None:
-        messages.insert(0, ChatMessageSystem(content=config.system_message))
-        config.system_message = None
+    # Hoist the request's `system` value into leading system messages, ONE PER
+    # ANTHROPIC BLOCK. Block boundaries are load-bearing: the API consumes a
+    # system block whose text begins with an `x-anthropic-*-header:` line as
+    # request metadata, so concatenating blocks can prepend such a header to a
+    # real instruction block and the API then discards the whole block --
+    # silently dropping the instructions. Observed with Claude Code's auto-mode
+    # security classifier, which sends `system` as
+    # [billing-header, monitor-prompt, session-context]: flattened, the 106k-char
+    # prompt billed only 253 input tokens (i.e. never arrived), leaving the
+    # classifier with no instructions and no verdict grammar.
+    system_texts = anthropic_system_to_texts(json_data.get("system"))
+    for offset, system_text in enumerate(system_texts):
+        messages.insert(offset, ChatMessageSystem(content=system_text))
+    config.system_message = None
 
     # try to maintain id stability
     apply_message_ids(bridge, messages)
@@ -193,13 +204,34 @@ def debug_log(caption: str, o: Any) -> None:
 
 def anthropic_system_to_text(value: Any) -> str:
     """Flatten an Anthropic ``system`` value (``str`` or ``list[TextBlockParam]``) to text."""
+    return "\n\n".join(anthropic_system_to_texts(value))
+
+
+def anthropic_system_to_texts(value: Any) -> list[str]:
+    """Split an Anthropic ``system`` value into one text per block.
+
+    ``system`` is either a plain string or a list of ``TextBlockParam``. Callers
+    that turn these into Inspect system messages must preserve one entry per
+    block rather than concatenating: the Anthropic API treats a system block
+    beginning with an ``x-anthropic-*-header:`` line as request metadata and
+    drops that block, so gluing a header block onto an instruction block causes
+    the instructions to be discarded server-side.
+
+    Empty blocks are omitted (they carry no instructions and would otherwise
+    become empty system messages).
+    """
+    if value is None:
+        return []
     if isinstance(value, str):
-        return value
-    return "\n\n".join(
-        str(b.get("text", ""))
-        for b in value
-        if isinstance(b, dict) and b.get("type") == "text"
-    )
+        return [value] if value else []
+    texts: list[str] = []
+    for block in value:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        text = str(block.get("text", ""))
+        if text:
+            texts.append(text)
+    return texts
 
 
 def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -158,7 +158,6 @@ async def inspect_anthropic_api_request_impl(
     system_texts = anthropic_system_to_texts(json_data.get("system"))
     for offset, system_text in enumerate(system_texts):
         messages.insert(offset, ChatMessageSystem(content=system_text))
-    config.system_message = None
 
     # try to maintain id stability
     apply_message_ids(bridge, messages)
@@ -202,11 +201,6 @@ def debug_log(caption: str, o: Any) -> None:
     pass
 
 
-def anthropic_system_to_text(value: Any) -> str:
-    """Flatten an Anthropic ``system`` value (``str`` or ``list[TextBlockParam]``) to text."""
-    return "\n\n".join(anthropic_system_to_texts(value))
-
-
 def anthropic_system_to_texts(value: Any) -> list[str]:
     """Split an Anthropic ``system`` value into one text per block.
 
@@ -238,8 +232,6 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
     config = GenerateConfig()
     config.max_tokens = json_data.get("max_tokens", None)
     config.stop_seqs = json_data.get("stop_sequences", None) or None
-    if (system := json_data.get("system")) is not None:
-        config.system_message = anthropic_system_to_text(system)
     config.temperature = json_data.get("temperature", None)
     config.top_k = json_data.get("top_k", None)
     config.top_p = json_data.get("top_p", None)
@@ -515,8 +507,9 @@ async def messages_from_anthropic_input(
                 flush_pending_user_content()
 
         elif param["role"] == "system":
-            messages.append(
-                ChatMessageSystem(content=anthropic_system_to_text(param["content"]))
+            messages.extend(
+                ChatMessageSystem(content=text)
+                for text in anthropic_system_to_texts(param["content"])
             )
 
         else:

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -7,6 +7,7 @@ from anthropic.types import ThinkingBlockParam
 from inspect_ai._util.content import ContentDocument
 from inspect_ai.agent._bridge.anthropic_api_impl import (
     anthropic_system_to_text,
+    anthropic_system_to_texts,
     base_64_data,
     content_block_to_content,
     messages_from_anthropic_input,
@@ -119,6 +120,50 @@ def test_anthropic_system_to_text() -> None:
         )
         == "a\n\nb"
     )
+
+
+def test_anthropic_system_to_texts_preserves_block_boundaries() -> None:
+    """Blocks stay separate so a header block can't be glued to instructions."""
+    assert anthropic_system_to_texts(None) == []
+    assert anthropic_system_to_texts("") == []
+    assert anthropic_system_to_texts("plain") == ["plain"]
+    assert anthropic_system_to_texts(
+        [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+    ) == ["a", "b"]
+    # empty blocks contribute no system message
+    assert anthropic_system_to_texts(
+        [{"type": "text", "text": "a"}, {"type": "text", "text": ""}]
+    ) == ["a"]
+    # non-text blocks are ignored
+    assert anthropic_system_to_texts(
+        [{"type": "image"}, {"type": "text", "text": "a"}]
+    ) == ["a"]
+
+
+def test_anthropic_system_header_block_not_glued_to_instructions() -> None:
+    """Regression: a metadata header block must not absorb the real prompt.
+
+    Claude Code's auto-mode classifier sends ``system`` as
+    ``[billing-header, monitor-prompt, session-context]``. The Anthropic API
+    consumes a system block starting with ``x-anthropic-*-header:`` as request
+    metadata and DROPS that block, so concatenating the blocks made the API
+    discard the monitor prompt too -- the classifier then had no instructions
+    and no verdict grammar, and fail-closed on every action.
+    """
+    header = "x-anthropic-billing-header: cc_version=2.1.205; cc_entrypoint=sdk-cli;"
+    prompt = "You are a security monitor for autonomous AI coding agents."
+    context = "## Session Context"
+    texts = anthropic_system_to_texts(
+        [
+            {"type": "text", "text": header},
+            {"type": "text", "text": prompt},
+            {"type": "text", "text": context},
+        ]
+    )
+    assert texts == [header, prompt, context]
+    # the header must stand alone: nothing else may ride along in its block
+    assert texts[0] == header
+    assert prompt not in texts[0]
 
 
 @pytest.mark.anyio

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -189,3 +189,94 @@ def test_base_64_data_error_includes_value() -> None:
         base_64_data(Path("/tmp/image.png"))
     assert "/tmp/image.png" in str(exc_info.value)
     assert "{data}" not in str(exc_info.value)
+
+
+# --- impl-level: request `system` becomes leading system messages ------------
+
+
+class _CapturedMessages(Exception):
+    """Sentinel carrying the messages the impl handed to generation."""
+
+    def __init__(self, messages: list[Any]) -> None:
+        self.messages = messages
+
+
+async def _request_impl_messages(
+    monkeypatch: pytest.MonkeyPatch, json_data: dict[str, Any]
+) -> list[Any]:
+    """Run inspect_anthropic_api_request_impl and capture its inspect messages."""
+    import inspect_ai.agent._bridge.anthropic_api_impl as impl
+    from inspect_ai.agent._agent import AgentState
+    from inspect_ai.agent._bridge.types import AgentBridge
+
+    async def capture(bridge: Any, model: Any, messages: Any, *args: Any) -> Any:
+        raise _CapturedMessages(messages)
+
+    monkeypatch.setattr(impl, "bridge_generate", capture)
+    bridge = AgentBridge(state=AgentState(messages=[]))
+    with pytest.raises(_CapturedMessages) as exc_info:
+        await impl.inspect_anthropic_api_request_impl(
+            {
+                "model": "mockllm/model",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "hello"}],
+                **json_data,
+            },
+            headers=None,
+            web_search=None,
+            code_execution=None,
+            bridge=bridge,
+        )
+    return exc_info.value.messages
+
+
+@pytest.mark.anyio
+async def test_request_impl_no_system(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages = await _request_impl_messages(monkeypatch, {})
+    assert [type(m) for m in messages] == [ChatMessageUser]
+
+
+@pytest.mark.anyio
+async def test_request_impl_string_system(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages = await _request_impl_messages(monkeypatch, {"system": "be helpful"})
+    assert [type(m) for m in messages] == [ChatMessageSystem, ChatMessageUser]
+    assert messages[0].text == "be helpful"
+
+
+@pytest.mark.anyio
+async def test_request_impl_single_block_system(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = await _request_impl_messages(
+        monkeypatch, {"system": [{"type": "text", "text": "be helpful"}]}
+    )
+    assert [type(m) for m in messages] == [ChatMessageSystem, ChatMessageUser]
+    assert messages[0].text == "be helpful"
+
+
+@pytest.mark.anyio
+async def test_request_impl_multi_block_system_preserves_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One leading system message per Anthropic system block, in order."""
+    messages = await _request_impl_messages(
+        monkeypatch,
+        {
+            "system": [
+                {"type": "text", "text": "x-anthropic-billing-header: abc"},
+                {"type": "text", "text": "you are a security classifier"},
+                {"type": "text", "text": "session context"},
+            ]
+        },
+    )
+    assert [type(m) for m in messages] == [
+        ChatMessageSystem,
+        ChatMessageSystem,
+        ChatMessageSystem,
+        ChatMessageUser,
+    ]
+    assert [m.text for m in messages[:3]] == [
+        "x-anthropic-billing-header: abc",
+        "you are a security classifier",
+        "session context",
+    ]

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -6,7 +6,6 @@ from anthropic.types import ThinkingBlockParam
 
 from inspect_ai._util.content import ContentDocument
 from inspect_ai.agent._bridge.anthropic_api_impl import (
-    anthropic_system_to_text,
     anthropic_system_to_texts,
     base_64_data,
     content_block_to_content,
@@ -55,6 +54,31 @@ async def test_inline_system_role_block_content() -> None:
     )
     assert isinstance(messages[1], ChatMessageSystem)
     assert messages[1].text == "reminder"
+
+
+@pytest.mark.anyio
+async def test_inline_system_role_multi_block_content() -> None:
+    """A role="system" turn with multiple blocks keeps one message per block."""
+    messages = await messages_from_anthropic_input(
+        [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "x-anthropic-billing-header: abc"},
+                    {"type": "text", "text": "instructions"},
+                ],
+            },
+        ],
+        tools=[],
+    )
+    assert [type(m) for m in messages] == [
+        ChatMessageUser,
+        ChatMessageSystem,
+        ChatMessageSystem,
+    ]
+    assert messages[1].text == "x-anthropic-billing-header: abc"
+    assert messages[2].text == "instructions"
 
 
 @pytest.mark.anyio
@@ -110,16 +134,6 @@ def test_browser_state_block_raises() -> None:
         RuntimeError, match="Unsupported content block type: browser_state"
     ):
         content_block_to_content(cast(Any, {"type": "browser_state"}))
-
-
-def test_anthropic_system_to_text() -> None:
-    assert anthropic_system_to_text("plain") == "plain"
-    assert (
-        anthropic_system_to_text(
-            [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
-        )
-        == "a\n\nb"
-    )
 
 
 def test_anthropic_system_to_texts_preserves_block_boundaries() -> None:

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -167,7 +167,10 @@ def test_anthropic_forward_then_clear():
     # reasoning_tokens and effort specifically must be among the cleared fields
     assert config.reasoning_tokens is None
     assert config.effort is None
-    assert config.system_message == "You are a dope model."
+    # `system` no longer flows through GenerateConfig: it is hoisted into
+    # leading ChatMessageSystem messages (one per block) by the request impl
+    # (see the impl-level tests in test_bridge_anthropic_messages.py)
+    assert config.system_message is None
     assert config.stop_seqs == ["foo"]
     assert config.parallel_tool_calls is False
 


### PR DESCRIPTION
Continuation of #4669 (moved from the org fork to a personal fork so 'Allow edits by maintainers' can be enabled; prior review history there).

## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

The agent bridge flattens a multi-block Anthropic `system` value into a single system message. The Anthropic API consumes a system block whose text begins with an `x-anthropic-*-header:` line as request metadata and discards that block, so concatenating a header block onto an instruction block causes the instructions to be silently dropped server-side. Observed with Claude Code's auto-mode security classifier: its 106k-character monitor prompt billed only 253 input tokens (it never reached the model), leaving the classifier with no instructions.

### What is the new behavior?

The `system` value is hoisted into one Inspect system message per Anthropic block, preserving block boundaries end to end. Includes regression tests for boundary preservation and the header-block case.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Written by Claude, acting for Sami (@sjawhar).
