### PR TITLE
Fix sandbox bridge accepting file inputs that reference host paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Inspect CTL: Terminal escape sequences and control characters in agent-generated text are now sanitized in `inspect ctl` human-readable output, preventing spoofing of the operator's terminal.
 - Fixed sandbox tools (`text_editor`, `bash_session`) failing to install in non-root sandboxes (e.g. Kubernetes pods with `runAsNonRoot`).
 - Breaking: Runtime media paths and URLs now require `materialize_media()` before model use; fixed selected-dataset media remains automatic, while sandbox bridges require inline data URIs.
+- Fixed sandbox agent bridge forwarding file inputs that are not inline `data:` URIs (e.g. host paths or URLs); such requests are now rejected.
 - Mistral: Provider-generated images remain available when replayed in subsequent conversation turns.
 
 ## 0.3.259 (16 August 2026)

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -1,5 +1,4 @@
 import json
-import mimetypes
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from functools import reduce
@@ -154,10 +153,9 @@ from inspect_ai._util.content import (
     ContentToolUse,
     ContentVideo,
 )
-from inspect_ai._util.images import as_data_uri, inline_media_data_uri
+from inspect_ai._util.images import inline_media_data_uri
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.text import truncate_string_to_bytes
-from inspect_ai._util.url import is_data_uri
 from inspect_ai.model._agent_message import validate_agent_message
 from inspect_ai.model._call_tools import parse_tool_call
 from inspect_ai.model._chat_message import (
@@ -800,12 +798,11 @@ def content_from_response_input_content_param(
             image=input.get("image_url", "") or "", detail=input.get("detail", "auto")
         )
     elif is_input_file(input):
-        file_data = input["file_data"]
-        filename = input["filename"]
-        if not is_data_uri(file_data):
-            mime_type, _ = mimetypes.guess_type(filename, strict=False)
-            file_data = as_data_uri(mime_type or "application/octet-stream", file_data)
-        return ContentDocument(document=file_data, filename=filename)
+        # `file_data` must be a resolved `data:` URI (the form the responses
+        # API requires); anything else (a filesystem path, URL, or bare
+        # base64) is preserved as-is so that media validation rejects it
+        # rather than forwarding it disguised as inline data
+        return ContentDocument(document=input["file_data"], filename=input["filename"])
     else:
         raise RuntimeError(f"Unexpected input from responses API: {input}")
 

--- a/tests/model/test_inline_media_serialization.py
+++ b/tests/model/test_inline_media_serialization.py
@@ -118,21 +118,24 @@ async def test_all_model_entry_points_reject_non_inline_media(operation: str) ->
             await model.compact(messages, [])
 
 
-def test_responses_bare_file_data_is_normalized_without_io() -> None:
+@pytest.mark.parametrize(
+    "file_data",
+    [
+        "/tmp/host-only-secret.txt",
+        "https://example.com/report.pdf",
+        "JVBERi0xLjQ=",
+    ],
+)
+def test_responses_non_uri_file_data_is_not_normalized(file_data: str) -> None:
     content = content_from_response_input_content_param(
         cast(
             Any,
-            {
-                "type": "input_file",
-                "file_data": "JVBERi0xLjQ=",
-                "filename": "report.pdf",
-            },
+            {"type": "input_file", "file_data": file_data, "filename": "secret.txt"},
         )
     )
 
     assert isinstance(content, ContentDocument)
-    assert content.document == "data:application/pdf;base64,JVBERi0xLjQ="
-    assert content.mime_type == "application/pdf"
+    assert content.document == file_data
 
 
 def test_responses_typed_file_data_is_preserved() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`test_sandbox_bridge_cannot_read_host_media` fails in the scheduled slow-test run ([run](https://github.com/meridianlabs-ai/actions/actions/runs/32064101111/job/95492115725)): a sandboxed agent that submits an `input_file` whose `file_data` is a host filesystem path is not rejected by the bridge. The responses input parser (added in #4362's "Harden media authority review boundaries" commit) normalizes **any** non-data-URI `file_data` into a data URI, so a host path like `/tmp/host-only-secret.txt` becomes `data:text/plain;base64,/tmp/host-only-secret.txt`. That forged URI passes both `validate_bridge_media` and the model-boundary inline check, and the request reaches the provider. No host data is dereferenced (the path string itself is sent as bogus base64), but the bridge's reject-non-inline guarantee is bypassed and the host path leaks to the provider.

The test never ran pre-merge: it requires Docker and the slow marker, so PR CI skipped it, and the offending commit landed ~2 hours before merge. The first execution was the post-merge scheduled run.

### What is the new behavior?

`input_file.file_data` must be a resolved `data:` URI — the form the responses API specifies. The bare-base64 normalization is removed entirely: anything that is not a data URI (path, URL, bare base64) is preserved as-is, so `validate_bridge_media` rejects it with `BridgePolicyError` (and non-bridge paths fail with `UnresolvedMediaError` at the model boundary). No payload decoding or normalization work happens in the parser, which re-runs over the full input history on every bridge request.

The bare-base64 leniency was never released (it landed the same day #4362 merged, after 0.3.259 was cut), and the real OpenAI endpoint rejects bare base64 `file_data` as well, so removing it matches actual API behavior and breaks no existing usage.

Verified: `test_sandbox_bridge_cannot_read_host_media` passes locally with Docker (`--runslow`), along with `tests/model/test_inline_media_serialization.py` and `tests/util/test_media_resolver.py`; mypy clean.

### Does this PR introduce a breaking change?

No. Agents sending the documented data-URI form are unaffected; bare base64 and other strings never worked against released versions (rejected by OpenAI itself, and misread as host paths by Inspect pre-#4362).

### Other information:

### Agent review
- Reviewer: Claude Fable 5 (session-context self-review after root-causing the nightly failure; fix verified against the failing test rather than an independent review pass). Maintainer (dragonstyle) reviewed the initial strict-base64-validation approach and requested the simpler data-URI-required form, adopted here.
- Findings: 1 — adjacent gap noted, not fixed here: `input_file` items carrying `file_url`/`file_id` instead of `file_data` raise `KeyError` in the parser (pre-existing); rejecting them with a clear policy error would be a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
