### PR TITLE
Run sandbox tools under per-user servers

### DIFF
--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -172,15 +172,15 @@ async def _extract_tools_tree(
     cached in the binaries dir so we decompress at most once per artifact.
     """
     gz_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tgz"
-    # Stage as the extracting user so the later `rm` owns the file: /var/tmp is
-    # sticky, so deleting another user's file there requires CAP_FOWNER.
-    await sandbox.write_file(gz_tmp, gz_bytes, user=user)
+    await sandbox.write_file(gz_tmp, gz_bytes)
     # -o (--no-same-owner) so extraction as root does not chown to the archive's
     # uids, which fails in capability-dropped sandboxes lacking CAP_CHOWN.
     result = await sandbox.exec(
         ["tar", "xzof", gz_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
     )
-    await sandbox.exec(["rm", "-f", gz_tmp], user=user)
+    # Remove as the default user (the one write_file wrote as): /var/tmp is
+    # sticky, so deleting another user's file there requires CAP_FOWNER.
+    await sandbox.exec(["rm", "-f", gz_tmp])
     if result.success:
         return
 
@@ -191,11 +191,11 @@ async def _extract_tools_tree(
         f"tar xzf failed ({result.stderr.strip()}); retrying with uncompressed tar",
     )
     tar_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tar"
-    await sandbox.write_file(tar_tmp, _uncompressed_tar_bytes(name, gz_bytes), user=user)
+    await sandbox.write_file(tar_tmp, _uncompressed_tar_bytes(name, gz_bytes))
     result = await sandbox.exec(
         ["tar", "xof", tar_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
     )
-    await sandbox.exec(["rm", "-f", tar_tmp], user=user)
+    await sandbox.exec(["rm", "-f", tar_tmp])
     if not result.success:
         raise RuntimeError(f"Failed to extract sandbox tools: {result.stderr}")
 

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -115,21 +115,21 @@ async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
 
         await _extract_tools_tree(sandbox, name, gz_bytes, sandbox._tools_user)
 
-        # When running as root, restrict the tree so the agent can neither read nor
-        # execute the tools. The default user (the one that runs `exec`) is root, so
-        # this does not impede tool calls.
+        # When running as root, make the tree root-owned and read-only for other
+        # users, but keep it world-executable: non-root users run the CLI (and
+        # their own servers) directly, so the tree cannot be fully hidden.
         if sandbox._tools_user == "root":
             result = await sandbox.exec(
-                ["chmod", "700", SANDBOX_TOOLS_DIR], user="root"
+                ["chmod", "-R", "a+rX,go-w", SANDBOX_TOOLS_DIR], user="root"
             )
             if not result.success:
                 raise RuntimeError(
                     f"Failed to chmod sandbox tools dir: {result.stderr}"
                 )
 
-        # Start the server as root so it can setuid to any user for exec_remote.
-        # If root isn't available, fall back to the sandbox's default user —
-        # user-switching will be disabled (auto-detected by the server).
+        # Start the default server as the tools user (root when available, else
+        # the sandbox's default user). Commands for other users run under
+        # per-user servers started lazily by the CLI on first use.
         result = await sandbox.exec(
             [SANDBOX_CLI, "start-server"], user=sandbox._tools_user
         )
@@ -172,9 +172,13 @@ async def _extract_tools_tree(
     cached in the binaries dir so we decompress at most once per artifact.
     """
     gz_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tgz"
-    await sandbox.write_file(gz_tmp, gz_bytes)
+    # Stage as the extracting user so the later `rm` owns the file: /var/tmp is
+    # sticky, so deleting another user's file there requires CAP_FOWNER.
+    await sandbox.write_file(gz_tmp, gz_bytes, user=user)
+    # -o (--no-same-owner) so extraction as root does not chown to the archive's
+    # uids, which fails in capability-dropped sandboxes lacking CAP_CHOWN.
     result = await sandbox.exec(
-        ["tar", "xzf", gz_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
+        ["tar", "xzof", gz_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
     )
     await sandbox.exec(["rm", "-f", gz_tmp], user=user)
     if result.success:
@@ -187,9 +191,9 @@ async def _extract_tools_tree(
         f"tar xzf failed ({result.stderr.strip()}); retrying with uncompressed tar",
     )
     tar_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tar"
-    await sandbox.write_file(tar_tmp, _uncompressed_tar_bytes(name, gz_bytes))
+    await sandbox.write_file(tar_tmp, _uncompressed_tar_bytes(name, gz_bytes), user=user)
     result = await sandbox.exec(
-        ["tar", "xf", tar_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
+        ["tar", "xof", tar_tmp, "-C", SANDBOX_TOOLS_DIR], user=user
     )
     await sandbox.exec(["rm", "-f", tar_tmp], user=user)
     if not result.success:

--- a/src/inspect_ai/tool/_tools/_bash_session.py
+++ b/src/inspect_ai/tool/_tools/_bash_session.py
@@ -208,7 +208,7 @@ def bash_session(
                         transport=transport,
                         error_mapper=SandboxToolsErrorMapper,
                         timeout=TRANSPORT_TIMEOUT,
-                        user=sandbox._tools_user,
+                        user=user or sandbox._tools_user,
                     )
                 ).session_name
             except TimeoutError:
@@ -234,7 +234,7 @@ def bash_session(
             transport=transport,
             error_mapper=SandboxToolsErrorMapper,
             timeout=timeout,
-            user=sandbox._tools_user,
+            user=user or sandbox._tools_user,
         )
 
         # Return the appropriate response

--- a/src/inspect_ai/tool/_tools/_text_editor.py
+++ b/src/inspect_ai/tool/_tools/_text_editor.py
@@ -122,10 +122,7 @@ def text_editor(timeout: int | None = None, user: str | None = None) -> Tool:
             if k in inspect.signature(execute).parameters
         }
 
-        # Pass user via reserved param for CLI-side setuid (in-process tool)
-        if user is not None:
-            params["_run_as_user"] = user
-
+        # Run the CLI directly as the requested user (in-process tool)
         return await exec_scalar_request(
             method="text_editor",
             params=params,
@@ -133,7 +130,7 @@ def text_editor(timeout: int | None = None, user: str | None = None) -> Tool:
             transport=SandboxJSONRPCTransport(sandbox, SANDBOX_CLI),
             error_mapper=SandboxToolsErrorMapper,
             timeout=timeout,
-            user=sandbox._tools_user,
+            user=user or sandbox._tools_user,
         )
 
     return execute

--- a/src/inspect_ai/util/_sandbox/_cli.py
+++ b/src/inspect_ai/util/_sandbox/_cli.py
@@ -15,8 +15,8 @@ We choose /var/tmp as the injection location since:
 
 We additionally choose a dot-prefixed random hash sub-directory to further
 attempt to prevent LLMs from stumbling on the injected tools. When root is
-available, the extracted tree is later chmod'ed to 0755 so it is root-owned (and
-not writable by other users) while remaining executable by per-user servers.
+available, the extracted tree is later chmod'ed a+rX,go-w so it is root-owned
+(and not writable by other users) while remaining executable by per-user servers.
 """
 
 # Also defined in inspect_ai.tool._sandbox_tools_utils._build_config — keep in sync.

--- a/src/inspect_ai/util/_sandbox/_cli.py
+++ b/src/inspect_ai/util/_sandbox/_cli.py
@@ -15,8 +15,8 @@ We choose /var/tmp as the injection location since:
 
 We additionally choose a dot-prefixed random hash sub-directory to further
 attempt to prevent LLMs from stumbling on the injected tools. When root is
-available, the extracted tree is later chmod'ed to 0700 so only the tools user can
-access it.
+available, the extracted tree is later chmod'ed to 0755 so it is root-owned (and
+not writable by other users) while remaining executable by per-user servers.
 """
 
 # Also defined in inspect_ai.tool._sandbox_tools_utils._build_config — keep in sync.
@@ -25,3 +25,10 @@ SANDBOX_TOOLS_BASE_NAME = "inspect-sandbox-tools"
 SANDBOX_TOOLS_DIR = "/var/tmp/.da7be258e003d428"
 
 SANDBOX_CLI = f"{SANDBOX_TOOLS_DIR}/{SANDBOX_TOOLS_BASE_NAME}"
+
+# Also defined in inspect_sandbox_tools._util.constants — keep in sync.
+SANDBOX_TOOLS_SERVER_DIR_ENV = "INSPECT_SANDBOX_TOOLS_DIR"
+
+
+def sandbox_tools_server_dir(user: str) -> str:
+    return f"/tmp/sandbox-tools-{user}"

--- a/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
+++ b/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
@@ -20,7 +20,11 @@ from inspect_ai._util._json_rpc import (
 if TYPE_CHECKING:
     from .environment import SandboxEnvironment
 
-from ._cli import SANDBOX_CLI
+from ._cli import (
+    SANDBOX_CLI,
+    SANDBOX_TOOLS_SERVER_DIR_ENV,
+    sandbox_tools_server_dir,
+)
 from .limits import SandboxEnvironmentLimits
 
 _JSON_RPC_RESPONSE_CHUNK_METHOD = "__inspect_json_rpc_response_chunk__"
@@ -113,6 +117,19 @@ class SandboxJSONRPCTransport(JSONRPCTransport):
             if max_response_bytes is not None
             else None
         )
+        # A non-default user gets its own server directory, and thus its own
+        # server started lazily by the CLI already running as that user. This
+        # keeps per-user execution working without CAP_SETUID in the sandbox.
+        user = transport_extra_args.get("user", None)
+        if (
+            self.cli == SANDBOX_CLI
+            and user is not None
+            and user != self.sandbox._tools_user
+        ):
+            env = {
+                **(env or {}),
+                SANDBOX_TOOLS_SERVER_DIR_ENV: sandbox_tools_server_dir(user),
+            }
         exec_result = await self.sandbox.exec(
             [self.cli, "exec"],
             input=request,

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -383,7 +383,9 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         return exec_result
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self, file: str, contents: str | bytes, user: str | None = None
+    ) -> None:
         # defualt timeout for write_file operations
         TIMEOUT = 600
 
@@ -393,7 +395,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         # ensure that the directory exists
         parent = Path(file).parent.as_posix()
         if parent != ".":
-            result = await self.exec(["mkdir", "-p", parent])
+            result = await self.exec(["mkdir", "-p", parent], user=user)
             if not result.success:
                 msg = f"Failed to create container directory {parent}: {result.stderr}"
                 raise RuntimeError(msg)
@@ -410,6 +412,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                     file,
                 ],
                 input=contents,
+                user=user,
                 timeout=TIMEOUT,
             )
         else:
@@ -424,6 +427,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                     file,
                 ],
                 input=base64_contents,
+                user=user,
                 timeout=TIMEOUT,
             )
         if result.returncode != 0:

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -193,7 +193,8 @@ class SandboxEnvironment(abc.ABC):
           contents: Text or binary file contents.
           user: Optional username or UID to write the file as, so the file
             (and any created parent directories) are owned by that user.
-            Defaults to the sandbox's default user.
+            Defaults to the sandbox's default user. Support is
+            provider-specific.
 
         Raises:
           TimeoutError: If the operation times out.

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -179,7 +179,9 @@ class SandboxEnvironment(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self, file: str, contents: str | bytes, user: str | None = None
+    ) -> None:
         """Write a file into the sandbox environment.
 
         If the parent directories of the file path do not exist they
@@ -189,6 +191,9 @@ class SandboxEnvironment(abc.ABC):
           file: Path to file (relative file paths will resolve to the
             per-sample working directory).
           contents: Text or binary file contents.
+          user: Optional username or UID to write the file as, so the file
+            (and any created parent directories) are owned by that user.
+            Defaults to the sandbox's default user.
 
         Raises:
           TimeoutError: If the operation times out.

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -138,7 +138,9 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
         )
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self, file: str, contents: str | bytes, user: str | None = None
+    ) -> None:
         from inspect_ai.event._sandbox import SandboxEvent
         from inspect_ai.log._transcript import transcript
 
@@ -146,7 +148,7 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
 
         # make call
         try:
-            await self._sandbox.write_file(file, contents)
+            await self._sandbox.write_file(file, contents, user=user)
         except TimeoutError as ex:
             raise SandboxTimeoutError(str(ex)) from ex
 

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -146,9 +146,13 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
 
         timestamp = datetime.now(timezone.utc)
 
-        # make call
+        # make call (pass user only when requested so providers that predate
+        # the parameter keep working)
         try:
-            await self._sandbox.write_file(file, contents, user=user)
+            if user is None:
+                await self._sandbox.write_file(file, contents)
+            else:
+                await self._sandbox.write_file(file, contents, user=user)
         except TimeoutError as ex:
             raise SandboxTimeoutError(str(ex)) from ex
 

--- a/src/inspect_ai/util/_sandbox/exec_remote.py
+++ b/src/inspect_ai/util/_sandbox/exec_remote.py
@@ -281,11 +281,12 @@ class ExecRemoteProcess:
             timeout=RPC_TIMEOUT
             if self._options.poll_timeout is None
             else self._options.poll_timeout,
-            # Run the CLI wrapper as the same user that started the server.
-            # When root is available, this is "root" (needed to access the
-            # protected server directory at /tmp/sandbox-tools/, mode 0o700).
-            # When root isn't available, this is None (sandbox default user).
-            user=self._sandbox._tools_user,
+            # Run the CLI wrapper as the requested user so the job runs under
+            # that user's own server (no setuid required). With no requested
+            # user, fall back to the tools user: "root" when root is available
+            # (needed to access the protected server directory at
+            # /tmp/sandbox-tools/, mode 0o700), else None (sandbox default user).
+            user=self._options.user or self._sandbox._tools_user,
             concurrency=self._options.concurrency,
         )
         if self._options.poll_timeout_retry is not None:

--- a/src/inspect_ai/util/_sandbox/local.py
+++ b/src/inspect_ai/util/_sandbox/local.py
@@ -128,7 +128,15 @@ class LocalSandboxEnvironment(SandboxEnvironment):
             )
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self, file: str, contents: str | bytes, user: str | None = None
+    ) -> None:
+        if user is not None:
+            warnings.warn(
+                "The 'user' parameter is ignored in LocalSandboxEnvironment. Files will be written as the current user.",
+                UserWarning,
+            )
+
         # resolve file and ensure the parent dir exists
         file = self._resolve_file(file)
         Path(file).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Drafted by Fable 5

## Description

Sandboxes that drop Linux capabilities (`cap_drop: ALL` in compose) cannot use per-user execution today: the sandbox-tools server starts as root and setuids per command, which needs CAP_SETUID/CAP_SETGID, and killing a job it spawned for another user needs CAP_KILL.

Now each requested user gets their own sandbox-tools server. The CLI is exec'd as that user through the provider's own user switching (`docker exec --user`, which sets credentials from outside the container) with a per-user server directory, so the server, its jobs, and its kills all run under one uid and no capability is needed. `text_editor` runs the CLI directly as the requested user (replacing its CLI-side setuid), while `bash_session` and `exec_remote` route to the requested user's server. The in-container binary is unchanged: it already starts its server in the directory named by `INSPECT_SANDBOX_TOOLS_DIR` on first use, and skips user switching when the requested user is the current one.

Also:

- `write_file()` takes an optional `user`, so files written by the host (and any created parent directories) are owned by that user. Implemented for Docker; the local sandbox warns and ignores it, and the keyword is only forwarded to a provider when a caller passes it, so third-party providers that predate the parameter keep working.
- Tools-tree extraction passes `-o` (`--no-same-owner`) so tar running as root does not chown to the archive's uids (needs CAP_CHOWN), and the staged tarball is removed by the same default user that wrote it, since deleting another user's file from sticky `/var/tmp` needs CAP_FOWNER.
- The injected tree is chmod'd `a+rX,go-w` instead of `700`, since non-root users now execute the CLI directly. It stays root-owned and unwritable by other users, but is no longer hidden from them.

## How has this been tested?

One-sample eval against a Docker compose sandbox with `user: user` and `cap_drop: ALL` (no cap_add): exec as the default user, root, and a third user; `CapEff` verified all-zero; `write_file` ownership as default user and as root; `text_editor` and `bash_session` as a non-root user; `exec_remote` as root and as two different users concurrently (two per-user servers coexisting); and `kill()` of a running user job. The same checks pass against a default root Docker sandbox (no `user:`, default capabilities).

## Does this PR introduce a breaking change?

No.
