### PR TITLE
fix: install sandbox tools in rootless k8s pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - ACP: Emit an `inspect/turn_state` extension notification (`started` / `ended` / `cancelled`) from the agent turn boundary so ACP clients have an exact "agent working" signal.
+- Fixed sandbox tools (`text_editor`, `bash_session`) failing to install in non-root sandboxes (e.g. Kubernetes pods with `runAsNonRoot`).
 
 ## 0.3.259 (16 August 2026)
 

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -104,9 +104,7 @@ async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
         # can be hidden from the agent; fall back to the default user for rootless
         # sandboxes (where user-switching will be disabled, auto-detected by the
         # server).
-        if (
-            await sandbox.exec(["mkdir", "-p", SANDBOX_TOOLS_DIR], user="root")
-        ).success:
+        if await _create_tools_dir_as_root(sandbox):
             sandbox._tools_user = "root"
         else:
             result = await sandbox.exec(["mkdir", "-p", SANDBOX_TOOLS_DIR])
@@ -141,6 +139,20 @@ async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
         raise SandboxInjectionError(
             f"Failed to inject sandbox tools into sandbox: {e}", cause=e
         ) from e
+
+
+async def _create_tools_dir_as_root(sandbox: SandboxEnvironment) -> bool:
+    try:
+        return (
+            await sandbox.exec(["mkdir", "-p", SANDBOX_TOOLS_DIR], user="root")
+        ).success
+    except Exception as ex:
+        trace_message(
+            logger,
+            TRACE_SANDBOX_TOOLS,
+            f"root sandbox tools dir probe failed; falling back to default user: {ex}",
+        )
+        return False
 
 
 async def _extract_tools_tree(

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -147,6 +147,9 @@ async def _create_tools_dir_as_root(sandbox: SandboxEnvironment) -> bool:
             await sandbox.exec(["mkdir", "-p", SANDBOX_TOOLS_DIR], user="root")
         ).success
     except Exception as ex:
+        # Broad catch is deliberate: providers signal "cannot exec as root" by
+        # raising provider-specific exception types, so no narrower type is
+        # available. Trade-off: any probe failure selects the rootless install.
         trace_message(
             logger,
             TRACE_SANDBOX_TOOLS,

--- a/tests/tools/sandbox_tools_utils/test_sandbox_tools_injection.py
+++ b/tests/tools/sandbox_tools_utils/test_sandbox_tools_injection.py
@@ -7,7 +7,7 @@ from typing import AsyncIterator, BinaryIO, Literal, overload
 import pytest
 
 from inspect_ai.tool._sandbox_tools_utils import sandbox as sandbox_tools
-from inspect_ai.util._sandbox._cli import SANDBOX_CLI, SANDBOX_TOOLS_DIR
+from inspect_ai.util._sandbox._cli import SANDBOX_TOOLS_DIR
 from inspect_ai.util._sandbox.environment import (
     SandboxEnvironment,
     SandboxEnvironmentConfigType,
@@ -96,8 +96,4 @@ async def test_inject_container_tools_falls_back_when_root_probe_raises(
 
     assert sandbox._tools_user is None
     assert sandbox.extracted_as_user is None
-    assert sandbox.exec_calls == [
-        (["mkdir", "-p", SANDBOX_TOOLS_DIR], "root"),
-        (["mkdir", "-p", SANDBOX_TOOLS_DIR], None),
-        ([SANDBOX_CLI, "start-server"], None),
-    ]
+    assert (["mkdir", "-p", SANDBOX_TOOLS_DIR], "root") in sandbox.exec_calls

--- a/tests/util/sandbox/test_sandbox_tools_injection.py
+++ b/tests/util/sandbox/test_sandbox_tools_injection.py
@@ -1,0 +1,103 @@
+"""Tests for sandbox tools injection."""
+
+from contextlib import asynccontextmanager
+from io import BytesIO
+from typing import AsyncIterator, BinaryIO, Literal, overload
+
+import pytest
+
+from inspect_ai.tool._sandbox_tools_utils import sandbox as sandbox_tools
+from inspect_ai.util._sandbox._cli import SANDBOX_CLI, SANDBOX_TOOLS_DIR
+from inspect_ai.util._sandbox.environment import (
+    SandboxEnvironment,
+    SandboxEnvironmentConfigType,
+)
+from inspect_ai.util._sandbox.recon import Architecture, SupportedContainerOSInfo
+from inspect_ai.util._subprocess import ExecResult
+
+
+class RootProbeRaisesSandbox(SandboxEnvironment):
+    def __init__(self) -> None:
+        super().__init__()
+        self.exec_calls: list[tuple[list[str], str | None]] = []
+        self.extracted_as_user: str | None | object = object()
+
+    async def exec(
+        self,
+        cmd: list[str],
+        input: str | bytes | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        timeout: int | None = None,
+        timeout_retry: bool = True,
+        concurrency: bool = True,
+    ) -> ExecResult[str]:
+        self.exec_calls.append((cmd, user))
+        if cmd == ["mkdir", "-p", SANDBOX_TOOLS_DIR] and user == "root":
+            raise RuntimeError("runuser: may not be used by non-root users")
+        return ExecResult(success=True, returncode=0, stdout="", stderr="")
+
+    async def write_file(self, file: str, contents: str | bytes) -> None:
+        pass
+
+    @overload
+    async def read_file(self, file: str, text: Literal[True] = True) -> str: ...
+
+    @overload
+    async def read_file(self, file: str, text: Literal[False]) -> bytes: ...
+
+    async def read_file(self, file: str, text: bool = True) -> str | bytes:
+        raise NotImplementedError
+
+    @classmethod
+    async def sample_cleanup(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        environments: dict[str, SandboxEnvironment],
+        interrupted: bool,
+    ) -> None:
+        pass
+
+
+async def test_inject_container_tools_falls_back_when_root_probe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox = RootProbeRaisesSandbox()
+
+    async def fake_detect_sandbox_os(
+        _sandbox: SandboxEnvironment,
+    ) -> SupportedContainerOSInfo:
+        return {"architecture": "amd64", "libc": "glibc"}
+
+    @asynccontextmanager
+    async def fake_open_executable_for_arch(
+        _arch: Architecture,
+        _musl: bool,
+    ) -> AsyncIterator[tuple[str, BinaryIO]]:
+        yield "inspect-sandbox-tools", BytesIO(b"binary")
+
+    async def fake_extract_tools_tree(
+        _sandbox: SandboxEnvironment,
+        _name: str,
+        _gz_bytes: bytes,
+        user: str | None,
+    ) -> None:
+        sandbox.extracted_as_user = user
+
+    monkeypatch.setattr(sandbox_tools, "detect_sandbox_os", fake_detect_sandbox_os)
+    monkeypatch.setattr(
+        sandbox_tools, "_open_executable_for_arch", fake_open_executable_for_arch
+    )
+    monkeypatch.setattr(sandbox_tools, "_extract_tools_tree", fake_extract_tools_tree)
+
+    await sandbox_tools._inject_container_tools_code(sandbox)
+
+    assert sandbox._tools_user is None
+    assert sandbox.extracted_as_user is None
+    assert sandbox.exec_calls == [
+        (["mkdir", "-p", SANDBOX_TOOLS_DIR], "root"),
+        (["mkdir", "-p", SANDBOX_TOOLS_DIR], None),
+        ([SANDBOX_CLI, "start-server"], None),
+    ]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4845.

Sandbox tool injection first probes whether it can create the tools directory as `root`. For rootless k8s sandboxes, the provider can raise when asked to exec as `root` rather than returning an unsuccessful `ExecResult`. That exception exits injection before the existing default-user fallback can run, so tools such as `text_editor` and `bash_session` fail in `runAsNonRoot` pods.

### What is the new behavior?

- Treat a raised exception from the root install-dir probe as "root is unavailable" and continue through the existing default-user fallback.
- Preserve the existing root-owned install path when the root probe succeeds.
- Add regression coverage for the raised-exception path, asserting that injection falls back to the sandbox default user without coupling the test to the full exec sequence.
- Add an outcome-first Unreleased changelog entry for the user-visible rootless sandbox tool injection fix.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This only allows the existing rootless fallback to run when a sandbox provider reports root-exec failure by raising.

### Other information:

Issue status:
- #4845 is labeled `accepted`.

Validation:
- Targeted:
  - `uv run pytest tests/tools/sandbox_tools_utils/test_sandbox_tools_injection.py -q`
    - Passed. Exercises the k8s-like failure mode where the `user="root"` mkdir probe raises, then verifies the default-user extraction path; 1 passed, 1 skipped.
  - `uv run pytest tests/tools/sandbox_tools_utils -q`
    - Passed. Covers the new regression in the existing `_sandbox_tools_utils` test home plus adjacent sandbox-tools utility tests; 31 passed, 10 skipped.
- Regression:
  - `uv run make check`
    - Passed. Runs ruff, formatting checks, inspect tool support checks, and mypy.
  - `uv run make test`
    - Passed. Pytest collected 12,800 items and completed successfully.

CI/CD coverage expected:
- The standard Build workflow should run ruff, mypy, package inspection, and pytest on supported Python versions.
- Changelog Lint should verify the Unreleased entry.
- Sandbox-tool gates may run because this touches `src/inspect_ai/tool/**`; no `sandbox_tools_version.txt` bump is needed because the injected sandbox-tools package itself is unchanged.
- Validate Embedded Viewer should remain unaffected because this PR does not touch viewer source, schema, submodule, or dist assets.

### Agent review

- Tooling disclosure: AI-assisted coding and review tools were used.
- Separate review pass: not run.
- Findings: the contributor reviewed the final diff and validation results; no separate review-pass findings to report.

Closes #4845.
