### PR TITLE
docs: correct the sandbox exec() output-limit contract (#4778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Breaking: Runtime media paths and URLs now require `materialize_media()` before model use; fixed selected-dataset media remains automatic, while sandbox bridges require inline data URIs.
 - Fixed sandbox agent bridge forwarding file inputs that are not inline `data:` URIs (e.g. host paths or URLs); such requests are now rejected.
 - Mistral: Provider-generated images remain available when replayed in subsequent conversation turns.
+- Docs: Clarify that the sandbox `exec()` output limit is enforced by front-truncating the output streams rather than by raising `OutputLimitExceededError` (which remains the behaviour for `read_file()`). (#4778)
 
 ## 0.3.259 (16 August 2026)
 

--- a/docs/sandboxing.qmd
+++ b/docs/sandboxing.qmd
@@ -160,9 +160,11 @@ def my_task(cpus: float = 1.0):
 
 The `ComposeConfig` and `ComposeService` classes mirror the structure of Docker Compose files, supporting fields like `image`, `build`, `command`, `environment`, `volumes`, `ports`, `mem_limit`, `cpus`, and more. Extension fields (prefixed with `x-`) are also supported.
 
-## Sandbox Limits
+## Sandbox Limits {#sec-sandbox-limits}
 
 By default, sandboxes limit the size of file reads to 100MB and execution output to 10MB. These limits exist to prevent boundary cases of outputs or executions that don't terminate and result in OOM or hung evaluations (i.e. they usually indicate an error by the model).
+
+The two limits are not enforced in the same way. `read_file()` always raises `OutputLimitExceededError` when the limit is exceeded. For `exec()` the behaviour depends on the sandbox provider: the built-in providers front-truncate each output stream (keeping only its trailing portion), so `exec()` returns a successful `ExecResult` whose `stdout` or `stderr` may be silently incomplete rather than raising. Don't rely on an exception to detect `exec()` overflow—this matters in particular when parsing structured output such as JSON. If a command can produce output near the limit and you need all of it, have the command write to a file and read it with `read_file()`.
 
 You can however increase these limits using environment variables. For example, here we set the read file limit to 200MB and the exec output size to 20MB:
 

--- a/docs/tools-custom.qmd
+++ b/docs/tools-custom.qmd
@@ -35,7 +35,7 @@ If you do not explicitly handle errors, then Inspect provides some default error
 
 -   `UnicodeDecodeError` — Occurs when the output from executing a process or reading a file is binary rather than text.
 
--   `OutputLimitExceededError` - Occurs when one or both of the output streams from `sandbox().exec()` exceed 10 MiB or when attempting to read a file over 100 MiB in size.
+-   `OutputLimitExceededError` - Occurs when attempting to read a file over 100 MiB in size. It may also occur when one or both of the output streams from `sandbox().exec()` exceed 10 MiB, however this is provider dependent: a provider may instead return only the trailing portion of the output with the beginning discarded, so this error should not be relied upon to detect `exec()` overflow (see [Sandbox Limits](sandboxing.qmd#sec-sandbox-limits)).
 
 -   `ToolError` — Special error thrown by tools to indicate they'd like to report an error to the model.
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Follows up on #4778 and the closed #4857 — per @dragonstyle's note there ("I think a documentation update makes more sense than reporting this... welcome a new PR to correct the docs!"), this is the docs-only correction, with no interface or behaviour change.

The `SandboxEnvironment.exec()` docstring was already corrected by #4506, but the user-facing docs were not. `docs/tools-custom.qmd` still states unconditionally:

> `OutputLimitExceededError` - Occurs when one or both of the output streams from `sandbox().exec()` exceed 10 MiB or when attempting to read a file over 100 MiB in size.

That is not what the built-in providers do. Both `LocalSandboxEnvironment.exec()` and `DockerSandboxEnvironment.exec()` pass `output_limit=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE` to `subprocess()`, which front-truncates:

> `output_limit`: Maximum bytes to retain from stdout/stderr. If output exceeds this limit, only the most recent bytes are kept (older output is discarded). The process continues to completion.

Because the stream handed back is already clamped *to* the limit, `SandboxEnvironmentProxy.verify_exec_result_size()` — the only place that raises `OutputLimitExceededError` on the exec path — never fires. The caller gets `returncode=0` and silently truncated output, which is exactly what #4778 measured.

`read_file()` is different: it does always raise, and that half of the sentence is accurate.

### What is the new behavior?

Three small docs edits, no code:

- `docs/tools-custom.qmd` — the `OutputLimitExceededError` bullet now leads with the `read_file()` case (which always raises) and describes the `exec()` case as provider dependent, matching the `exec()` docstring wording from #4506.
- `docs/sandboxing.qmd` — "Sandbox Limits" gains a paragraph spelling out the `read_file()`/`exec()` asymmetry, the JSON-parsing hazard, and the write-to-a-file-then-`read_file()` workaround the docstring already recommends. The heading gains an explicit `{#sec-sandbox-limits}` anchor so `tools-custom.qmd` can link to it.
- `CHANGELOG.md` — one `Docs:` entry under Unreleased.

### Does this PR introduce a breaking change?

No — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
