### PR TITLE
fix: strip Windows log prefixes from manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Sandbox: Editable installs now avoid spurious `-dev` sandbox-tools binaries when local main refs are missing, stale, or unavailable.
+- Eval Log: Log directory manifests now strip Windows-style directory prefixes before normalizing paths, avoiding parent directories in bundled listings.
 - Sandboxes: The HTTP proxy example now disables container network egress, preventing agents from bypassing mitmproxy by ignoring proxy environment variables.
 - Sandboxes: The evals-in-eval example now uses rootless Docker-in-Docker and warns that its privileged sidecar is unsuitable for adversarial agents.
 - Sandbox: Recognized Docker failures to run a command (stopped container; missing or unlaunchable timeout wrapper) now surface as tool errors of type `sandbox_unavailable` rather than as command output; non-tool callers (e.g. scorers) get a `SandboxUnavailableError` or `PermissionError` raise. (#4709)

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -1088,7 +1088,7 @@ def read_eval_log_samples(
 def manifest_eval_log_name(info: EvalLogInfo, log_dir: str, sep: str) -> str:
     # ensure that log dir has a trailing seperator
     if not log_dir.endswith(sep):
-        log_dir = f"{log_dir}/"
+        log_dir = f"{log_dir}{sep}"
 
     # slice off log_dir from the front
     log = info.name.replace(log_dir, "")

--- a/tests/log/test_list_logs.py
+++ b/tests/log/test_list_logs.py
@@ -7,13 +7,45 @@ import pytest
 
 from inspect_ai._util.file import filesystem
 from inspect_ai.log import list_eval_logs, list_eval_logs_async
-from inspect_ai.log._file import _walk_without_detail
+from inspect_ai.log._file import (
+    EvalLogInfo,
+    _walk_without_detail,
+    manifest_eval_log_name,
+)
 
 file = Path(__file__)
 
 log_dir = join(dirname(file), "test_list_logs")
 
 ignored_files = ["ignore.json"]
+
+
+def test_manifest_eval_log_name_uses_filesystem_separator() -> None:
+    info = EvalLogInfo(
+        name="logs\\2024-01-01_task.eval",
+        type="file",
+        size=100,
+        mtime=1.0,
+        task="task",
+        task_id="1",
+        suffix=None,
+    )
+
+    assert manifest_eval_log_name(info, "logs", "\\") == "2024-01-01_task.eval"
+
+
+def test_manifest_eval_log_name_normalizes_manifest_separator() -> None:
+    info = EvalLogInfo(
+        name="logs/subdir/2024-01-01_task.eval",
+        type="file",
+        size=100,
+        mtime=1.0,
+        task="task",
+        task_id="1",
+        suffix=None,
+    )
+
+    assert manifest_eval_log_name(info, "logs", "/") == "subdir/2024-01-01_task.eval"
 
 
 def test_list_logs():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`manifest_eval_log_name()` accepts the filesystem separator as `sep`, but when it needs to add a trailing separator to `log_dir`, it hardcodes `/`. With Windows-style separators, this prevents the log directory prefix from being stripped before manifest paths are normalized.

Fixes #4647.

### What is the new behavior?

- `manifest_eval_log_name()` appends the caller-provided filesystem separator when preparing `log_dir`.
- Windows-style names such as `logs\2024-01-01_task.eval` now strip the `logs\` prefix correctly.
- Manifest keys continue to normalize to `/` because manifests are web artifacts.
- Added an `Unreleased` changelog entry for the manifest behavior fix.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This fixes manifest relative names for non-slash filesystem separators while preserving forward-slash manifest output.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/log/test_list_logs.py::test_manifest_eval_log_name_uses_filesystem_separator tests/log/test_list_logs.py::test_manifest_eval_log_name_normalizes_manifest_separator -v`
    - Passed. Covers the reported backslash prefix case and existing forward-slash manifest normalization.
- Adjacent:
  - `uv run pytest tests/log/test_list_logs.py -v`
    - Passed: 14 passed, 7 skipped. Exercises the surrounding log-listing behavior.
- Static:
  - `uv run make check`
    - Passed: ruff, ruff format, and mypy.
- Full suite:
  - `uv run make test`
    - Attempted. The run hit an unrelated `tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans` failure.
  - `uv run pytest tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans -q`
    - Passed on rerun, matching a flaky/unrelated failure rather than this manifest helper change.
- Git hooks:
  - Pre-commit and pre-push hooks passed.

CI/CD coverage expected:
- Standard Build and Test workflows should rerun ruff, mypy, packaging, and Python test coverage.

### Agent review
- AI assistance was used for implementation and pre-PR review. I reviewed and tested the final diff.
- Reviewer: frontier-class GPT coding model, fresh read-only context, 1 pass.
- Findings: 0 blockers, 0 major, 0 minor. The review confirmed the separator fix matches the issue, manifest keys still normalize to `/`, tests cover the reported case, and the changelog entry is under `Unreleased`.
