### PR TITLE
feat(human): let human_cli customize its command list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Human Agent: Sandbox installation of the `task` CLI now refuses a pre-planted or non-root-owned `/opt/human_agent`, errors instead of silently skipping when it cannot be created, and no longer runs a staged install script.
 - Human Agent: The `task` shell hook is now appended to the login user's `.bashrc` as that user, so a `.bashrc` that user cannot write (e.g. root-owned) or that is a symlink fails installation instead of being written by the sandbox default user (root in most images).
 - Human Agent: `human_cli()` now accepts a `commands_filter` option for tailoring the commands available in the human agent CLI.
+- Human Agent: Generated command handlers now support `@override` decorators.
 - Bugfix: MockLLM callable `custom_outputs` now populate default token usage when the returned `ModelOutput` omits `usage`, matching iterable/generator behavior.
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Eval Log: Reading zstd-compressed `.eval` files no longer fails with `AttributeError: ... '_needs_input'` on Python builds that include CPython's gh-156002 zipfile change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Eval Set: Tasks that set a non-mean epochs reducer now reuse their completed log on subsequent `eval_set()` calls instead of being re-run every time.
 - Human Agent: Sandbox installation of the `task` CLI now refuses a pre-planted or non-root-owned `/opt/human_agent`, errors instead of silently skipping when it cannot be created, and no longer runs a staged install script.
 - Human Agent: The `task` shell hook is now appended to the login user's `.bashrc` as that user, so a `.bashrc` that user cannot write (e.g. root-owned) or that is a symlink fails installation instead of being written by the sandbox default user (root in most images).
+- Human Agent: `human_cli()` now accepts a `commands_filter` option for tailoring the commands available in the human agent CLI.
 - Bugfix: MockLLM callable `custom_outputs` now populate default token usage when the returned `ModelOutput` omits `usage`, matching iterable/generator behavior.
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Eval Log: Reading zstd-compressed `.eval` files no longer fails with `AttributeError: ... '_needs_input'` on Python builds that include CPython's gh-156002 zipfile change.
@@ -47,7 +48,6 @@
 - OpenAI: Fixed `temperature`, `top_p`, and `logprobs` causing a 400 error on GPT-5.5+ models when no `reasoning_effort` is set (they are now dropped with a warning).
 - Grok: Oversized prompts now return `stop_reason="model_length"` instead of failing with a generation error under xAI's current context-overflow wording.
 - Eval Log: Sample summaries now keep `Score.reason`, so an explicit reason is no longer dropped (and a stale `metadata["unscored_reason"]` cannot replace it).
-- Human Agent: `human_cli()` now accepts a `commands_filter` option for tailoring the commands available in the human agent CLI.
 - Agent bridge: A Chat Completions response truncated by the output-token limit now reports `finish_reason="length"` instead of `"stop"`.
 - Google: Batched evaluations with a system message now serialize `system_instruction` as REST `Content` instead of a bare JSON array, fixing batch submission failures; batch results are now parsed through the SDK converter so unknown REST fields (e.g. `usageMetadata.serviceTier`) no longer fail the whole batch. (#5100)
 - Google/Gemini: Faster client setup under high sandbox concurrency, with custom CA bundles now preserved on both sync and async requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - OpenAI: Fixed `temperature`, `top_p`, and `logprobs` causing a 400 error on GPT-5.5+ models when no `reasoning_effort` is set (they are now dropped with a warning).
 - Grok: Oversized prompts now return `stop_reason="model_length"` instead of failing with a generation error under xAI's current context-overflow wording.
 - Eval Log: Sample summaries now keep `Score.reason`, so an explicit reason is no longer dropped (and a stale `metadata["unscored_reason"]` cannot replace it).
+- Human Agent: `human_cli()` now accepts a `commands_filter` option for tailoring the commands available in the human agent CLI.
 - Agent bridge: A Chat Completions response truncated by the output-token limit now reports `finish_reason="length"` instead of `"stop"`.
 - Google: Batched evaluations with a system message now serialize `system_instruction` as REST `Content` instead of a bare JSON array, fixing batch submission failures; batch results are now parsed through the SDK converter so unknown REST fields (e.g. `usageMetadata.serviceTier`) no longer fail the whole batch. (#5100)
 - Google/Gemini: Faster client setup under high sandbox concurrency, with custom CA bundles now preserved on both sync and async requests.

--- a/docs/reference/inspect_ai.agent.qmd
+++ b/docs/reference/inspect_ai.agent.qmd
@@ -59,6 +59,8 @@ description: Agent scaffolds and protocol.
 ### AgentAttempts
 ### AgentContinue
 ### AgentSubmit
+### HumanAgentCommand
+### HumanAgentCommandsFilter
 
 ## Deprecated
 

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -16,6 +16,7 @@ from ._deepagent import Subagent, deepagent, general, plan, research, subagent
 from ._filter import MessageFilter, content_only, last_message, remove_tools
 from ._handoff import handoff
 from ._human.agent import human_cli
+from ._human.commands.command import HumanAgentCommand, HumanAgentCommandsFilter
 from ._react import react
 from ._run import run
 from ._types import (
@@ -29,6 +30,8 @@ __all__ = [
     "react",
     "bridge",
     "human_cli",
+    "HumanAgentCommand",
+    "HumanAgentCommandsFilter",
     "run",
     "handoff",
     "as_tool",

--- a/src/inspect_ai/agent/_human/agent.py
+++ b/src/inspect_ai/agent/_human/agent.py
@@ -7,6 +7,7 @@ from inspect_ai.util._sandbox.events import SandboxEnvironmentProxy
 
 from .._agent import Agent, AgentState, agent
 from .commands import human_agent_commands
+from .commands.command import HumanAgentCommandsFilter
 from .install import install_human_agent
 from .panel import HumanAgentPanel
 from .service import run_human_agent_service
@@ -21,6 +22,7 @@ def human_cli(
     user: str | None = None,
     instructions: str | None = None,
     bashrc: str | None = None,
+    commands_filter: HumanAgentCommandsFilter | None = None,
 ) -> Agent:
     """Human CLI agent for tasks that run in a sandbox.
 
@@ -43,6 +45,10 @@ def human_cli(
        user: User to login as. Defaults to the sandbox environment's default user.
        instructions: Additional instructions beyond the default task command instructions.
        bashrc: Additional content to include in the .bashrc file for the human cli shell.
+       commands_filter: Optional transform applied to the default command
+          list before it is installed (and before the instructions command is
+          built, so `task instructions` lists any added commands). Lets a caller
+          swap or append `HumanAgentCommand`s without forking this function.
 
     Returns:
        Agent: Human CLI agent.
@@ -73,6 +79,7 @@ def human_cli(
                         intermediate_scoring,
                         record_session,
                         instructions,
+                        commands_filter,
                     )
 
                     # install agent tools

--- a/src/inspect_ai/agent/_human/agent.py
+++ b/src/inspect_ai/agent/_human/agent.py
@@ -49,6 +49,10 @@ def human_cli(
           list before it is installed (and before the instructions command is
           built, so `task instructions` lists any added commands). Lets a caller
           swap or append `HumanAgentCommand`s without forking this function.
+          The filtered list must still include a command named `"start"`
+          (`raises ValueError` otherwise): the login shell unconditionally
+          runs `task start` to begin the task clock, and submission refuses
+          to complete while it never has.
 
     Returns:
        Agent: Human CLI agent.

--- a/src/inspect_ai/agent/_human/agent.py
+++ b/src/inspect_ai/agent/_human/agent.py
@@ -50,9 +50,10 @@ def human_cli(
           built, so `task instructions` lists any added commands). Lets a caller
           swap or append `HumanAgentCommand`s without forking this function.
           The filtered list must still include a command named `"start"`
-          (`raises ValueError` otherwise): the login shell unconditionally
-          runs `task start` to begin the task clock, and submission refuses
-          to complete while it never has.
+          with both `"cli"` and `"service"` in its `contexts` (`raises
+          ValueError` otherwise): the login shell unconditionally runs
+          `task start` to begin the task clock over the sandbox service
+          RPC, and submission refuses to complete while it never has.
 
     Returns:
        Agent: Human CLI agent.

--- a/src/inspect_ai/agent/_human/commands/__init__.py
+++ b/src/inspect_ai/agent/_human/commands/__init__.py
@@ -1,6 +1,6 @@
 from ..._agent import AgentState
 from .clock import StartCommand, StopCommand
-from .command import HumanAgentCommand
+from .command import HumanAgentCommand, HumanAgentCommandsFilter
 from .instructions import InstructionsCommand
 from .note import NoteCommand
 from .score import ScoreCommand
@@ -14,6 +14,7 @@ def human_agent_commands(
     intermediate_scoring: bool,
     record_session: bool,
     instructions: str | None,
+    commands_filter: HumanAgentCommandsFilter | None = None,
 ) -> list[HumanAgentCommand]:
     # base submit, validate, and quit
     commands = [
@@ -35,6 +36,10 @@ def human_agent_commands(
             StopCommand(),
         ]
     )
+
+    # let the caller swap/append commands before instructions is built
+    if commands_filter is not None:
+        commands = commands_filter(commands)
 
     # with instructions (letting it see the other commands)
     return commands + [InstructionsCommand(commands, instructions)]

--- a/src/inspect_ai/agent/_human/commands/__init__.py
+++ b/src/inspect_ai/agent/_human/commands/__init__.py
@@ -40,6 +40,17 @@ def human_agent_commands(
     # let the caller swap/append commands before instructions is built
     if commands_filter is not None:
         commands = commands_filter(commands)
+        if not any(command.name == "start" for command in commands):
+            raise ValueError(
+                "commands_filter removed the 'start' command: the human "
+                "agent's login shell unconditionally runs `task start` to "
+                "begin the task clock, and `task submit`/`task validate` "
+                "refuse to complete while the clock has never started, so a "
+                "command list without one named 'start' leaves the task "
+                "permanently stuck. Retain a command named 'start' (a "
+                "subclass of StartCommand, or your own with equivalent "
+                "clock-start semantics)."
+            )
 
     # with instructions (letting it see the other commands)
     return commands + [InstructionsCommand(commands, instructions)]

--- a/src/inspect_ai/agent/_human/commands/__init__.py
+++ b/src/inspect_ai/agent/_human/commands/__init__.py
@@ -40,16 +40,22 @@ def human_agent_commands(
     # let the caller swap/append commands before instructions is built
     if commands_filter is not None:
         commands = commands_filter(commands)
-        if not any(command.name == "start" for command in commands):
+        if not any(
+            command.name == "start" and "cli" in command.contexts
+            for command in commands
+        ):
             raise ValueError(
-                "commands_filter removed the 'start' command: the human "
-                "agent's login shell unconditionally runs `task start` to "
-                "begin the task clock, and `task submit`/`task validate` "
-                "refuse to complete while the clock has never started, so a "
-                "command list without one named 'start' leaves the task "
-                "permanently stuck. Retain a command named 'start' (a "
-                "subclass of StartCommand, or your own with equivalent "
-                "clock-start semantics)."
+                "commands_filter removed the 'start' command (or left it "
+                "without 'cli' in its contexts): the human agent's login "
+                "shell unconditionally runs `task start` to begin the task "
+                "clock, and that only reaches the CLI dispatch installed in "
+                "`task.py` (built from commands with 'cli' in `contexts`) -- "
+                "`task submit`/`task validate` refuse to complete while the "
+                "clock has never started, so a command list without a "
+                "CLI-installed 'start' command leaves the task permanently "
+                "stuck. Retain a command named 'start' with 'cli' in its "
+                "contexts (a subclass of StartCommand, or your own with "
+                "equivalent clock-start semantics)."
             )
 
     # with instructions (letting it see the other commands)

--- a/src/inspect_ai/agent/_human/commands/__init__.py
+++ b/src/inspect_ai/agent/_human/commands/__init__.py
@@ -41,21 +41,27 @@ def human_agent_commands(
     if commands_filter is not None:
         commands = commands_filter(commands)
         if not any(
-            command.name == "start" and "cli" in command.contexts
+            command.name == "start"
+            and "cli" in command.contexts
+            and "service" in command.contexts
             for command in commands
         ):
             raise ValueError(
                 "commands_filter removed the 'start' command (or left it "
-                "without 'cli' in its contexts): the human agent's login "
-                "shell unconditionally runs `task start` to begin the task "
-                "clock, and that only reaches the CLI dispatch installed in "
-                "`task.py` (built from commands with 'cli' in `contexts`) -- "
-                "`task submit`/`task validate` refuse to complete while the "
-                "clock has never started, so a command list without a "
-                "CLI-installed 'start' command leaves the task permanently "
-                "stuck. Retain a command named 'start' with 'cli' in its "
-                "contexts (a subclass of StartCommand, or your own with "
-                "equivalent clock-start semantics)."
+                "without both 'cli' and 'service' in its contexts): the "
+                "human agent's login shell unconditionally runs `task "
+                "start` to begin the task clock, which reaches the CLI "
+                "dispatch installed in `task.py` (built from commands with "
+                "'cli' in `contexts`) and calls it over the sandbox service "
+                "RPC handled by `run_human_agent_service` (built from "
+                "commands with 'service' in `contexts`) -- a 'start' "
+                "missing either context leaves that call unable to flip "
+                "`HumanAgentState.running`, and `task submit`/`task "
+                "validate` refuse to complete while the clock has never "
+                "started, so the task is permanently stuck. Retain a "
+                "command named 'start' with both 'cli' and 'service' in "
+                "its contexts (a subclass of StartCommand, or your own "
+                "with equivalent clock-start semantics)."
             )
 
     # with instructions (letting it see the other commands)

--- a/src/inspect_ai/agent/_human/commands/command.py
+++ b/src/inspect_ai/agent/_human/commands/command.py
@@ -49,6 +49,17 @@ class HumanAgentCommand(abc.ABC):
         """Positional command line arguments."""
         return []
 
+    @property
+    def cli_state(self) -> dict[str, JsonValue]:
+        """State serialized into the sandbox for `cli`.
+
+        `cli` runs in a generated sandbox script, so it receives a
+        `Namespace` whose attributes are the JSON values returned here rather
+        than this command instance. Override this property when `cli` needs
+        command state.
+        """
+        return {}
+
     def cli(self, args: Namespace) -> None:
         """CLI command (runs in container). Required for context "cli"."""
         pass

--- a/src/inspect_ai/agent/_human/commands/command.py
+++ b/src/inspect_ai/agent/_human/commands/command.py
@@ -7,7 +7,9 @@ from pydantic import JsonValue
 from ..state import HumanAgentState
 
 
-class HumanAgentCommand:
+class HumanAgentCommand(abc.ABC):
+    """A command exposed by the human CLI agent -- implementable as a `task <name>` CLI subcommand, a service-side RPC handler, or both (see `contexts`)."""
+
     @property
     @abc.abstractmethod
     def name(self) -> str:
@@ -22,6 +24,7 @@ class HumanAgentCommand:
 
     @property
     def group(self) -> Literal[1, 2, 3]:
+        """Display group in `task instructions` (1 and 2 are separated by a blank line from what follows; 3 is last, with no trailing separator)."""
         return 1
 
     @property
@@ -30,9 +33,16 @@ class HumanAgentCommand:
         return ["cli", "service"]
 
     class CLIArg(NamedTuple):
+        """A positional argument accepted by this command's CLI invocation."""
+
         name: str
+        """Argument name, as displayed in help text."""
+
         description: str
+        """Argument description, as displayed in help text."""
+
         required: bool = False
+        """Whether the argument must be provided."""
 
     @property
     def cli_args(self) -> list[CLIArg]:
@@ -57,3 +67,9 @@ class HumanAgentCommand:
 
 def call_human_agent(method: str, **params: Any) -> Any:
     return None
+
+
+HumanAgentCommandsFilter = Callable[[list[HumanAgentCommand]], list[HumanAgentCommand]]
+"""Filter applied to the human CLI agent's command list before it is installed
+(and before the instructions command is built, so `task instructions` reflects
+the result)."""

--- a/src/inspect_ai/agent/_human/install.py
+++ b/src/inspect_ai/agent/_human/install.py
@@ -34,6 +34,7 @@ the fallback may itself be running as root.
 """
 
 import inspect
+import json
 import stat
 from textwrap import dedent
 
@@ -259,6 +260,7 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
     # standard imports (including any dependencies that call methods carry)
     imports = dedent("""
     import argparse
+    import json
     import sys
     from argparse import Namespace
     from pathlib import Path
@@ -272,12 +274,9 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
         return f"{hours:.0f}:{minutes:02.0f}:{seconds:02.0f}"
     """)
 
-    # command handler source code (extracted from call methods)
+    # command handler source code and state (extracted from call methods)
     command_handlers = "\n\n".join(
-        dedent(
-            inspect.getsource(command.cli).replace("cli(self, ", f"{command.name}(", 1)
-        )
-        for command in commands
+        human_agent_command_handler(command) for command in commands
     )
 
     # parse commands
@@ -324,6 +323,20 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
     """) + "\n".join(command_dispatchers)
 
     return "\n".join([imports, command_handlers, parse, dispatch]) + "\n"
+
+
+def human_agent_command_handler(command: HumanAgentCommand) -> str:
+    name = command.name
+    handler = dedent(
+        inspect.getsource(command.cli).replace("cli(self, ", f"_{name}_cli(self, ", 1)
+    )
+    state = repr(json.dumps(command.cli_state))
+    return (
+        f"{handler}\n"
+        f"_{name}_state = Namespace(**json.loads({state}))\n"
+        f"def {name}(args):\n"
+        f"    _{name}_cli(_{name}_state, args)"
+    )
 
 
 def human_agent_bashrc(

--- a/src/inspect_ai/agent/_human/install.py
+++ b/src/inspect_ai/agent/_human/install.py
@@ -33,6 +33,7 @@ refused even here: no earlier release left a rootless installation to repair, an
 the fallback may itself be running as root.
 """
 
+import ast
 import inspect
 import json
 import stat
@@ -253,6 +254,38 @@ async def append_bashrc(
         )
 
 
+def _strip_type_only_override_decorators(source: str) -> str:
+    """Remove ``@override`` decorators from copied standalone handler source."""
+    handler = ast.parse(source).body[0]
+    if not isinstance(handler, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        raise ValueError("Expected a command handler function")
+
+    line_offsets = [0]
+    for line in source.splitlines(keepends=True):
+        line_offsets.append(line_offsets[-1] + len(line))
+
+    decorator_ranges: list[tuple[int, int]] = []
+    for decorator in handler.decorator_list:
+        if isinstance(decorator, ast.Name) and decorator.id == "override":
+            if decorator.end_lineno is None or decorator.end_col_offset is None:
+                raise ValueError("Override decorator has no source range")
+            line_start = line_offsets[decorator.lineno - 1]
+            decorator_start = source.rfind(
+                "@", line_start, line_start + decorator.col_offset
+            )
+            if decorator_start == -1:
+                raise ValueError("Could not find override decorator source")
+            decorator_end = (
+                line_offsets[decorator.end_lineno - 1] + decorator.end_col_offset
+            )
+            decorator_ranges.append((decorator_start, decorator_end))
+
+    for decorator_start, decorator_end in reversed(decorator_ranges):
+        source = source[:decorator_start] + source[decorator_end:]
+
+    return source
+
+
 def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
     # filter out hidden commands
     commands = [command for command in commands if "cli" in command.contexts]
@@ -327,8 +360,12 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
 
 def human_agent_command_handler(command: HumanAgentCommand) -> str:
     name = command.name
-    handler = dedent(
-        inspect.getsource(command.cli).replace("cli(self, ", f"_{name}_cli(self, ", 1)
+    handler = _strip_type_only_override_decorators(
+        dedent(
+            inspect.getsource(command.cli).replace(
+                "cli(self, ", f"_{name}_cli(self, ", 1
+            )
+        )
     )
     state = repr(json.dumps(command.cli_state))
     return (

--- a/src/inspect_ai/agent/_human/install.py
+++ b/src/inspect_ai/agent/_human/install.py
@@ -37,6 +37,7 @@ import ast
 import inspect
 import json
 import stat
+from pathlib import Path
 from textwrap import dedent
 
 from inspect_ai.util import SandboxEnvironment, sandbox
@@ -254,36 +255,33 @@ async def append_bashrc(
         )
 
 
-def _strip_type_only_override_decorators(source: str) -> str:
-    """Remove ``@override`` decorators from copied standalone handler source."""
-    handler = ast.parse(source).body[0]
-    if not isinstance(handler, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        raise ValueError("Expected a command handler function")
-
-    line_offsets = [0]
-    for line in source.splitlines(keepends=True):
-        line_offsets.append(line_offsets[-1] + len(line))
-
-    decorator_ranges: list[tuple[int, int]] = []
-    for decorator in handler.decorator_list:
-        if isinstance(decorator, ast.Name) and decorator.id == "override":
-            if decorator.end_lineno is None or decorator.end_col_offset is None:
-                raise ValueError("Override decorator has no source range")
-            line_start = line_offsets[decorator.lineno - 1]
-            decorator_start = source.rfind(
-                "@", line_start, line_start + decorator.col_offset
+def _human_agent_command_handler_source(command: HumanAgentCommand) -> str:
+    """Render the bound CLI method structurally from its defining source file."""
+    handler = getattr(command.cli, "__func__", command.cli)
+    source_file = inspect.getsourcefile(handler)
+    if source_file is None:
+        raise ValueError("Could not find command handler source file")
+    tree = ast.parse(Path(source_file).read_text(encoding="utf-8"))
+    handler_line = handler.__code__.co_firstlineno
+    handler_node = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == handler.__name__
+            and min(
+                (decorator.lineno for decorator in node.decorator_list),
+                default=node.lineno,
             )
-            if decorator_start == -1:
-                raise ValueError("Could not find override decorator source")
-            decorator_end = (
-                line_offsets[decorator.end_lineno - 1] + decorator.end_col_offset
-            )
-            decorator_ranges.append((decorator_start, decorator_end))
+            == handler_line
+        ),
+        None,
+    )
+    if handler_node is None:
+        raise ValueError("Could not find command handler definition")
 
-    for decorator_start, decorator_end in reversed(decorator_ranges):
-        source = source[:decorator_start] + source[decorator_end:]
-
-    return source
+    handler_node.name = f"_{command.name}_cli"
+    return ast.unparse(handler_node)
 
 
 def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
@@ -295,8 +293,29 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
     import argparse
     import json
     import sys
+    import types
+    import typing
     from argparse import Namespace
     from pathlib import Path
+
+    try:
+        import typing_extensions
+    except ImportError:
+        typing_extensions = None
+
+    try:
+        from typing_extensions import override
+    except ImportError:
+        try:
+            from typing import override
+        except ImportError:
+            def override(function):
+                return function
+
+    if not hasattr(typing, "override"):
+        typing.override = override
+    if typing_extensions is None:
+        typing_extensions = types.SimpleNamespace(override=override)
 
     sys.path.append("/var/tmp/sandbox-services/human_agent")
     from human_agent import call_human_agent
@@ -360,13 +379,7 @@ def human_agent_commands(commands: list[HumanAgentCommand]) -> str:
 
 def human_agent_command_handler(command: HumanAgentCommand) -> str:
     name = command.name
-    handler = _strip_type_only_override_decorators(
-        dedent(
-            inspect.getsource(command.cli).replace(
-                "cli(self, ", f"_{name}_cli(self, ", 1
-            )
-        )
-    )
+    handler = _human_agent_command_handler_source(command)
     state = repr(json.dumps(command.cli_state))
     return (
         f"{handler}\n"

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -19,11 +19,17 @@ from test_helpers.sandbox import CannedSandbox
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import Task, eval
+from inspect_ai.agent import (
+    AgentState,
+    HumanAgentCommand,
+    HumanAgentCommandsFilter,
+    human_cli,
+)
 from inspect_ai.agent._human import install as human_install
-from inspect_ai.agent._human.agent import human_cli
-from inspect_ai.agent._human.commands import submit
-from inspect_ai.agent._human.commands.command import HumanAgentCommand
+from inspect_ai.agent._human.commands import human_agent_commands, submit
+from inspect_ai.agent._human.commands.instructions import InstructionsCommand
 from inspect_ai.agent._human.commands.submit import QuitCommand, SubmitCommand
+from inspect_ai.agent._human.state import HumanAgentState
 from inspect_ai.agent._human.install import (
     _BASHRC_APPEND_SCRIPT,
     BASHRC,
@@ -84,6 +90,59 @@ def test_session_end_commands_decline_on_eof(
     command.cli(args)
 
     assert calls == expected_calls
+
+
+class _AdditionalCommand(HumanAgentCommand):
+    @property
+    def name(self) -> str:
+        return "additional"
+
+    @property
+    def description(self) -> str:
+        return "Additional test command."
+
+
+def test_human_cli_accepts_public_commands_filter():
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [*commands, _AdditionalCommand()]
+
+    filter_: HumanAgentCommandsFilter = commands_filter
+
+    assert callable(human_cli(commands_filter=filter_))
+
+
+async def test_human_cli_commands_filter_seen_by_instructions() -> None:
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [*commands, _AdditionalCommand()]
+
+    commands = human_agent_commands(
+        AgentState(messages=[]),
+        answer=True,
+        intermediate_scoring=False,
+        record_session=False,
+        instructions=None,
+        commands_filter=commands_filter,
+    )
+
+    # The filter's appended command is in the built list, ahead of the
+    # instructions command that the filter must run before.
+    names = [command.name for command in commands]
+    assert names.index("additional") < names.index("instructions")
+
+    # The instructions command itself was built from the filtered list, so
+    # `task instructions` renders the added command.
+    instructions_command = commands[-1]
+    assert isinstance(instructions_command, InstructionsCommand)
+    rendered = await instructions_command.service(
+        HumanAgentState(instructions="do the task")
+    )()
+    assert isinstance(rendered, str)
+    assert "additional" in rendered
+    assert "Additional test command." in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -15,6 +15,7 @@ from typing import Callable, Literal, NamedTuple, overload
 from uuid import uuid4
 
 import pytest
+from pydantic import JsonValue
 from test_helpers.sandbox import CannedSandbox
 from test_helpers.utils import skip_if_no_docker
 
@@ -29,6 +30,9 @@ from inspect_ai.agent._human import install as human_install
 from inspect_ai.agent._human.commands import human_agent_commands, submit
 from inspect_ai.agent._human.commands.instructions import InstructionsCommand
 from inspect_ai.agent._human.commands.submit import QuitCommand, SubmitCommand
+from inspect_ai.agent._human.install import (
+    human_agent_commands as human_agent_task_commands,
+)
 from inspect_ai.agent._human.state import HumanAgentState
 from inspect_ai.agent._human.install import (
     _BASHRC_APPEND_SCRIPT,
@@ -102,6 +106,18 @@ class _AdditionalCommand(HumanAgentCommand):
         return "Additional test command."
 
 
+class _StatefulAdditionalCommand(_AdditionalCommand):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    @property
+    def cli_state(self) -> dict[str, JsonValue]:
+        return {"value": self.value}
+
+    def cli(self, args: Namespace) -> None:
+        print(self.value)
+
+
 def test_human_cli_accepts_public_commands_filter():
     def commands_filter(
         commands: list[HumanAgentCommand],
@@ -111,6 +127,38 @@ def test_human_cli_accepts_public_commands_filter():
     filter_: HumanAgentCommandsFilter = commands_filter
 
     assert callable(human_cli(commands_filter=filter_))
+
+
+def test_human_cli_runs_stateful_appended_command(tmp_path: Path) -> None:
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [*commands, _StatefulAdditionalCommand("custom value")]
+
+    commands = human_agent_commands(
+        AgentState(messages=[]),
+        answer=True,
+        intermediate_scoring=False,
+        record_session=False,
+        instructions=None,
+        commands_filter=commands_filter,
+    )
+    (tmp_path / "human_agent.py").write_text(
+        "def call_human_agent(method: str, **params: object) -> None:\n    pass\n"
+    )
+    task_py = tmp_path / "task.py"
+    task_py.write_text(human_agent_task_commands(commands))
+
+    result = subprocess.run(
+        [sys.executable, task_py.as_posix(), "additional"],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "custom value\n"
 
 
 async def test_human_cli_commands_filter_seen_by_instructions() -> None:

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -18,6 +18,7 @@ import pytest
 from pydantic import JsonValue
 from test_helpers.sandbox import CannedSandbox
 from test_helpers.utils import skip_if_no_docker
+from typing_extensions import override
 
 from inspect_ai import Task, eval
 from inspect_ai.agent import (
@@ -632,6 +633,48 @@ async def test_failed_task_py_write_is_reported() -> None:
 def test_generated_task_py_is_valid_python() -> None:
     """What the installer publishes for a real command list must at least parse."""
     ast.parse(human_agent_commands(REAL_COMMANDS))
+
+
+def test_generated_task_py_executes_handler_decorated_with_override(
+    tmp_path: Path,
+) -> None:
+    class OverrideCommand(HumanAgentCommand):
+        @property
+        def name(self) -> str:
+            return "override"
+
+        @property
+        def description(self) -> str:
+            return "A command whose handler uses a type-only decorator."
+
+        @override
+        def cli(self, args: Namespace) -> None:
+            """The generated handler documentation contains @override."""
+            # @override
+            message = "handler literal @override"
+            del args
+            print(message)
+
+    task_py = human_agent_commands([OverrideCommand()])
+    (tmp_path / "human_agent.py").write_text(
+        "def call_human_agent(*args, **kwargs):\n    return None\n",
+        encoding="utf-8",
+    )
+    task_py_path = tmp_path / "task.py"
+    task_py_path.write_text(task_py, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(task_py_path), "override"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "handler literal @override\n"
+    assert "The generated handler documentation contains @override." in task_py
+    assert "# @override\n" in task_py
 
 
 def test_installer_source_runs_nothing_outside_the_helper_and_bashrc_scripts() -> None:

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -172,6 +172,31 @@ def test_human_cli_commands_filter_rejects_service_only_start() -> None:
         )
 
 
+def test_human_cli_commands_filter_rejects_cli_only_start() -> None:
+    class _CLIOnlyStartCommand(StartCommand):
+        @property
+        def contexts(self) -> list[Literal["cli", "service"]]:
+            return ["cli"]
+
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [
+            _CLIOnlyStartCommand() if command.name == "start" else command
+            for command in commands
+        ]
+
+    with pytest.raises(ValueError, match="start"):
+        human_agent_commands(
+            AgentState(messages=[]),
+            answer=True,
+            intermediate_scoring=False,
+            record_session=False,
+            instructions=None,
+            commands_filter=commands_filter,
+        )
+
+
 def test_human_cli_runs_stateful_appended_command(tmp_path: Path) -> None:
     def commands_filter(
         commands: list[HumanAgentCommand],

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -28,6 +28,7 @@ from inspect_ai.agent import (
 )
 from inspect_ai.agent._human import install as human_install
 from inspect_ai.agent._human.commands import human_agent_commands, submit
+from inspect_ai.agent._human.commands.clock import StartCommand
 from inspect_ai.agent._human.commands.instructions import InstructionsCommand
 from inspect_ai.agent._human.commands.submit import QuitCommand, SubmitCommand
 from inspect_ai.agent._human.install import (
@@ -134,6 +135,31 @@ def test_human_cli_commands_filter_rejects_dropping_start() -> None:
         commands: list[HumanAgentCommand],
     ) -> list[HumanAgentCommand]:
         return [command for command in commands if command.name != "start"]
+
+    with pytest.raises(ValueError, match="start"):
+        human_agent_commands(
+            AgentState(messages=[]),
+            answer=True,
+            intermediate_scoring=False,
+            record_session=False,
+            instructions=None,
+            commands_filter=commands_filter,
+        )
+
+
+def test_human_cli_commands_filter_rejects_service_only_start() -> None:
+    class _ServiceOnlyStartCommand(StartCommand):
+        @property
+        def contexts(self) -> list[Literal["cli", "service"]]:
+            return ["service"]
+
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [
+            _ServiceOnlyStartCommand() if command.name == "start" else command
+            for command in commands
+        ]
 
     with pytest.raises(ValueError, match="start"):
         human_agent_commands(

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -129,6 +129,23 @@ def test_human_cli_accepts_public_commands_filter():
     assert callable(human_cli(commands_filter=filter_))
 
 
+def test_human_cli_commands_filter_rejects_dropping_start() -> None:
+    def commands_filter(
+        commands: list[HumanAgentCommand],
+    ) -> list[HumanAgentCommand]:
+        return [command for command in commands if command.name != "start"]
+
+    with pytest.raises(ValueError, match="start"):
+        human_agent_commands(
+            AgentState(messages=[]),
+            answer=True,
+            intermediate_scoring=False,
+            record_session=False,
+            instructions=None,
+            commands_filter=commands_filter,
+        )
+
+
 def test_human_cli_runs_stateful_appended_command(tmp_path: Path) -> None:
     def commands_filter(
         commands: list[HumanAgentCommand],

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -1,5 +1,6 @@
 import ast
 import concurrent.futures
+import importlib.util
 import os
 import re
 import shutil
@@ -7,14 +8,17 @@ import stat
 import subprocess
 import sys
 import time
+import typing
 from argparse import Namespace
 from collections.abc import AsyncIterator, Iterator
 from io import StringIO
 from pathlib import Path
+from textwrap import dedent
 from typing import Callable, Literal, NamedTuple, overload
 from uuid import uuid4
 
 import pytest
+import typing_extensions
 from pydantic import JsonValue
 from test_helpers.sandbox import CannedSandbox
 from test_helpers.utils import skip_if_no_docker
@@ -33,10 +37,6 @@ from inspect_ai.agent._human.commands.clock import StartCommand
 from inspect_ai.agent._human.commands.instructions import InstructionsCommand
 from inspect_ai.agent._human.commands.submit import QuitCommand, SubmitCommand
 from inspect_ai.agent._human.install import (
-    human_agent_commands as human_agent_task_commands,
-)
-from inspect_ai.agent._human.state import HumanAgentState
-from inspect_ai.agent._human.install import (
     _BASHRC_APPEND_SCRIPT,
     BASHRC,
     BASHRC_MARKER,
@@ -45,9 +45,12 @@ from inspect_ai.agent._human.install import (
     TASK_PY_MODE,
     append_bashrc,
     human_agent_bashrc,
-    human_agent_commands,
     install_human_agent,
 )
+from inspect_ai.agent._human.install import (
+    human_agent_commands as human_agent_task_commands,
+)
+from inspect_ai.agent._human.state import HumanAgentState
 from inspect_ai.util._sandbox._framework_directory import (
     _SCRIPT,
     _STAT_ENTRY,
@@ -118,6 +121,68 @@ class _StatefulAdditionalCommand(_AdditionalCommand):
 
     def cli(self, args: Namespace) -> None:
         print(self.value)
+
+
+class _TypingExtensionsOverrideCommand(_AdditionalCommand):
+    @typing_extensions.override
+    def cli(self, args: Namespace) -> None:
+        del args
+        print("attribute override handler ran")
+
+
+class _ParenthesizedTypingExtensionsOverrideCommand(_AdditionalCommand):
+    @(typing_extensions.override)
+    def cli(self, args: Namespace) -> None:
+        del args
+        print("attribute override handler ran")
+
+
+class _RuntimeOverrideCommand(_AdditionalCommand):
+    @Namespace(
+        override=lambda function: (print("runtime decorator ran"), function)[1]
+    ).override
+    def cli(self, args: Namespace) -> None:
+        del args
+        print("custom command ran")
+
+
+class _MatrixOverrideCommand(_AdditionalCommand):
+    @((lambda function: function) if True else (None @ None))
+    @override
+    def cli(self, args: Namespace) -> None:
+        del args
+        print("custom command ran")
+
+
+class _InheritedOverrideBaseCommand(_AdditionalCommand):
+    @override
+    def cli(self, args: Namespace) -> None:
+        del args
+        print("custom command ran")
+
+
+class _InheritedOverrideCommand(_InheritedOverrideBaseCommand):
+    pass
+
+
+_ATTRIBUTE_OVERRIDE_COMMANDS = [
+    pytest.param(_TypingExtensionsOverrideCommand(), id="typing-extensions"),
+    pytest.param(
+        _ParenthesizedTypingExtensionsOverrideCommand(),
+        id="parenthesized-typing-extensions",
+    ),
+]
+if sys.version_info >= (3, 12):
+
+    class _TypingOverrideCommand(_AdditionalCommand):
+        @typing.override
+        def cli(self, args: Namespace) -> None:
+            del args
+            print("attribute override handler ran")
+
+    _ATTRIBUTE_OVERRIDE_COMMANDS.append(
+        pytest.param(_TypingOverrideCommand(), id="typing")
+    )
 
 
 def test_human_cli_accepts_public_commands_filter():
@@ -413,7 +478,7 @@ async def test_install_writes_task_py_into_verified_root_dir_after_bashrc(
     assert write_user == "root"
     assert helper_flags(write) == ROOT_CHECK
     assert is_task_py_write(write)
-    assert sandbox.inputs[3] == human_agent_commands([])
+    assert sandbox.inputs[3] == human_agent_task_commands([])
 
     # Every command is launched through the absolute shell path; nothing is staged,
     # chowned, or executed from a directory the login user could replace.
@@ -632,7 +697,7 @@ async def test_failed_task_py_write_is_reported() -> None:
 
 def test_generated_task_py_is_valid_python() -> None:
     """What the installer publishes for a real command list must at least parse."""
-    ast.parse(human_agent_commands(REAL_COMMANDS))
+    ast.parse(human_agent_task_commands(REAL_COMMANDS))
 
 
 def test_generated_task_py_executes_handler_decorated_with_override(
@@ -655,7 +720,7 @@ def test_generated_task_py_executes_handler_decorated_with_override(
             del args
             print(message)
 
-    task_py = human_agent_commands([OverrideCommand()])
+    task_py = human_agent_task_commands([OverrideCommand()])
     (tmp_path / "human_agent.py").write_text(
         "def call_human_agent(*args, **kwargs):\n    return None\n",
         encoding="utf-8",
@@ -674,7 +739,218 @@ def test_generated_task_py_executes_handler_decorated_with_override(
     assert result.returncode == 0, result.stderr
     assert result.stdout == "handler literal @override\n"
     assert "The generated handler documentation contains @override." in task_py
-    assert "# @override\n" in task_py
+
+
+@pytest.mark.parametrize("command", _ATTRIBUTE_OVERRIDE_COMMANDS)
+def test_generated_task_py_executes_handler_decorated_with_attribute_override(
+    tmp_path: Path, command: HumanAgentCommand
+) -> None:
+    task_py = human_agent_task_commands([command])
+    (tmp_path / "human_agent.py").write_text(
+        "def call_human_agent(*args, **kwargs):\n    return None\n",
+        encoding="utf-8",
+    )
+    task_py_path = tmp_path / "task.py"
+    task_py_path.write_text(task_py, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(task_py_path), "additional"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "attribute override handler ran\n"
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_output"),
+    [
+        pytest.param(
+            _RuntimeOverrideCommand(),
+            "runtime decorator ran\ncustom command ran\n",
+            id="runtime-attribute",
+        ),
+        pytest.param(
+            _MatrixOverrideCommand(), "custom command ran\n", id="matrix-operator"
+        ),
+        pytest.param(
+            _InheritedOverrideCommand(), "custom command ran\n", id="inherited"
+        ),
+    ],
+)
+def test_generated_task_py_preserves_handler_decorators(
+    tmp_path: Path, command: HumanAgentCommand, expected_output: str
+) -> None:
+    task_py = human_agent_task_commands([command])
+    (tmp_path / "human_agent.py").write_text(
+        "def call_human_agent(*args, **kwargs):\n    return None\n",
+        encoding="utf-8",
+    )
+    task_py_path = tmp_path / "task.py"
+    task_py_path.write_text(task_py, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(task_py_path), "additional"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected_output
+
+
+@pytest.mark.parametrize(
+    ("source", "module_name"),
+    [
+        pytest.param(
+            dedent("""
+                import typing_extensions
+                from argparse import Namespace
+
+                from inspect_ai.agent import HumanAgentCommand
+
+
+                class OverrideCommand(HumanAgentCommand):
+                    @property
+                    def name(self) -> str:
+                        return "override"
+
+                    @property
+                    def description(self) -> str:
+                        return "A command with a multiline type-only decorator."
+
+                    @(
+                        typing_extensions.override
+                    )
+                    def cli(self, args: Namespace) -> None:
+                        del args
+                        print("tokenized override handler ran")
+                """),
+            "multiline_override_command",
+            id="multiline",
+        ),
+        pytest.param(
+            dedent("""
+                import typing_extensions
+                from argparse import Namespace
+
+                from inspect_ai.agent import HumanAgentCommand
+
+
+                class OverrideCommand(HumanAgentCommand):
+                    @property
+                    def name(self) -> str:
+                        return "override"
+
+                    @property
+                    def description(self) -> str:
+                        return "A command with a comment in its type-only decorator."
+
+                    @(typing_extensions.override  # (
+                    )
+                    def cli(self, args: Namespace) -> None:
+                        del args
+                        print("tokenized override handler ran")
+                """),
+            "commented_override_command",
+            id="commented",
+        ),
+        pytest.param(
+            dedent("""
+                from argparse import Namespace
+                from typing_extensions import override
+
+                from inspect_ai.agent import HumanAgentCommand
+
+
+                class OverrideCommand(HumanAgentCommand):
+                    @property
+                    def name(self) -> str:
+                        return "override"
+
+                    @property
+                    def description(self) -> str:
+                        return "A command with a multiline matrix decorator."
+
+                    @(
+                        (lambda function: function)
+                        if True
+                        else (None @ None)
+                    )
+                    @override
+                    def cli(self, args: Namespace) -> None:
+                        del args
+                        print("tokenized override handler ran")
+                """),
+            "multiline_matrix_override_command",
+            id="multiline-matrix",
+        ),
+        pytest.param(
+            dedent("""
+                from argparse import Namespace
+                from typing_extensions import override
+
+                from inspect_ai.agent import HumanAgentCommand
+
+
+                class OverrideCommand(HumanAgentCommand):
+                    @property
+                    def name(self) -> str:
+                        return "override"
+
+                    @property
+                    def description(self) -> str:
+                        return "A command with decorator string arguments."
+
+                    @((lambda *args: lambda function: function)(")", "@", "cli(self, "))
+                    @override
+                    def cli(self, args: Namespace) -> None:
+                        del args
+                        print("tokenized override handler ran")
+                """),
+            "decorator_string_argument_command",
+            id="decorator-string-argument",
+        ),
+    ],
+)
+def test_generated_task_py_executes_multiline_override_decorators(
+    tmp_path: Path, source: str, module_name: str
+) -> None:
+    command_path = tmp_path / f"{module_name}.py"
+    command_path.write_text(source, encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(module_name, command_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        command = getattr(module, "OverrideCommand")()
+        task_py = human_agent_task_commands([command])
+    finally:
+        del sys.modules[module_name]
+
+    (tmp_path / "human_agent.py").write_text(
+        "def call_human_agent(*args, **kwargs):\n    return None\n",
+        encoding="utf-8",
+    )
+    task_py_path = tmp_path / "task.py"
+    task_py_path.write_text(task_py, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(task_py_path), "override"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "tokenized override handler ran\n"
 
 
 def test_installer_source_runs_nothing_outside_the_helper_and_bashrc_scripts() -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`human_cli()` installs a fixed command list, so callers cannot tailor the human-agent CLI without patching Inspect. It also copies custom command handlers into a standalone `task.py`; handlers decorated with `@override`, `@typing.override`, or `@typing_extensions.override` fail at startup because those type-only decorator names are not imported into that script.

### What is the new behavior?

`human_cli()` accepts `commands_filter: HumanAgentCommandsFilter | None = None`. The filter runs on the default command list before `InstructionsCommand` is built, so added or replaced commands are installed and rendered by `task instructions`. `HumanAgentCommand` and `HumanAgentCommandsFilter` are public exports, with their reference documentation included.

Custom commands can supply JSON-serializable `cli_state`, which is restored into a `Namespace` passed as `self` to the generated handler. The filtered list must retain a `start` command installed in both the CLI and service contexts; otherwise it raises `ValueError` instead of creating a task that cannot start its clock.

The installer parses the defining source module to reconstruct each command handler structurally, preserves its decorators, and emits the unparsed handler plus standard type-only `override` names used by bare, `typing`, and `typing_extensions` forms into the generated script. Handler comments are not retained in the generated script.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `commands_filter`, `cli_state`, and the public command types are additive. Existing command lists and handlers continue to use the defaults.

### Other information:

### Slow tests

- `uv run make check` passed: ruff, mypy (`Success: no issues found in 1461 source files`), and the suppressions ledger (`787 suppressions`, `776 without a reason`, `258 files`).
- `uv run --python 3.14 pytest tests/agent/test_agent_human.py -q` passed: `52 passed, 43 skipped, 13 warnings`. This default invocation exercises the synchronous generated-script decorator cases.
- `uv run --python 3.14 pytest tests/agent/test_agent_human.py::test_human_cli_commands_filter_seen_by_instructions --runtrio -q` passed: `1 passed, 1 skipped`, exercising this PR's async ordering test under Trio.
- `uv run --python 3.14 pytest tests/agent/test_agent_human.py::test_generated_task_py_executes_handler_decorated_with_override tests/agent/test_agent_human.py::test_generated_task_py_executes_handler_decorated_with_attribute_override tests/agent/test_agent_human.py::test_generated_task_py_preserves_handler_decorators tests/agent/test_agent_human.py::test_generated_task_py_executes_multiline_override_decorators -q` passed: `11 passed`, covering bare and qualified type-only decorators, runtime decorators, matrix multiplication in decorator expressions, inherited handlers, multiline decorators, and decorator string arguments.
- Collection of `test_agent_human.py` succeeded under both Python 3.10 and 3.11 (`94 tests collected` each).
- The full `--runtrio` file run has an intermittent `anyio.BrokenResourceError` in unchanged `.bashrc` error-path handling; it was independently reproduced on `main@upstream`. The relevant Trio ordering test above passes.
- Not run in this update: `make test` and Docker-backed `test_human_cli*` coverage. Those Docker tests exercise only the default command list, not generated handlers with type-only decorators; the focused subprocess tests above execute the changed generated-script path directly.

### Agent review

- Reviewer: openai/gpt-6-astra via Oh My Pi, 5 fresh-context reviews.
- Findings: the first four reviews found correctness and portability defects and drove two redesigns—from source-range removal to a preamble, then to structural AST extraction. The fifth review verified the final code behavior and corrected the test-collection count above.
