### PR TITLE
Fix static-analysis failures (4 mypy errors) caused by anthropic 0.124.0 widened type unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: Compatibility with anthropic SDK 0.124.0 (browser state tool results and file-based image/document sources no longer fail type checking).
 - Sandbox: Editable installs now avoid spurious `-dev` sandbox-tools binaries when local main refs are missing, stale, or unavailable.
 - Eval Log: Log directory manifests now strip Windows-style directory prefixes before normalizing paths, avoiding parent directories in bundled listings.
 - Sandboxes: The HTTP proxy example now disables container network egress, preventing agents from bypassing mitmproxy by ignoring proxy environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Anthropic: Compatibility with anthropic SDK 0.124.0 (browser state tool results and file-based image/document sources no longer fail type checking).
+- Anthropic: Compatibility with anthropic SDK 0.124.0, which is now the minimum supported version (browser state tool results and file-based image/document sources no longer fail type checking).
 - Sandbox: Editable installs now avoid spurious `-dev` sandbox-tools binaries when local main refs are missing, stale, or unavailable.
 - Eval Log: Log directory manifests now strip Windows-style directory prefixes before normalizing paths, avoiding parent directories in bundled listings.
 - Sandboxes: The HTTP proxy example now disables container network egress, preventing agents from bypassing mitmproxy by ignoring proxy environment variables.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 adlfs>=2025.8.0
-anthropic>=0.115.0
+anthropic>=0.124.0
 antlr4-python3-runtime>=4.9.3,<=4.13.2,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1
 apprise
 aws-bedrock-token-generator

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -7,6 +7,7 @@ from os import PathLike
 from typing import IO, Any, Literal, cast
 
 from anthropic.types import (
+    BrowserStateBlockParam,
     ContentBlock,
     ContentBlockParam,
     DocumentBlockParam,
@@ -496,7 +497,8 @@ def content_block_to_content(
     | ImageBlockParam
     | DocumentBlockParam
     | SearchResultBlockParam
-    | ToolReferenceBlockParam,
+    | ToolReferenceBlockParam
+    | BrowserStateBlockParam,
 ) -> Content:
     if block["type"] == "text":
         text = block["text"]
@@ -519,8 +521,12 @@ def content_block_to_content(
                     data=data,
                 )
             )
-        else:
+        elif block["source"]["type"] == "url":
             return ContentImage(image=block["source"]["url"])
+        else:
+            raise RuntimeError(
+                f"Unsupported image source type: {block['source']['type']}"
+            )
     elif block["type"] == "document":
         source = block["source"]
         if source["type"] == "text":
@@ -543,6 +549,8 @@ def content_block_to_content(
                 return ContentText(text=c)
             else:
                 return content_block_to_content(list(c)[0])
+        else:
+            raise RuntimeError(f"Unsupported document source type: {source['type']}")
     else:
         raise RuntimeError(f"Unsupported content block type: {type(block)}")
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -552,7 +552,7 @@ def content_block_to_content(
         else:
             raise RuntimeError(f"Unsupported document source type: {source['type']}")
     else:
-        raise RuntimeError(f"Unsupported content block type: {type(block)}")
+        raise RuntimeError(f"Unsupported content block type: {block['type']}")
 
 
 def base_64_data(data: str | IO[bytes] | PathLike[str]) -> str:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -31,6 +31,7 @@ from anthropic import (
 from anthropic.lib.streaming import AsyncMessageStream
 from anthropic.types import (
     Base64PDFSourceParam,
+    BrowserStateBlockParam,
     CacheControlEphemeralParam,
     CitationsConfigParam,
     CodeExecutionToolResultBlock,
@@ -2491,7 +2492,9 @@ def _citation_document_blocks(messages: list[MessageParam]) -> list[DocumentBloc
     return documents
 
 
-CitationCandidateBlock = ContentBlock | ContentBlockParam | ToolReferenceBlockParam
+CitationCandidateBlock = (
+    ContentBlock | ContentBlockParam | ToolReferenceBlockParam | BrowserStateBlockParam
+)
 
 
 def _is_citation_document_block(

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -377,7 +377,7 @@ def validate_openai_client(feature: str) -> None:
 
 def validate_anthropic_client(feature: str) -> None:
     PACKAGE = "anthropic"
-    MIN_VERSION = "0.115.0"
+    MIN_VERSION = "0.124.0"
 
     # verify we have the package
     try:

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -84,6 +84,33 @@ async def test_inline_text_document_round_trip() -> None:
     }
 
 
+def test_file_image_source_raises() -> None:
+    with pytest.raises(RuntimeError, match="Unsupported image source type: file"):
+        content_block_to_content(
+            cast(
+                Any,
+                {"type": "image", "source": {"type": "file", "file_id": "file_123"}},
+            )
+        )
+
+
+def test_file_document_source_raises() -> None:
+    with pytest.raises(RuntimeError, match="Unsupported document source type: file"):
+        content_block_to_content(
+            cast(
+                Any,
+                {"type": "document", "source": {"type": "file", "file_id": "file_123"}},
+            )
+        )
+
+
+def test_browser_state_block_raises() -> None:
+    with pytest.raises(
+        RuntimeError, match="Unsupported content block type: browser_state"
+    ):
+        content_block_to_content(cast(Any, {"type": "browser_state"}))
+
+
 def test_anthropic_system_to_text() -> None:
     assert anthropic_system_to_text("plain") == "plain"
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.115.0"
+version = "0.124.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -303,9 +303,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/52/b9022707a25fd263b8ff5e11f480dcc9cd6da0a380c486e5be053c01d995/anthropic-0.115.0.tar.gz", hash = "sha256:6bb25184441d51544f8bc9877a7efbddd9bc4a6207cce898536d84b233310f4a", size = 949136, upload-time = "2026-06-30T19:47:33.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/44/2afd86c9aac387b41f1b133cd3f595e0b110a2b980625f7987e897cee543/anthropic-0.124.0.tar.gz", hash = "sha256:b5c855a2912b157829a667ce21e10561f2b23bca98bb03af6abee2aa7f4a4cf3", size = 1054437, upload-time = "2026-08-19T16:51:31.493809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/89/cd08c2fb41f10fc902593579cb81717ce0ce5489fdf9dcb8e04ea9825fb2/anthropic-0.115.0-py3-none-any.whl", hash = "sha256:aa4bbea9272fa1cced6749728f18d0af9d7934b7268779e84d6f5a246f4b998d", size = 960664, upload-time = "2026-06-30T19:47:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6a/3ab35f7bb9a2c512c80638eb108fbbcee21c433a00baca8ab0ded485e007/anthropic-0.124.0-py3-none-any.whl", hash = "sha256:e7f86e3182c4173edf09fd8f42aa328d1aa9246355a90a300287c355228bb356", size = 1147647, upload-time = "2026-08-19T16:51:33.459733Z" },
 ]
 
 [[package]]
@@ -2169,7 +2169,7 @@ requires-dist = [
     { name = "adlfs", marker = "extra == 'dev'", specifier = ">=2025.8.0" },
     { name = "agent-client-protocol", specifier = ">=0.12.0" },
     { name = "aioboto3", specifier = ">=13.0.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.115.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.124.0" },
     { name = "antlr4-python3-runtime", marker = "extra == 'dev'", specifier = ">=4.9.3,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1,<=4.13.2" },
     { name = "antlr4-python3-runtime", marker = "extra == 'math'", specifier = ">=4.9.3,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1,<=4.13.2" },
     { name = "anyio", specifier = ">=4.14.0" },


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#270

`anthropic` 0.124.0 widened three type unions — `ToolResultBlockParam` content gained `BrowserStateBlockParam`, and `ImageBlockParam.source` / `DocumentBlockParam.source` gained file-based (Files API) source variants. Since `requirements-dev.txt` pins only `anthropic>=0.115.0`, every `static-analysis` CI run now fails with 4 mypy errors in `src/inspect_ai/model/_providers/anthropic.py` and `src/inspect_ai/agent/_bridge/anthropic_api_impl.py`. At runtime, a file-based image source in the agent bridge would have raised an opaque `KeyError: 'url'`, and a file-based document source would have silently returned `None`.

### What is the new behavior?

- `BrowserStateBlockParam` is accepted by the `CitationCandidateBlock` union (provider) and `content_block_to_content`'s parameter union (bridge). No new handling branch is needed: browser-state blocks are not documents (skipped by the citation guard) and fall through to the bridge's existing unsupported-block raise, matching how `SearchResultBlockParam` / `ToolReferenceBlockParam` are treated.
- The bridge's image branch now narrows explicitly on `source["type"] == "url"` and raises a clear `RuntimeError` for unsupported source types (e.g. `file`); the document branch gains an equivalent trailing raise. A Files-API `file_id` cannot be resolved to inline content in the bridge, so raising matches the file's existing handling of unrepresentable input. The unsupported-block error now names the block's `type` field (e.g. `browser_state`) instead of the always-`dict` `type(block)`.
- The minimum supported `anthropic` version is raised to 0.124.0 (`requirements-dev.txt`, `uv.lock`, and `validate_anthropic_client`'s `MIN_VERSION` all agree), since the provider and bridge now import `BrowserStateBlockParam` at module level — users on 0.115–0.123 get the friendly upgrade message rather than an `ImportError`.
- New unit tests in `tests/agent/test_bridge_anthropic_messages.py` pin the three error branches (file-source image, file-source document, `browser_state` fall-through).
- `mypy --exclude tests/test_package src tests` passes again with anthropic 0.124.0.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking API change; the minimum supported `anthropic` package version rises from 0.115.0 to 0.124.0 (disclosed in the CHANGELOG).

### Other information:

Implements the verified patch from meridianlabs-ai/inspect_ai#270 (SDK-drift triage; precedent: meridianlabs-ai/inspect_ai#233, meridianlabs-ai/inspect_ai#198).

Verification (anthropic 0.124.0 installed):
- `mypy --exclude tests/test_package src tests`: the 4 CI errors are gone; 5 remaining errors are local-environment stub/version drift in unrelated files (missing `types-requests` ×2, urllib3 `version_string`, click `ParamType`, an unused-ignore), present before and after the patch.
- `ruff check` and `ruff format --check` clean on both touched files.
- `pytest tests/agent/test_bridge_anthropic_messages.py tests/model/providers/test_anthropic.py tests/util/test_document.py`: 134 passed, 61 skipped.

### Agent review
- Reviewer (pre-PR): Claude Fable 5 (fresh-context subagent, same model as author), 1 pass. Findings: 1 nit — the bridge's final unsupported-block raise printed `type(block)` (always `dict`) rather than the block's `type` field. Initially dismissed as pre-existing wording, then fixed in a8d7527fd after PR review round 1 re-raised it (with a test asserting the new message in cd9241271).
- Reviewer (on-PR): Claude (fresh-context automated review), 3 rounds. Round 1 found the missing version-floor bump (fixed: `requirements-dev.txt`/`uv.lock`/`MIN_VERSION` → 0.124.0) and the `type(block)` nit (fixed). Round 2 found the untested error branches (fixed: 3 unit tests added). Round 3 found no code issues — only that this disclosure section was stale, corrected here.

Disclosure: implemented by Claude Code (Claude Fable 5) from the triage issue's proposed fix.

Generated with [Claude Code](https://claude.ai/code)