### PR TITLE
fix: preserve bridge thread continuity across system prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Metrics: Add `ci_wilson()` metric reporting the Wilson score confidence interval for the mean of binary scores (as `{"lower", "upper"}`), with bounds always within [0, 1]; `cluster=` computes an effective-sample-size interval accounting for within-cluster correlation.
 - Agent Bridge: Image tool results now reach sandboxed agents as MCP image content instead of being flattened to text.
 - Scoring: `inspect_ai.scorer` now exports `Reference`, the model for the message/event references that scanner scores store in metadata (previously importable only from Inspect Scout).
+- Agent Bridge: Preserve conversation continuity when scaffolds stamp per-request cache/billing tokens into otherwise stable system prompts.
 - Moonshot: Sampling parameters (`temperature`, `top_p`, penalties) set on Kimi models with thinking disabled are now warned about and ignored instead of causing a 400 error.
 - Model API: New `stream_idle_timeout` option (also retunable live via `inspect ctl config`) abandons and retries a model call whose streaming response stalls, instead of waiting out the whole-attempt timeout.
 - Together: Logprobs requests no longer fail with a 400 on newer models, and `top_logprobs` is now honored instead of being silently capped at 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
+- Agent Bridge: Preserve conversation continuity when scaffolds stamp per-request cache/billing tokens into otherwise stable system prompts.
 
 ## 0.3.262 (02 September 2026)
 
@@ -83,7 +84,6 @@
 - Metrics: Add `ci_wilson()` metric reporting the Wilson score confidence interval for the mean of binary scores (as `{"lower", "upper"}`), with bounds always within [0, 1]; `cluster=` computes an effective-sample-size interval accounting for within-cluster correlation.
 - Agent Bridge: Image tool results now reach sandboxed agents as MCP image content instead of being flattened to text.
 - Scoring: `inspect_ai.scorer` now exports `Reference`, the model for the message/event references that scanner scores store in metadata (previously importable only from Inspect Scout).
-- Agent Bridge: Preserve conversation continuity when scaffolds stamp per-request cache/billing tokens into otherwise stable system prompts.
 - Moonshot: Sampling parameters (`temperature`, `top_p`, penalties) set on Kimi models with thinking disabled are now warned about and ignored instead of causing a 400 error.
 - Model API: New `stream_idle_timeout` option (also retunable live via `inspect ctl config`) abandons and retries a model call whose streaming response stalls, instead of waiting out the whole-attempt timeout.
 - Together: Logprobs requests no longer fail with a 400 on newer models, and `top_logprobs` is now honored instead of being silently capped at 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Agent Bridge: Preserve conversation continuity when scaffolds stamp per-request cache/billing tokens into otherwise stable system prompts.
 
 ## 0.3.263 (03 September 2026)
 
@@ -28,7 +29,6 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
-- Agent Bridge: Preserve conversation continuity when scaffolds stamp per-request cache/billing tokens into otherwise stable system prompts.
 
 ## 0.3.262 (02 September 2026)
 

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,3 +1,4 @@
+import re
 from enum import IntEnum
 from functools import lru_cache
 from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
@@ -273,7 +274,9 @@ class AgentBridge:
         displace the real conversation. Instead we track thread identity:
 
         - A call whose messages extend the tracked thread (the tracked messages
-          are a prefix of it, compared by role + text) always updates the state.
+          are a prefix of it, compared by role + text after normalizing the
+          observed per-request scaffold cache token in system prompts) always
+          updates the state.
         - Otherwise the call starts a new thread and we consult *descent*: a
           thread descends from the initial input if its non-system messages
           start with the initial input's non-system messages (verbatim, as
@@ -458,8 +461,29 @@ class _MessageFingerprint(NamedTuple):
     text_hash: str
 
 
+_ANTHROPIC_BILLING_CCH_RE = re.compile(
+    r"(?im)^(x-anthropic-billing-header:\s*.*?\bcch=)([^;\s]+)"
+)
+
+
+def _fingerprint_text(message: ChatMessage) -> str:
+    """Text used for message fingerprinting.
+
+    Claude Code stamps a per-request `cch=` value into its
+    `x-anthropic-billing-header` system-prompt line. Normalize only that
+    observed volatile field so extension tracking survives cache-token churn
+    without ignoring meaningful system-prompt changes.
+    """
+    text = message.text
+    if message.role == "system":
+        return _ANTHROPIC_BILLING_CCH_RE.sub(r"\1<volatile>", text)
+    return text
+
+
 def _message_fingerprint(message: ChatMessage) -> _MessageFingerprint:
-    return _MessageFingerprint(role=message.role, text_hash=mm3_hash(message.text))
+    return _MessageFingerprint(
+        role=message.role, text_hash=mm3_hash(_fingerprint_text(message))
+    )
 
 
 class _Descent(IntEnum):

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -401,6 +401,71 @@ async def test_extension_recognized_despite_new_ids_and_metadata() -> None:
     assert len(bridge.state.messages) == len(turn2) + 1
 
 
+def volatile_token_system(nonce: int) -> ChatMessageSystem:
+    return ChatMessageSystem(
+        content=(
+            "x-anthropic-billing-header: cc_version=2.1.126.edc; "
+            f"cc_entrypoint=sdk-cli; cch={nonce:05x};\n\n"
+            "You are an agent."
+        )
+    )
+
+
+async def test_extension_ignores_per_request_system_prompt_changes() -> None:
+    """A changing scaffold system prompt must not break thread continuity."""
+    bridge = task_bridge()
+
+    turn: list[ChatMessage] = [volatile_token_system(1), ChatMessageUser(content=TASK)]
+    out = await track(bridge, turn, "step 1")
+
+    for step in range(2, 5):
+        turn = [
+            volatile_token_system(step),
+            *turn[1:],
+            ChatMessageAssistant(content=out.message.text),
+            ChatMessageTool(content=f"tool result {step}"),
+        ]
+        out = await track(bridge, turn, f"step {step}")
+
+    assert bridge.state.output.completion == "step 4"
+    assert [m.text for m in bridge.state.messages] == [
+        volatile_token_system(4).text,
+        TASK,
+        "step 1",
+        "tool result 2",
+        "step 2",
+        "tool result 3",
+        "step 3",
+        "tool result 4",
+        "step 4",
+    ]
+    assert bridge._tracked_calls == 4
+
+
+async def test_stable_system_prompt_replacement_does_not_extend() -> None:
+    """Only volatile system prompt tokens are normalized for extension."""
+    bridge = task_bridge()
+
+    turn: list[ChatMessage] = [
+        ChatMessageSystem(content="You are the main agent."),
+        ChatMessageUser(content=TASK),
+    ]
+    out = await track(bridge, turn, "step 1")
+
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator."),
+            *turn[1:],
+            ChatMessageAssistant(content=out.message.text),
+            ChatMessageTool(content="Generate a concise title."),
+        ],
+        "Doctor Who setting",
+    )
+
+    assert bridge._tracked_calls == 1
+
+
 # ---------------------------------------------------------------------------
 # Descent anchoring on the initial input
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4758.

`AgentBridge._track_state` treats `_extends()` as the strongest continuity signal: if the next request is a proper continuation of the tracked thread, the bridge updates the surfaced agent state without falling back to length/descent heuristics.

That extension check fingerprints the whole message list by role and text. Scaffolds that stamp a volatile per-request cache or billing token into an otherwise stable system prompt produce a new system-message fingerprint on each call, so the same conversation no longer matches the extension branch and has to rely on fallback heuristics instead.

### What is the new behavior?

System message fingerprints now normalize a narrow set of volatile token values before hashing. The extension comparison still uses the full message list, including system prompts, so stable system prompt replacements are not treated as the same thread.

Added regression coverage that:
- proves a changing per-request `cch=` token no longer prevents extension tracking (`_tracked_calls == 4`)
- proves a stable system prompt replacement does not count as an extension

Changelog entry added under `## Unreleased`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This only changes bridge thread identity fingerprinting for volatile system-prompt token values. The stored messages and model outputs are still taken from the actual request/response path.

### Other information:

Validation:
- `uv run pytest tests/agent/test_bridge_track_state.py::test_extension_ignores_per_request_system_prompt_changes -v`
  - 1 passed, 1 skipped; proves the extension branch is used across changing `cch=` system-prompt tokens.
- `uv run pytest tests/agent/test_bridge_track_state.py::test_stable_system_prompt_replacement_does_not_extend -v`
  - 1 passed, 1 skipped; proves stable system prompt replacements do not use the extension branch.
- `uv run pytest tests/agent/test_bridge_track_state.py -v`
  - 51 passed, 51 skipped; covers bridge thread tracking, side calls, compaction, descent anchoring, rewritten prompts, and request-handler paths.
- `uv run pytest tests/agent -v`
  - 1424 passed, 1178 skipped, 2 warnings; covers the broader agent and bridge subsystem.
- `uv run make check`
  - Passed; ruff, formatting, inspect-tool-support checks, and mypy.
- `uv run make test`
  - Passed; full pytest suite collected 13249 tests.
- `git diff --check`
  - Passed.

CI/CD coverage expected:
- Standard Build workflow should run ruff, mypy, package inspection, Python test lanes, and pre-commit checks.
- Viewer, sandbox-tools, and docs-specific lanes should be skipped/no-op because this PR only touches bridge Python code, bridge tests, and the changelog.

### Agent review

AI assistance was used for implementation and pre-PR review. I reviewed and tested the final diff.

- Fresh read-only review flagged that ignoring all system prompts would be broader than necessary; the patch was tightened to normalize only volatile system-token values and keep system prompts in the extension prefix comparison.
- Final read-only review found no blockers or major issues. Optional polish was applied so the regression exercises the `cch=` token shape and the changelog mentions cache/billing tokens.
- Follow-up validation covered the new positive regression, the stable-system-prompt guard, the full bridge tracking file, the broader agent suite, `make check`, and the full `make test` run.
