### PR TITLE
Fix MCP tool call errors raising ValidationError (and mypy failures) with openai 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Control Channel: `inspect ctl` mutations with piped or captured output now print one outcome line each instead of repeating the full task header (`--terse/--no-terse` to override).
 - Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys.
 - OpenAI: the OpenAI providers and agent bridge now require openai >= 3.0.0, which verifies TLS against the OS trust store instead of certifi's bundle.
+- OpenAI: erroring MCP tool calls no longer raise a `ValidationError` with openai >= 3.1.0, which reports MCP call errors as structured objects rather than strings.
 - Scoring: Model-graded scorers can require their grader model role, preventing unintended fallback to the model being evaluated. (#4695)
 - Datasets (breaking): A ragged CSV row now raises `ValueError` naming the file and line, instead of `AttributeError` or a silent load. (#4546)
 - Multiple Choice: Answers listing choices with an Oxford or trailing comma (e.g. `ANSWER: A, B, and C`) are now scored correctly instead of as no answer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
 - Control Channel: `inspect ctl` mutations with piped or captured output now print one outcome line each instead of repeating the full task header (`--terse/--no-terse` to override).
 - Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys.
-- OpenAI: the OpenAI providers and agent bridge now require openai >= 3.0.0, which verifies TLS against the OS trust store instead of certifi's bundle.
+- OpenAI: the OpenAI providers and agent bridge now require openai >= 3.1.0, which verifies TLS against the OS trust store instead of certifi's bundle.
 - OpenAI: erroring MCP tool calls no longer raise a `ValidationError` with openai >= 3.1.0, which reports MCP call errors as structured objects rather than strings.
 - Scoring: Model-graded scorers can require their grader model role, preventing unintended fallback to the model being evaluated. (#4695)
 - Datasets (breaking): A ragged CSV row now raises `ValueError` naming the file and line, instead of `AttributeError` or a silent load. (#4546)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ mistralai>=2.4.5
 moto[server]>=5.1.5
 mypy>=2.3.0 # older mypy emits a `misc` error at a site where the ignore was removed as unused
 nbformat
-openai>=3.0.0
+openai>=3.1.0
 pandas>=2.0.0
 pandas-stubs
 panflute

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -1234,7 +1234,10 @@ def mcp_error_to_str(error: McpToolCallError | None) -> str | None:
                 else to_json_str_safe(error.content)
             )
         case _:
-            return error.message
+            # protocol and HTTP errors both carry a code worth surfacing (a
+            # JSON-RPC code or an HTTP status) -- the message alone often
+            # isn't enough to triage the failure from a transcript
+            return f"{error.message} ({error.code})"
 
 
 def mcp_error_from_str(error: str | None) -> McpToolCallErrorParam | None:

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -48,6 +48,16 @@ from openai.types.responses import (
     WebSearchToolParam,
 )
 from openai.types.responses import Response as OpenAIResponse
+from openai.types.responses.mcp_tool_call_error import (
+    McpToolCallError,
+    McpToolExecutionError,
+)
+from openai.types.responses.mcp_tool_call_error_param import (
+    McpToolCallErrorParam,
+)
+from openai.types.responses.mcp_tool_call_error_param import (
+    McpToolExecutionError as McpToolExecutionErrorParam,
+)
 from openai.types.responses.namespace_tool_param import (
     NamespaceToolParam,
 )
@@ -1206,6 +1216,39 @@ def mcp_list_tools_to_tool_use(output: McpListTools) -> ContentToolUse:
     )
 
 
+def mcp_error_to_str(error: McpToolCallError | None) -> str | None:
+    """Render a structured MCP tool call error as a display string.
+
+    openai 3.1.0 changed `McpCall.error` from `str | None` to a discriminated
+    union of error objects; `ContentToolUse.error` remains a display string.
+    """
+    match error:
+        case None:
+            return None
+        case McpToolExecutionError():
+            # pass string content through unchanged so the conversion is
+            # idempotent across replay round trips (no compounding JSON quoting)
+            return (
+                error.content
+                if isinstance(error.content, str)
+                else to_json_str_safe(error.content)
+            )
+        case _:
+            return error.message
+
+
+def mcp_error_from_str(error: str | None) -> McpToolCallErrorParam | None:
+    """Rebuild a structured MCP error from its display string.
+
+    The original variant isn't recoverable from the string, so surface it as a
+    tool execution error. Only reached when no verbatim cached `server_tool_uses`
+    item is available for the call.
+    """
+    if error is None:
+        return None
+    return McpToolExecutionErrorParam(type="mcp_tool_execution_error", content=error)
+
+
 def mcp_call_to_tool_use(output: McpCall) -> ContentToolUse:
     return ContentToolUse(
         tool_type="mcp_call",
@@ -1214,7 +1257,7 @@ def mcp_call_to_tool_use(output: McpCall) -> ContentToolUse:
         context=output.server_label,
         arguments=output.arguments,
         result=output.output or "",
-        error=output.error,
+        error=mcp_error_to_str(output.error),
     )
 
 
@@ -1245,7 +1288,7 @@ def tool_use_to_mcp_call_param(content: ContentToolUse) -> McpCallParam:
         arguments=content.arguments,
         server_label=content.context or "",
         output=content.result,
-        error=content.error,
+        error=mcp_error_from_str(content.error),
     )
 
 

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -363,7 +363,7 @@ def hf_inference_providers() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "3.0.0"
+    MIN_VERSION = "3.1.0"
 
     # verify we have the package
     try:

--- a/tests/model/test_openai_convert.py
+++ b/tests/model/test_openai_convert.py
@@ -15,12 +15,20 @@ from openai.types.responses import (
     ResponseReasoningItem,
     ResponseUsage,
 )
+from openai.types.responses.mcp_tool_call_error import (
+    HTTPError,
+    McpProtocolError,
+    McpToolCallError,
+    McpToolExecutionError,
+)
+from openai.types.responses.response_output_item import McpCall
 from openai.types.responses.response_usage import (
     InputTokensDetails,
     OutputTokensDetails,
 )
 
 from inspect_ai._util.content import ContentReasoning, ContentText
+from inspect_ai._util.json import to_json_str_safe
 from inspect_ai.model import (
     model_output_from_openai,
     model_output_from_openai_responses,
@@ -31,8 +39,10 @@ from inspect_ai.model._chat_message import (
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.model._openai import chat_message_assistant_from_openai
 from inspect_ai.model._openai_responses import (
+    mcp_call_to_tool_use,
     reasoning_from_responses_reasoning,
     responses_reasoning_from_reasoning,
+    tool_use_to_mcp_call_param,
 )
 
 
@@ -758,3 +768,59 @@ def test_reasoning_round_trip_content_encrypted_and_summary() -> None:
     assert len(replayed_summary) == 1
     assert replayed_summary[0]["text"] == "API summary"
     assert replayed["id"] == "rs_rt_all"
+
+
+def _mcp_call(error: McpToolCallError | None) -> McpCall:
+    return McpCall(
+        id="mcp_1",
+        type="mcp_call",
+        name="get_weather",
+        server_label="weather",
+        arguments='{"city": "Paris"}',
+        output=None,
+        error=error,
+    )
+
+
+def test_mcp_call_error_round_trip() -> None:
+    """In openai 3.1.0, `McpCall.error` changed from a string to a structured union."""
+    cases: list[tuple[McpToolCallError | None, str | None]] = [
+        (
+            McpProtocolError(
+                type="mcp_protocol_error", code=-32000, message="tool not found"
+            ),
+            "tool not found",
+        ),
+        (
+            HTTPError(type="http_error", code=503, message="upstream unavailable"),
+            "upstream unavailable",
+        ),
+        (
+            McpToolExecutionError(
+                type="mcp_tool_execution_error",
+                content=[{"type": "text", "text": "boom"}],
+            ),
+            to_json_str_safe([{"type": "text", "text": "boom"}]),
+        ),
+        # string content passes through unquoted so replay round trips are idempotent
+        (
+            McpToolExecutionError(type="mcp_tool_execution_error", content="boom"),
+            "boom",
+        ),
+        (None, None),
+    ]
+    for error, expected in cases:
+        content = mcp_call_to_tool_use(_mcp_call(error))
+        assert content.error == expected
+
+        param = tool_use_to_mcp_call_param(content)
+        revalidated = McpCall.model_validate(param)
+        if expected is None:
+            assert revalidated.error is None
+        else:
+            # the original variant isn't recoverable from the display string
+            assert isinstance(revalidated.error, McpToolExecutionError)
+            assert revalidated.error.content == expected
+
+        # a second conversion pass must not compound quoting
+        assert mcp_call_to_tool_use(revalidated).error == expected

--- a/tests/model/test_openai_convert.py
+++ b/tests/model/test_openai_convert.py
@@ -789,11 +789,11 @@ def test_mcp_call_error_round_trip() -> None:
             McpProtocolError(
                 type="mcp_protocol_error", code=-32000, message="tool not found"
             ),
-            "tool not found",
+            "tool not found (-32000)",
         ),
         (
             HTTPError(type="http_error", code=503, message="upstream unavailable"),
-            "upstream unavailable",
+            "upstream unavailable (503)",
         ),
         (
             McpToolExecutionError(

--- a/uv.lock
+++ b/uv.lock
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'dev'" },
     { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "panflute", marker = "extra == 'dev'" },
@@ -4276,7 +4276,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4288,9 +4288,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#233

`openai` 3.1.0 changed `McpCall.error` from `Optional[str]` to a structured discriminated union (`McpProtocolError | McpToolExecutionError | HTTPError`). With openai >= 3.1.0 installed:

- Any MCP tool call that returns an error raises a pydantic `ValidationError` when the response is converted to `ContentToolUse` (whose `error` field is a display string).
- `mypy` fails on `src/inspect_ai/model/_openai_responses.py` at the two `mcp_call` conversion sites (`arg-type` at `mcp_call_to_tool_use`, `typeddict-item` at `tool_use_to_mcp_call_param`). This has been failing every scheduled CI run since openai 3.1.0 was published (2026-08-14).

### What is the new behavior?

Errors are converted at the OpenAI boundary. `ContentToolUse.error` stays a display string: it is a provider-neutral field published in the log schema (`inspect-openapi.json`) and generated viewer types, every other provider already collapses structured errors into it (the Anthropic MCP path sets a literal `"error"`), and its only readers treat it as text. Fidelity for replay is carried separately by the verbatim `server_tool_uses` cache, which is preferred at the replay site — so the string is a display projection, not the round-trip carrier.

- `mcp_error_to_str` renders the structured error as a display string for `ContentToolUse.error`: `message` plus the numeric `code` (a JSON-RPC code for `McpProtocolError`, an HTTP status for `HTTPError` — both variants share the same `code`/`message` shape) rendered as `"<message> (<code>)"`, since the message alone often isn't enough to triage a failure from a transcript; and for `McpToolExecutionError` the `content` — passed through unchanged when it is already a string (so replay round trips are idempotent, with no compounding JSON quoting), otherwise JSON-rendered.
- `mcp_error_from_str` rebuilds a `McpToolExecutionError` param from the string on the way back. The original variant isn't recoverable from the display string; this path is only reached when no verbatim cached `server_tool_uses` item is available for the call (replay from a log), since the cached item round-trips the structured error losslessly.
- The `openai` floor in `requirements-dev.txt` is bumped to `>=3.1.0` since the new import paths (`openai/types/responses/mcp_tool_call_error*.py`) don't exist in 3.0.0, and `uv.lock` is regenerated for the bump (via the repo's `uv-lock` pre-commit hook; the only change is openai 3.0.0 → 3.1.0).
- `MIN_VERSION` in `validate_openai_client` (`src/inspect_ai/model/_providers/providers.py`) moves to `3.1.0` to match. The new imports are module-level, so without this a user on openai 3.0.0 hits a raw `ModuleNotFoundError: No module named 'openai.types.responses.mcp_tool_call_error'` at provider/bridge startup instead of the friendly "requires openai>=..." guidance that gate exists to give. The existing Unreleased CHANGELOG line naming the floor is updated to match.
- A regression test (`test_mcp_call_error_round_trip` in `tests/model/test_openai_convert.py`) covers the `McpCall` → `ContentToolUse` → `McpCallParam` → `McpCall.model_validate` round trip for all three error variants, string content, and `None`, including second-pass idempotency.

`mcp_list_tools` sites are intentionally untouched — `McpListTools.error` remains `Optional[str]` in 3.1.0.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, for users pinned to openai 3.0.0. `openai` is not a declared runtime dependency of `inspect-ai`, so `validate_openai_client` is the only enforcement point; it now requires `>=3.1.0`, and users of the OpenAI providers or the agent bridge on 3.0.0 must upgrade. This mirrors the floor bump in b70f946a two days earlier. The package's own dependency constraints are unchanged.

### Other information:

Verification (local: Python 3.12, openai 3.1.0; plus this PR's CI):

- `pytest tests/model/test_openai_convert.py` — 25 passed, 13 skipped (trio variants).
- `ruff check` and `ruff format --check` — clean on changed files.
- Full `mypy --exclude tests/test_package src tests` — clean (1360 source files); the two CI errors are gone.
- All PR CI checks green, including `mypy (3.10)`, `mypy (3.11)`, `pre-commit`, and `test (3.10)`/`test (3.11)`.

One CI wrinkle worth recording: the first CI round failed `mypy` on an unrelated pre-existing site (`src/inspect_ai/_cli/ctl.py:168`, which deliberately subscripts `click.ParamType[...]` and needs click ≥ 8.4 stubs). Changing `requirements-dev.txt` had invalidated `uv.lock`, so `uv run mypy` re-locked from scratch on CI's tagless checkout (where setuptools-scm yields `0.1.dev1`, forcing `inspect-scout` — which requires `inspect-ai>=0.3.252` — and transitively click to downgrade). Regenerating `uv.lock` properly (with tags fetched so the project version resolves as 0.3.259.dev71) keeps click at 8.4.2 and inspect-scout at 0.4.46, changing only openai — which fixed both the `pre-commit` (uv-lock hook) and `mypy` jobs.

The fix follows the boundary-conversion approach worked out and repeatedly verified in the issue thread, including the thread's refinement to pass string `McpToolExecutionError.content` through unquoted and the note that `to_json_str_safe` pretty-prints (the test asserts against `to_json_str_safe(...)` rather than a compact-JSON literal).

### Agent review
- Reviewer: automated `@review` pass (claude[bot]) on 38c1061, fresh context, 1 pass. Findings: 1 — the stale `MIN_VERSION = "3.0.0"` runtime gate (fixed in 48d36dd).
- Reviewer: a second frontier-model pass in a fresh interactive session, 1 pass over the design and the diff. It endorsed converting to a string at the boundary (reasoning now summarized above) and rejected widening `ContentToolUse.error` to a structured type or stashing the raw error in `ContentToolUse.internal` as redundant with the `server_tool_uses` cache. Findings: 1 — `McpProtocolError.code` / `HTTPError.code` were being dropped from the display string (fixed in bf44d40), verified idempotent across a second conversion pass against a real openai 3.1.0 wheel and confirmed safe by auditing every reader of `ContentToolUse.error` for parsing or equality checks (there are none).
- Agent involvement: implemented by Claude via claude-code-action, triggered by a maintainer request on the issue; subsequent fixes pushed by Claude Code.

Generated with [Claude Code](https://claude.ai/code)


---

Relocated from meridianlabs-ai/inspect_ai#234 (opened upstream from a personal fork per the contribution guidance; the org-fork PR is closed in favor of this one). The verification and CI results described above ran on that PR.
