### PR TITLE
Anthropic: preserve interleaved thinking/client-tool order on replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Anthropic: A single assistant turn that interleaves thinking with client tool calls now replays in its original order, so subsequent requests no longer fail with "thinking ... blocks in the latest assistant message cannot be modified".
 - OpenAI: Chat Completions usage now preserves prompt-cache read and write tokens for accurate cache-aware costing.
 - Scoring: `model_graded_qa`/`model_graded_fact` no longer score a malformed multi-character verdict such as `GRADE: CI` as correct; such verdicts now leave the sample unscored with `grade_parse_failure` recorded.
 - OpenAI: Fixed background responses failing on transient connection and timeout errors.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -2823,10 +2823,12 @@ async def assistant_message_block_params(
 
     # Ensure thinking blocks are not the final block in the message.
     # The API rejects messages where the last block is thinking/redacted_thinking.
-    # This can happen when the model uses its entire output budget on thinking
-    # and produces no text or tool calls.
-    if block_params and all(
-        c.get("type") in ("thinking", "redacted_thinking") for c in block_params
+    # This can happen when the model uses its entire output budget on thinking and
+    # produces no text or tool calls, or when a client tool call is spliced earlier
+    # in the turn (above) and leaves an interleaved thinking block as the last one.
+    if block_params and block_params[-1].get("type") in (
+        "thinking",
+        "redacted_thinking",
     ):
         block_params.append(TextBlockParam(type="text", text=NO_CONTENT))
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -2728,8 +2728,15 @@ async def assistant_message_block_params(
     message: ChatMessageAssistant,
 ) -> list[MessageBlockParam]:
     block_params: list[MessageBlockParam] = []
+
+    # build block params per content item ("segments") so that client tool
+    # calls can be spliced back at their original interleaved positions below.
+    segments: list[list[MessageBlockParam]] = []
+    pending_span_params: list[MessageBlockParam] = []
     if isinstance(message.content, str):
-        block_params = [TextBlockParam(type="text", text=message.content or NO_CONTENT)]
+        segments.append(
+            [TextBlockParam(type="text", text=message.content or NO_CONTENT)]
+        )
     else:
         # server tool spans recorded for this message at generate time. server
         # tool blocks are opaque server artifacts (encrypted content, caller
@@ -2743,15 +2750,17 @@ async def assistant_message_block_params(
         )
         emitted: set[int] = set()
         for content in message.content:
+            segment: list[MessageBlockParam] = []
             span = _server_tool_span_for_content(content, record)
             if span is not None:
                 # emit the whole span verbatim at the position of its first
                 # content item (subsequent items of the same span emit nothing)
                 if id(span) not in emitted:
                     emitted.add(id(span))
-                    block_params.extend(_span_block_params(span, message))
+                    segment.extend(_span_block_params(span, message))
             else:
-                block_params.extend(await message_block_params(content))
+                segment.extend(await message_block_params(content))
+            segments.append(segment)
         # a span whose results never arrived (the turn ended first, e.g. a
         # client tool call cut in) has no content item to anchor it, so the
         # loop above never emits it. it must still be replayed: the API
@@ -2760,13 +2769,42 @@ async def assistant_message_block_params(
         # content qualify -- a span whose content items were removed by a
         # scaffold edit was deleted deliberately and stays dropped. with no
         # anchor, the span lands after the content-derived blocks rather than
-        # at its original wire position (which is not recorded); the API does
-        # not require intra-message position fidelity (client tool_use blocks
-        # are likewise always re-appended last, below).
+        # at its original wire position (which is not recorded).
         for span in record or []:
             if not span.content_ids and id(span) not in emitted:
                 emitted.add(id(span))
-                block_params.extend(_span_block_params(span, message))
+                pending_span_params.extend(_span_block_params(span, message))
+
+    # splice client tool_use blocks back at their recorded interleaved
+    # positions. a call recorded at position p (p content items preceded it in
+    # the original wire order) is emitted right after the first p content items,
+    # so a `[thinking, tool_use, thinking, tool_use]` turn round-trips with its
+    # thinking blocks still separated -- front-loading them (the result of
+    # appending all tool_use blocks last) is rejected on replay with "thinking
+    # ... blocks in the latest assistant message cannot be modified". Calls with
+    # no recorded position (str content, an older log, or another system's
+    # message) default to last, preserving the historical append-last behavior.
+    content_len = len(segments)
+    tools_by_position: dict[int, list[MessageBlockParam]] = {}
+    for tool_call in message.tool_calls or []:
+        position = assistant_internal().client_tool_call_positions.get(
+            tool_call.id, content_len
+        )
+        position = min(max(position, 0), content_len)
+        internal_name = _internal_name_from_tool_call(tool_call)
+        tools_by_position.setdefault(position, []).append(
+            ToolUseBlockParam(
+                type="tool_use",
+                id=tool_call.id,
+                name=internal_name or tool_call.function,
+                input=tool_call.arguments,
+            )
+        )
+    for position, segment in enumerate(segments):
+        block_params.extend(tools_by_position.get(position, []))
+        block_params.extend(segment)
+    block_params.extend(pending_span_params)
+    block_params.extend(tools_by_position.get(content_len, []))
 
     # move the first instance of thinking to the front (we only need to do this
     # for claude 3 models as we enable interleaved thinking for claude 4)
@@ -2782,18 +2820,6 @@ async def assistant_message_block_params(
     block_params = [
         c for c in block_params if not c["type"] == "text" or len(c["text"]) > 0
     ]
-
-    # now add tools
-    for tool_call in message.tool_calls or []:
-        internal_name = _internal_name_from_tool_call(tool_call)
-        block_params.append(
-            ToolUseBlockParam(
-                type="tool_use",
-                id=tool_call.id,
-                name=internal_name or tool_call.function,
-                input=tool_call.arguments,
-            )
-        )
 
     # Ensure thinking blocks are not the final block in the message.
     # The API rejects messages where the last block is thinking/redacted_thinking.
@@ -2938,6 +2964,20 @@ class _AssistantInternal:
         default_factory=dict
     )
     tool_call_internal_names: dict[str, str | None] = field(default_factory=dict)
+    client_tool_call_positions: dict[str, int] = field(default_factory=dict)
+    """Client tool call position within its assistant message content, keyed by
+    tool use id.
+
+    The value is the number of content items (text/reasoning/server tool
+    results) that preceded the tool use in the original wire order. Recorded at
+    parse time and used by `assistant_message_block_params` to splice client
+    tool_use blocks back at their interleaved positions rather than appending
+    them last. Front-loading thinking blocks (the result of appending tool uses
+    last) is rejected on replay by the API with "thinking ... blocks in the
+    latest assistant message cannot be modified" (Claude 4+ interleaves thinking
+    with client tool calls in a single turn). Keyed by tool use id (like
+    `tool_call_internal_names`) so it survives the agent bridge and log
+    round-trip."""
     server_mcp_tool_uses: dict[
         str, tuple[BetaMCPToolUseBlockParam, BetaRequestMCPToolResultBlockParam]
     ] = field(default_factory=dict)
@@ -2983,6 +3023,9 @@ def init_sample_anthropic_assistant_internal(value: JsonValue | None = None) -> 
     )
     internal.tool_call_internal_names.update(
         cast("dict[str, str | None]", value.get("tool_call_internal_names", {}))
+    )
+    internal.client_tool_call_positions.update(
+        cast("dict[str, int]", value.get("client_tool_call_positions", {}))
     )
     internal.server_mcp_tool_uses.update(
         {
@@ -3047,6 +3090,7 @@ def dump_anthropic_assistant_internal() -> JsonValue | None:
     if not (
         internal.thinking_blocks
         or internal.tool_call_internal_names
+        or internal.client_tool_call_positions
         or internal.server_mcp_tool_uses
         or span_table
         or internal.containers
@@ -3057,6 +3101,7 @@ def dump_anthropic_assistant_internal() -> JsonValue | None:
         {
             "thinking_blocks": dict(internal.thinking_blocks),
             "tool_call_internal_names": dict(internal.tool_call_internal_names),
+            "client_tool_call_positions": dict(internal.client_tool_call_positions),
             "server_mcp_tool_uses": {
                 tool_use_id: list(use_result)
                 for tool_use_id, use_result in internal.server_mcp_tool_uses.items()
@@ -3777,6 +3822,13 @@ def content_and_tool_calls_from_assistant_content_blocks(
             (tool_name, internal_name) = _names_for_tool_call(content_block.name, tools)
             assistant_internal().tool_call_internal_names[content_block.id] = (
                 internal_name
+            )
+            # record where this client tool call sits in the content stream so
+            # the rebuild can splice it back at its interleaved position rather
+            # than front-loading the surrounding thinking blocks (see
+            # `_AssistantInternal.client_tool_call_positions`)
+            assistant_internal().client_tool_call_positions[content_block.id] = len(
+                content
             )
             tool_calls.append(
                 ToolCall(

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -2785,10 +2785,20 @@ async def assistant_message_block_params(
     # no recorded position (str content, an older log, or another system's
     # message) default to last, preserving the historical append-last behavior.
     content_len = len(segments)
+    # Positions are recorded against a single message's content list. A
+    # collapsed message (combine_messages concatenates content and tool_calls,
+    # stamping metadata["combined_from"]) invalidates those offsets -- a
+    # position from the second message would splice into the first message's
+    # items -- so collapsed messages use the historical append-last placement.
+    combined = bool(message.metadata and "combined_from" in message.metadata)
     tools_by_position: dict[int, list[MessageBlockParam]] = {}
     for tool_call in message.tool_calls or []:
-        position = assistant_internal().client_tool_call_positions.get(
-            tool_call.id, content_len
+        position = (
+            content_len
+            if combined
+            else assistant_internal().client_tool_call_positions.get(
+                tool_call.id, content_len
+            )
         )
         position = min(max(position, 0), content_len)
         internal_name = _internal_name_from_tool_call(tool_call)

--- a/src/inspect_ai/util/_checkpoint/plans/assistant-internal.md
+++ b/src/inspect_ai/util/_checkpoint/plans/assistant-internal.md
@@ -31,6 +31,7 @@ Move from `run.py:2041-2068` (delete there; update import at `run.py:1091`; keep
 {
   "thinking_blocks": {...},
   "tool_call_internal_names": {...},
+  "client_tool_call_positions": {"tool_use_id": content_position},
   "server_mcp_tool_uses": {"id": [use, result]},
   "spans": [{"blocks": [...], "content_ids": [...], "open_use_ids": [...]}],
   "server_tool_spans": {"msg_id": [span_index, ...]},

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2359,6 +2359,7 @@ async def test_anthropic_collapsed_message_ignores_recorded_positions() -> None:
         content=content, tool_calls=tool_calls, model="claude-opus-4-8"
     )
     combined = combine_messages(injected, parsed, ChatMessageAssistant)
+    assert isinstance(combined, ChatMessageAssistant)
     assert combined.metadata and "combined_from" in combined.metadata
 
     order: list[str] = [

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2182,7 +2182,7 @@ async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
         ToolInfo(name="tool_a", description="Tool A.", parameters=arg),
         ToolInfo(name="tool_b", description="Tool B.", parameters=arg),
     ]
-    interleaved = [
+    interleaved: list[ContentBlock] = [
         ThinkingBlock(type="thinking", thinking="t1", signature="sig1"),
         ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
         ThinkingBlock(type="thinking", thinking="t2", signature="sig2"),
@@ -2200,7 +2200,7 @@ async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
     message = ChatMessageAssistant(
         content=content, tool_calls=tool_calls, model="claude-opus-4-8"
     )
-    order = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
     assert order == ["thinking", "tool_use", "thinking", "tool_use"], order
     assert not thinking_blocks_adjacent(order)
 
@@ -2235,7 +2235,7 @@ async def test_anthropic_interleaved_thinking_last_gets_no_content() -> None:
 
     arg = ToolParams(properties={"x": ToolParam(type="string")}, required=["x"])
     tools = [ToolInfo(name="tool_a", description="A.", parameters=arg)]
-    blocks = [
+    blocks: list[ContentBlock] = [
         ThinkingBlock(type="thinking", thinking="t1", signature="s1"),
         ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
         ThinkingBlock(type="thinking", thinking="t2", signature="s2"),
@@ -2247,7 +2247,7 @@ async def test_anthropic_interleaved_thinking_last_gets_no_content() -> None:
     message = ChatMessageAssistant(
         content=content, tool_calls=tool_calls, model="claude-opus-4-8"
     )
-    order = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
     assert order == ["thinking", "tool_use", "thinking", "text"], order
 
 
@@ -2268,7 +2268,7 @@ async def test_anthropic_interleaved_parallel_tool_calls_grouped() -> None:
         ToolInfo(name="tool_b", description="B.", parameters=arg),
         ToolInfo(name="tool_c", description="C.", parameters=arg),
     ]
-    blocks = [
+    blocks: list[ContentBlock] = [
         ThinkingBlock(type="thinking", thinking="t1", signature="s1"),
         ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
         ToolUseBlock(type="tool_use", id="b", name="tool_b", input={"x": "2"}),
@@ -2313,5 +2313,5 @@ async def test_anthropic_unrecorded_tool_call_appended_last() -> None:
         tool_calls=[ToolCall(id="z", function="tool_a", arguments={"x": "1"})],
         model="claude-opus-4-8",
     )
-    order = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
     assert order == ["thinking", "tool_use"], order

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2213,3 +2213,103 @@ async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
     assert restored_order == ["thinking", "tool_use", "thinking", "tool_use"], (
         restored_order
     )
+
+
+async def test_anthropic_interleaved_thinking_last_gets_no_content() -> None:
+    """A turn ending in an interleaved thinking block must not end on thinking.
+
+    Splicing a client tool call earlier in the turn can leave a thinking block as
+    the final block (`[thinking, tool_use, thinking]`). The API rejects a message
+    whose last block is thinking, so a placeholder text block must be appended.
+    """
+    from anthropic.types import ThinkingBlock, ToolUseBlock
+
+    from inspect_ai.model._providers.anthropic import (
+        assistant_message_block_params,
+        content_and_tool_calls_from_assistant_content_blocks,
+        init_sample_anthropic_assistant_internal,
+    )
+    from inspect_ai.tool._tool_params import ToolParam, ToolParams
+
+    arg = ToolParams(properties={"x": ToolParam(type="string")}, required=["x"])
+    tools = [ToolInfo(name="tool_a", description="A.", parameters=arg)]
+    blocks = [
+        ThinkingBlock(type="thinking", thinking="t1", signature="s1"),
+        ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
+        ThinkingBlock(type="thinking", thinking="t2", signature="s2"),
+    ]
+    init_sample_anthropic_assistant_internal()
+    content, tool_calls = content_and_tool_calls_from_assistant_content_blocks(
+        blocks, tools
+    )
+    message = ChatMessageAssistant(
+        content=content, tool_calls=tool_calls, model="claude-opus-4-8"
+    )
+    order = [p["type"] for p in await assistant_message_block_params(message)]
+    assert order == ["thinking", "tool_use", "thinking", "text"], order
+
+
+async def test_anthropic_interleaved_parallel_tool_calls_grouped() -> None:
+    """Parallel client tool calls at one interleaved position stay grouped in order."""
+    from anthropic.types import ThinkingBlock, ToolUseBlock
+
+    from inspect_ai.model._providers.anthropic import (
+        assistant_message_block_params,
+        content_and_tool_calls_from_assistant_content_blocks,
+        init_sample_anthropic_assistant_internal,
+    )
+    from inspect_ai.tool._tool_params import ToolParam, ToolParams
+
+    arg = ToolParams(properties={"x": ToolParam(type="string")}, required=["x"])
+    tools = [
+        ToolInfo(name="tool_a", description="A.", parameters=arg),
+        ToolInfo(name="tool_b", description="B.", parameters=arg),
+        ToolInfo(name="tool_c", description="C.", parameters=arg),
+    ]
+    blocks = [
+        ThinkingBlock(type="thinking", thinking="t1", signature="s1"),
+        ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
+        ToolUseBlock(type="tool_use", id="b", name="tool_b", input={"x": "2"}),
+        ThinkingBlock(type="thinking", thinking="t2", signature="s2"),
+        ToolUseBlock(type="tool_use", id="c", name="tool_c", input={"x": "3"}),
+    ]
+    init_sample_anthropic_assistant_internal()
+    content, tool_calls = content_and_tool_calls_from_assistant_content_blocks(
+        blocks, tools
+    )
+    message = ChatMessageAssistant(
+        content=content, tool_calls=tool_calls, model="claude-opus-4-8"
+    )
+    params = await assistant_message_block_params(message)
+    assert [p["type"] for p in params] == [
+        "thinking",
+        "tool_use",
+        "tool_use",
+        "thinking",
+        "tool_use",
+    ], [p["type"] for p in params]
+    assert [p["id"] for p in params if p["type"] == "tool_use"] == ["a", "b", "c"]
+
+
+async def test_anthropic_unrecorded_tool_call_appended_last() -> None:
+    """A client tool call with no recorded interleave position falls back to last.
+
+    Messages assembled outside the Anthropic parse (another provider's history, a
+    scaffold-built message) carry no recorded position; those tool calls must land
+    after the content, matching the historical append-last behavior.
+    """
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._providers.anthropic import (
+        assistant_message_block_params,
+        init_sample_anthropic_assistant_internal,
+    )
+    from inspect_ai.tool._tool_call import ToolCall
+
+    init_sample_anthropic_assistant_internal()  # empty: no positions recorded
+    message = ChatMessageAssistant(
+        content=[ContentReasoning(summary="t1", reasoning="s1", redacted=True)],
+        tool_calls=[ToolCall(id="z", function="tool_a", arguments={"x": "1"})],
+        model="claude-opus-4-8",
+    )
+    order = [p["type"] for p in await assistant_message_block_params(message)]
+    assert order == ["thinking", "tool_use"], order

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2150,6 +2150,8 @@ async def test_anthropic_nonempty_thinking_counts_reasoning_tokens() -> None:
     assert len(client.calls) == 1
     assert output.usage is not None
     assert output.usage.reasoning_tokens == 42
+
+
 async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
     """Interleaved thinking and client tool calls must survive a parse/rebuild.
 

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2167,7 +2167,7 @@ async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
     This is a pure structural test (constructed blocks, placeholder signatures, no
     network): the check is on block ORDER, so signature validity is irrelevant.
     """
-    from anthropic.types import ThinkingBlock, ToolUseBlock
+    from anthropic.types import ContentBlock, ThinkingBlock, ToolUseBlock
 
     from inspect_ai.model._providers.anthropic import (
         assistant_message_block_params,
@@ -2200,7 +2200,9 @@ async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
     message = ChatMessageAssistant(
         content=content, tool_calls=tool_calls, model="claude-opus-4-8"
     )
-    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [
+        p["type"] for p in await assistant_message_block_params(message)
+    ]
     assert order == ["thinking", "tool_use", "thinking", "tool_use"], order
     assert not thinking_blocks_adjacent(order)
 
@@ -2224,7 +2226,7 @@ async def test_anthropic_interleaved_thinking_last_gets_no_content() -> None:
     the final block (`[thinking, tool_use, thinking]`). The API rejects a message
     whose last block is thinking, so a placeholder text block must be appended.
     """
-    from anthropic.types import ThinkingBlock, ToolUseBlock
+    from anthropic.types import ContentBlock, ThinkingBlock, ToolUseBlock
 
     from inspect_ai.model._providers.anthropic import (
         assistant_message_block_params,
@@ -2247,13 +2249,15 @@ async def test_anthropic_interleaved_thinking_last_gets_no_content() -> None:
     message = ChatMessageAssistant(
         content=content, tool_calls=tool_calls, model="claude-opus-4-8"
     )
-    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [
+        p["type"] for p in await assistant_message_block_params(message)
+    ]
     assert order == ["thinking", "tool_use", "thinking", "text"], order
 
 
 async def test_anthropic_interleaved_parallel_tool_calls_grouped() -> None:
     """Parallel client tool calls at one interleaved position stay grouped in order."""
-    from anthropic.types import ThinkingBlock, ToolUseBlock
+    from anthropic.types import ContentBlock, ThinkingBlock, ToolUseBlock
 
     from inspect_ai.model._providers.anthropic import (
         assistant_message_block_params,
@@ -2313,5 +2317,56 @@ async def test_anthropic_unrecorded_tool_call_appended_last() -> None:
         tool_calls=[ToolCall(id="z", function="tool_a", arguments={"x": "1"})],
         model="claude-opus-4-8",
     )
-    order: list[str] = [p["type"] for p in await assistant_message_block_params(message)]
+    order: list[str] = [
+        p["type"] for p in await assistant_message_block_params(message)
+    ]
     assert order == ["thinking", "tool_use"], order
+
+
+async def test_anthropic_collapsed_message_ignores_recorded_positions() -> None:
+    """A collapsed assistant message falls back to append-last tool placement.
+
+    `combine_messages` concatenates two messages' content and tool_calls, so a
+    position recorded against the second message's content would splice its
+    tool_use into the first message's items. Positions are only meaningful
+    within the message they were recorded against: a message carrying
+    `combined_from` metadata must use the historical append-last placement.
+    """
+    from anthropic.types import ContentBlock, ThinkingBlock, ToolUseBlock
+
+    from inspect_ai.model._model import combine_messages
+    from inspect_ai.model._providers.anthropic import (
+        assistant_message_block_params,
+        content_and_tool_calls_from_assistant_content_blocks,
+        init_sample_anthropic_assistant_internal,
+    )
+    from inspect_ai.tool._tool_params import ToolParam, ToolParams
+
+    arg = ToolParams(properties={"x": ToolParam(type="string")}, required=["x"])
+    tools = [ToolInfo(name="tool_a", description="Tool A.", parameters=arg)]
+    wire: list[ContentBlock] = [
+        ThinkingBlock(type="thinking", thinking="t1", signature="sig1"),
+        ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
+        ThinkingBlock(type="thinking", thinking="t2", signature="sig2"),
+    ]
+
+    init_sample_anthropic_assistant_internal()
+    content, tool_calls = content_and_tool_calls_from_assistant_content_blocks(
+        wire, tools
+    )
+    injected = ChatMessageAssistant(content="I'll check.", model="claude-opus-4-8")
+    parsed = ChatMessageAssistant(
+        content=content, tool_calls=tool_calls, model="claude-opus-4-8"
+    )
+    combined = combine_messages(injected, parsed, ChatMessageAssistant)
+    assert combined.metadata and "combined_from" in combined.metadata
+
+    order: list[str] = [
+        p["type"] for p in await assistant_message_block_params(combined)
+    ]
+    # recorded position 1 is relative to the parsed message alone; in the
+    # combined message it would land the tool_use inside the injected text.
+    # Appended last (with thinking blocks front-loaded by the fallback) is the
+    # historical, deterministic behavior.
+    assert order[-1] == "tool_use", order
+    assert order[0] == "text", order

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -2150,3 +2150,66 @@ async def test_anthropic_nonempty_thinking_counts_reasoning_tokens() -> None:
     assert len(client.calls) == 1
     assert output.usage is not None
     assert output.usage.reasoning_tokens == 42
+async def test_anthropic_interleaved_thinking_tool_calls_preserved() -> None:
+    """Interleaved thinking and client tool calls must survive a parse/rebuild.
+
+    A `[thinking, tool_use, thinking, tool_use]` turn must round-trip through
+    parse -> ChatMessageAssistant -> rebuild with its thinking blocks still
+    separated by their client tool calls -- not front-loaded and made adjacent.
+
+    Claude 4+ interleaves thinking with client tool calls in a single turn. Parse
+    routes thinking into `.content` but client tool calls into the separate
+    `.tool_calls` list; rebuilding by appending all tool_use blocks last produces
+    `[thinking, thinking, tool_use, tool_use]`, which the API rejects on replay
+    with "thinking ... blocks in the latest assistant message cannot be modified".
+    This is a pure structural test (constructed blocks, placeholder signatures, no
+    network): the check is on block ORDER, so signature validity is irrelevant.
+    """
+    from anthropic.types import ThinkingBlock, ToolUseBlock
+
+    from inspect_ai.model._providers.anthropic import (
+        assistant_message_block_params,
+        content_and_tool_calls_from_assistant_content_blocks,
+        dump_anthropic_assistant_internal,
+        init_sample_anthropic_assistant_internal,
+    )
+    from inspect_ai.tool._tool_params import ToolParam, ToolParams
+
+    arg = ToolParams(properties={"x": ToolParam(type="string")}, required=["x"])
+    tools = [
+        ToolInfo(name="tool_a", description="Tool A.", parameters=arg),
+        ToolInfo(name="tool_b", description="Tool B.", parameters=arg),
+    ]
+    interleaved = [
+        ThinkingBlock(type="thinking", thinking="t1", signature="sig1"),
+        ToolUseBlock(type="tool_use", id="a", name="tool_a", input={"x": "1"}),
+        ThinkingBlock(type="thinking", thinking="t2", signature="sig2"),
+        ToolUseBlock(type="tool_use", id="b", name="tool_b", input={"x": "2"}),
+    ]
+
+    def thinking_blocks_adjacent(order: list[str]) -> bool:
+        idx = [i for i, t in enumerate(order) if t in ("thinking", "redacted_thinking")]
+        return any(b == a + 1 for a, b in zip(idx, idx[1:]))
+
+    init_sample_anthropic_assistant_internal()
+    content, tool_calls = content_and_tool_calls_from_assistant_content_blocks(
+        interleaved, tools
+    )
+    message = ChatMessageAssistant(
+        content=content, tool_calls=tool_calls, model="claude-opus-4-8"
+    )
+    order = [p["type"] for p in await assistant_message_block_params(message)]
+    assert order == ["thinking", "tool_use", "thinking", "tool_use"], order
+    assert not thinking_blocks_adjacent(order)
+
+    # the interleaving must survive a serialize/restore of the assistant internal
+    # (the position record round-trips like the rest of the internal state, e.g.
+    # when a sample is resumed from a log on a later turn)
+    dumped = dump_anthropic_assistant_internal()
+    assert dumped is not None
+    init_sample_anthropic_assistant_internal()  # reset
+    init_sample_anthropic_assistant_internal(dumped)  # restore
+    restored_order = [p["type"] for p in await assistant_message_block_params(message)]
+    assert restored_order == ["thinking", "tool_use", "thinking", "tool_use"], (
+        restored_order
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

When a Claude response interleaves thinking with **client** tool calls in a single assistant turn — wire order `[thinking, tool_use, thinking, tool_use]`, which Claude 4+ produces via interleaved thinking — the Anthropic provider loses the interleaving on replay:

- Parse (`content_and_tool_calls_from_assistant_content_blocks`) routes thinking blocks into `ChatMessageAssistant.content` but client tool calls into the separate `.tool_calls` list, discarding their relative order.
- Rebuild (`assistant_message_block_params`) emits all content blocks first, then appends every tool call last — producing `[thinking, thinking, tool_use, tool_use]` (thinking front-loaded and now adjacent).

On the next request the API rejects the reordered latest assistant message:

```
400 messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were in
the original response.
```

It shows up in long agentic/multi-turn rollouts where the model occasionally emits 2+ thinking blocks around its tool calls in one turn; that sample then errors. (Server tool calls are already order-preserved via `ContentToolUse` markers in `.content`; client tool calls were the gap.)

### What is the new behavior?

Interleaved thinking/client-tool order is preserved across parse → rebuild, so the replayed turn matches the original response and the API accepts it.

Approach — provider-local, no change to the shared `.content`/`.tool_calls` contract:
- Parse records `client_tool_call_positions[tool_use_id] = len(content-so-far)` on the Anthropic `_AssistantInternal` (keyed by tool-use id like the existing `tool_call_internal_names`; dumped/restored with the rest of the internal state, so it survives the log/checkpoint round-trip and the agent bridge).
- Rebuild splices each client `tool_use` back in after its recorded number of content items instead of appending last. Unrecorded or out-of-range positions fall back to append-last — byte-for-byte the previous behavior, so it is a no-op for the common single-thinking-block turn and for messages built outside the Anthropic parse.

### Does this PR introduce a breaking change?

No. The change is confined to the Anthropic provider's serialization. `.content` and `.tool_calls` are structurally unchanged, so other providers, transcript rendering, token counting, and log schema are unaffected. The serialized assistant-internal gains one backward-compatible JSON key (old logs restore fine via a default; older readers ignore the extra key).

### Other information:

Regression test in `tests/model/providers/test_anthropic.py`: a pure structural test (constructed blocks, placeholder signatures, no network) asserting `[thinking, tool_use, thinking, tool_use]` round-trips through the real parse → rebuild without the thinking blocks being front-loaded, plus a dump/restore round-trip and cases for the thinking-last guard, parallel client tool calls at an interleaved position, and the unrecorded-position fallback. It fails before the fix (`[thinking, thinking, tool_use, tool_use]`) and passes after.

Checks run in the dev environment: `tests/model/providers/test_anthropic.py` → 131 passed, 56 skipped (API/trio-gated), 1 failed — `test_anthropic_oauth_beta_preserved_with_effort`, a pre-existing `INSPECT_TELEMETRY` prerequisite that fails identically on `main`, unrelated to this change. `mypy`, `ruff check`, and `ruff format --check` are clean on the changed files. Full `make check` could not complete in this environment (missing optional-dependency stubs for `acp`/`textual`, unrelated to this change); the full gate is left to CI.

Agent involvement: this PR was prepared by an AI agent (Claude).

### Agent review
- Reviewer: Claude Fable 5 (fresh context, different model from the author), 1 pass, read-only over the diff and surrounding provider code.
- Findings: 2 acted on — (1) hardened the "thinking can't be the last block" guard to check the final block rather than whether *every* block is thinking, because splicing a client tool call earlier can newly leave an interleaved thinking block last; added a test. (2) Added belt-and-braces tests for parallel client tool calls at an interleaved position and the unrecorded-position append-last fallback. Verdict: ship-as-is. It independently rejected the alternative of giving client tool calls a positional `ContentToolUse` in `.content` (would widen the public `ContentToolUse.tool_type` log-schema literal and double-represent calls that must remain in `.tool_calls` for execution).
