### PR TITLE
Cut ~70s off PR test runs by rebalancing xdist workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,14 @@ convention = "google"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-rA --doctest-modules --color=yes"
+# --dist worksteal, not xdist's default load: load hands each worker a large
+# contiguous slice of the collection up front, and collection is file-ordered,
+# so cost clusters travel as a unit and one worker can end up holding the
+# eval-set and _control integration files while its peers go idle. Measured on
+# a 4-worker CI runner: 4 of 10 legs stranded 76-80s on a single worker.
+# worksteal lets an idle worker take pending tests back off a straggler.
+# No effect unless the run is distributed (-n); see design/ci-perf/report.md.
+addopts = "-rA --doctest-modules --color=yes --dist worksteal"
 testpaths = ["tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 norecursedirs = [


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The PR-gate `test` job runs pytest with 4 xdist workers (since #4935). xdist's
default `--dist load` hands each worker a large contiguous slice of the
collection up front, and collection is file-ordered, so cost clusters travel as
a unit — one worker can end up holding several of the expensive integration
files while its peers go idle.

Measured from the `test-report-log.jsonl` artifacts of all five Build runs that
have run with 4 workers so far (10 matrix legs, 13,245–13,250 tests each). Per
leg: each worker's busy time, the leg's average (its ideal per-worker share),
and the resulting imbalance.

| Run | Leg | worker busy times | max | leg avg | imbalance | test-phase wall |
|---|---|---|---|---|---|---|
| 32229091541 | 3.10 | 161 / **266** / 155 / 163 | 266s | 186s | **+80s** | 271s |
| 32229091541 | 3.11 | 182 / 182 / 181 / 213 | 213s | 189s | +23s | 218s |
| 32229392189 | 3.10 | 153 / **256** / 151 / 156 | 256s | 179s | **+77s** | 261s |
| 32229392189 | 3.11 | 171 / 175 / 200 / 212 | 212s | 190s | +23s | 219s |
| 32232439402 | 3.10 | 180 / 212 / 178 / 179 | 212s | 187s | +25s | 218s |
| 32232439402 | 3.11 | 222 / 175 / 220 / 175 | 222s | 198s | +24s | 224s |
| 32232447154 | 3.10 | 204 / 185 / 189 / 189 | 204s | 192s | +12s | 211s |
| 32232447154 | 3.11 | 146 / 149 / 145 / **248** | 248s | 172s | **+76s** | 254s |
| 32232453887 | 3.10 | 174 / 155 / **259** / 145 | 259s | 183s | **+76s** | 265s |
| 32232453887 | 3.11 | 184 / 204 / 194 / 188 | 204s | 192s | +12s | 209s |

**4 of 10 legs stranded 76–80s on a single worker.** The straggler in
32229091541/3.10 was one worker holding `test_eval_set.py` (49s) *and*
`test_sample_limits.py` (32s) *and* `test_cancellation_logging.py` (10s), while
the worker that finished 111s earlier had drawn the cheap `agent/deepagent` and
`model` directories.

A Build run waits for the slower of its two matrix legs, so the recoverable wall
clock per run is `max(leg wall) − leg avg`: **81s, 71s, 26s, 62s, 73s** across
the five runs — **median 71s**.

### What is the new behavior?

`--dist worksteal` is added to the pytest `addopts` in `pyproject.toml`. It lets
an idle worker take pending tests back off a straggler instead of waiting for it.

Measured locally on a runner identical to CI's (4 logical / 2 physical vCPU,
15GB, xdist 3.8.0), full suite, same command CI uses. All five runs produced
identical results — 9,446 passed / 3,799 skipped / 0 failed:

| Arm | worker busy times | max | leg avg | imbalance | test-phase wall | worker efficiency |
|---|---|---|---|---|---|---|
| `load` (current), run 1 | 200 / 202 / 243 / 240 | 243s | 221s | +22s (+10%) | 251s | 88% |
| `load` (current), run 2 | 196 / **305** / 193 / 195 | 305s | 222s | **+83s (+37%)** | 310s | 72% |
| `worksteal`, run 1 | 230 / 216 / 222 / 232 | 232s | 225s | +7s (+3%) | 234s | **96%** |
| `worksteal`, run 2 | 233 / 225 / 224 / 236 | 236s | 229s | +7s (+3%) | 239s | **96%** |
| `worksteal`, run 3 (flag from `addopts`, exact CI command) | 239 / 234 / 233 / 240 | 240s | 236s | +4s (+2%) | 247s | **96%** |

The second `load` run reproduced the CI straggler exactly — one worker at 305s
while the other three finished in ~195s. All three worksteal runs held at +4–7s
and 96% worker efficiency.

Total pytest wall was 328s / 451s for `load` and 342s / 380s / 356s for
`worksteal`. I am deliberately **not** quoting a wall-clock delta from those
numbers: this box's fixed overhead (collection plus worker startup) wandered
between 77s and 141s across the five runs, which swamps the effect. Imbalance and
worker efficiency are the run-internal metrics that survive that noise, and the
wall-clock claim in the title comes from the CI table above (median 71s
recoverable), not from local timing. The next CI-performance report will measure
the actual delivered effect with the same before/after split that validated
#4935 (`test` job 447s → 349s, Build wall 485s → 383s).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. It changes only how tests are distributed across xdist workers. `--dist` is
inert unless the run is distributed, so plain `pytest` is unaffected (verified).

### Other information:

**Why `pyproject.toml` rather than the workflow step.** `-n logical` lives in
`.github/workflows/build.yml`, so that is the other candidate home. `addopts` was
chosen because three separate consumers pass `-n` and all three want the same
scheduler: the PR-gate `test` job, the scheduled slow-test suite in
`meridianlabs-ai/actions` (`pytest --runslow --runapi -n logical`), and local
developer runs. It also sits with the other suite-wide pytest defaults, which the
CI command already duplicates (`-rA --doctest-modules --color=yes`). Full
disclosure of a second reason: the scheduled agent run that prepared this PR
cannot push branches touching `.github/workflows/**` (its token lacks `workflow`
scope), so the workflow step was not an option here. If you would rather have the
flag next to `-n logical`, moving it is a one-line change and I have no objection.

**Risk to weigh.** Changing the distribution algorithm reshuffles which tests
share a worker, and this suite has had order-dependent flakiness before
(meridianlabs-ai/inspect_ai#247, #250). `load` is already nondeterministic, so
this changes the *distribution* of co-location rather than introducing it; three
full-suite runs under a completely different assignment came back green with
identical counts.

**Validation run:** `ruff check` (clean), `ruff format --check` (1565 files
already formatted), and five full-suite runs as tabulated above. `uv` is not
installed in this sandbox so the `uv-lock` pre-commit hook could not be run
locally; the change touches `[tool.pytest.ini_options]` only, so it should be a
no-op for `uv.lock`, and I will watch the `pre-commit` check and fix it if not.

No CHANGELOG entry: test-configuration change with no user-visible behavior
change.

**Agent involvement.** This PR was prepared end to end by Claude Opus 5 (Claude
Code) during the unattended scheduled CI-performance run of the `ci-perf` skill
([workflow run](https://github.com/meridianlabs-ai/actions/actions/runs/32236499178)),
operating as the `i-am-marvin` machine account. The analysis, the measurements
and this description are its work. Full context, including everything that did
*not* become a PR, is in `design/ci-perf/report.md` (updated in a companion PR).

### Agent review
- Reviewer: none. No separate review pass was run — this is a one-line
  configuration change whose justification is entirely empirical, and the
  verification effort went into the measurements instead: 10 CI legs for the
  problem and 5 full-suite runs for the fix, with the deliberately conservative
  reading that local wall-clock timing on this box is too noisy to quote.
- Because no review pass ran, the claims worth an independent check are: (1) that
  `--dist worksteal` in `addopts` is inert for non-distributed runs, and (2) that
  the imbalance numbers above are read correctly from the report-log artifacts
  (per-worker sums of `duration` over `setup`/`call`/`teardown`).


**Update — CI has since measured the effect directly.** The fork review PR
(meridianlabs-ai/inspect_ai#261) and a companion PR shared a base commit and
differed only in this flag, giving a one-run-per-arm A/B: both worksteal legs
held at +3–4s imbalance / 95% worker efficiency, while the `load` arm reproduced
the straggler (one worker at 266s vs 156–160s peers, 68% efficiency). Slower-leg
test-phase wall: 199s (worksteal) vs 271s (load) — a 72s difference, matching
the 71s median predicted above. Full tables and caveats:
[meridianlabs-ai/inspect_ai#261 (comment)](https://github.com/meridianlabs-ai/inspect_ai/pull/261#issuecomment-5340634866).

This PR was reviewed on the fork as meridianlabs-ai/inspect_ai#261 and is
promoted from the same branch unchanged.
