### PR TITLE
Bedrock: support prompt caching in Converse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bedrock: Converse requests now cache stable prompt prefixes and report cache read and write token usage.
 - OpenAI: Responses API usage now records `cache_write_tokens` as `ModelUsage.input_tokens_cache_write` and excludes it from full-rate `input_tokens` (generate and compaction responses); compaction usage also now excludes cache reads and records reasoning tokens. (#4855)
 - Sandbox: Editable installs now avoid spurious `-dev` sandbox-tools binaries when local main refs are missing, stale, or unavailable.
 - Eval Log: Log directory manifests now strip Windows-style directory prefixes before normalizing paths, avoiding parent directories in bundled listings.

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -148,7 +148,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto"] | bool | None
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic and supported Bedrock Converse models only."""
 
     fallback_models: list[str] | None
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""
@@ -275,7 +275,7 @@ class GenerateConfig(BaseModel):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto"] | bool | None = Field(default=None)
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic and supported Bedrock Converse models only."""
 
     fallback_models: list[str] | None = Field(default=None)
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -141,6 +141,10 @@ class ConverseReasoningContent(BaseModel):
     reasoningText: ConverseReasoningText
 
 
+class ConverseCachePoint(BaseModel):
+    type: Literal["default"]
+
+
 class ConverseMessageContent(BaseModel):
     text: str | None = None
     image: ConverseImage | None = None
@@ -149,6 +153,7 @@ class ConverseMessageContent(BaseModel):
     toolResult: ConverseToolResult | None = None
     guardContent: ConverseGuardContent | None = None
     reasoningContent: ConverseReasoningContent | None = None
+    cachePoint: ConverseCachePoint | None = None
 
 
 class ConverseMessage(BaseModel):
@@ -164,6 +169,8 @@ class ConverseUsage(BaseModel):
     inputTokens: int
     outputTokens: int
     totalTokens: int
+    cacheReadInputTokens: int | None = None
+    cacheWriteInputTokens: int | None = None
 
 
 class ConverseMetrics(BaseModel):
@@ -208,6 +215,7 @@ class ConverseContent(BaseModel):
 class ConverseSystemContent(BaseModel):
     text: str | None = None
     guardContent: ConverseGuardContent | None = None
+    cachePoint: ConverseCachePoint | None = None
 
 
 class ConverseInferenceConfig(BaseModel):
@@ -226,7 +234,8 @@ class ConverseToolSpec(BaseModel):
 
 
 class ConverseTool(BaseModel):
-    toolSpec: ConverseToolSpec
+    toolSpec: ConverseToolSpec | None = None
+    cachePoint: ConverseCachePoint | None = None
 
 
 class ConverseToolChoice(BaseModel):
@@ -461,6 +470,22 @@ class BedrockAPI(ModelAPI):
     def is_nova(self) -> bool:
         return "nova" in self.model_family().lower()
 
+    def _cache_prompt_enabled(self, config: GenerateConfig) -> bool:
+        if config.cache_prompt is False:
+            return False
+        if self.is_nova():
+            return True
+        if not self.is_claude():
+            return False
+
+        family = self.model_family().lower()
+        return (
+            "claude-3-5-haiku-20241022" in family
+            or "claude-3-5-sonnet-20241022" in family
+            or "claude-3-7-sonnet" in family
+            or re.search(r"claude-[a-z]+-[45](?:-|$)", family) is not None
+        )
+
     def _is_claude_4_x(self, x: int) -> bool:
         # bedrock model ids look like
         # `anthropic.claude-opus-4-7-20260101-v1:0` or
@@ -614,6 +639,13 @@ class BedrockAPI(ModelAPI):
             system, messages = await converse_messages(
                 input, emulate_reasoning=self.is_claude()
             )
+            if self._cache_prompt_enabled(config):
+                add_cache_point(
+                    system,
+                    messages,
+                    tool_config,
+                    tools_supported=self.is_claude(),
+                )
 
             # Claude 4.7+ runs adaptive-thinking-only and rejects sampling
             # parameters; other thinking-enabled Claude models also reject
@@ -881,6 +913,37 @@ async def converse_messages(
     return system if len(system) > 0 else None, non_system
 
 
+def add_cache_point(
+    system: list[ConverseSystemContent] | None,
+    messages: list[ConverseMessage],
+    tool_config: ConverseToolConfig | None,
+    *,
+    tools_supported: bool,
+) -> None:
+    """Cache the latest stable prefix in Bedrock's request processing order."""
+    seen_blocks = 0
+    for message in reversed(messages):
+        for index in range(len(message.content) - 1, -1, -1):
+            seen_blocks += 1
+            if seen_blocks == 2:
+                message.content.insert(
+                    index + 1,
+                    ConverseMessageContent(
+                        cachePoint=ConverseCachePoint(type="default")
+                    ),
+                )
+                return
+
+    if system:
+        system.append(
+            ConverseSystemContent(cachePoint=ConverseCachePoint(type="default"))
+        )
+    elif tools_supported and tool_config is not None and tool_config.tools:
+        tool_config.tools.append(
+            ConverseTool(cachePoint=ConverseCachePoint(type="default"))
+        )
+
+
 def model_output_from_response(
     model: str, response: ConverseResponse, tools: list[ToolInfo]
 ) -> ModelOutput:
@@ -925,8 +988,15 @@ def model_output_from_response(
 
     # Compute usage
     input_tokens = response.usage.inputTokens
+    cache_read_tokens = response.usage.cacheReadInputTokens
+    cache_write_tokens = response.usage.cacheWriteInputTokens
     output_tokens = response.usage.outputTokens
-    total_tokens = input_tokens + output_tokens
+    total_tokens = (
+        input_tokens
+        + (cache_read_tokens or 0)
+        + (cache_write_tokens or 0)
+        + output_tokens
+    )
 
     # return ModelOutput
     return ModelOutput(
@@ -934,6 +1004,8 @@ def model_output_from_response(
         choices=[choice],
         usage=ModelUsage(
             input_tokens=input_tokens,
+            input_tokens_cache_read=cache_read_tokens,
+            input_tokens_cache_write=cache_write_tokens,
             output_tokens=output_tokens,
             total_tokens=total_tokens,
         ),

--- a/tests/model/providers/test_bedrock_prompt_cache.py
+++ b/tests/model/providers/test_bedrock_prompt_cache.py
@@ -1,0 +1,251 @@
+"""Regression tests for Bedrock Converse prompt caching."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal, cast
+
+import pytest
+
+pytest.importorskip("aiobotocore")
+pytest.importorskip("botocore")
+
+from inspect_ai.model import (  # noqa: E402
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.model._generate_config import GenerateConfig  # noqa: E402
+from inspect_ai.model._providers.bedrock import (  # noqa: E402
+    BedrockAPI,
+    ConverseResponse,
+    model_output_from_response,
+)
+from inspect_ai.tool import ToolInfo  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.request: dict[str, Any] | None = None
+
+    async def converse(self, **request: Any) -> dict[str, Any]:
+        self.request = request
+        return _response()
+
+
+class _FakeClientContext:
+    def __init__(self, client: _FakeClient) -> None:
+        self.client = client
+
+    async def __aenter__(self) -> _FakeClient:
+        return self.client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, client: _FakeClient) -> None:
+        self.client_instance = client
+
+    def client(self, **kwargs: Any) -> _FakeClientContext:
+        return _FakeClientContext(self.client_instance)
+
+
+class _FakeHooks:
+    def start_request(self) -> str:
+        return "request-id"
+
+    def user_agent_extra(self, request_id: str) -> str:
+        return f"test/{request_id}"
+
+    def end_request(self, request_id: str) -> float:
+        return 0.0
+
+
+def _response(
+    *, cache_read: int | None = None, cache_write: int | None = None
+) -> dict[str, Any]:
+    usage: dict[str, int] = {
+        "inputTokens": 11,
+        "outputTokens": 7,
+        "totalTokens": 18 + (cache_read or 0) + (cache_write or 0),
+    }
+    if cache_read is not None:
+        usage["cacheReadInputTokens"] = cache_read
+    if cache_write is not None:
+        usage["cacheWriteInputTokens"] = cache_write
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+        "stopReason": "end_turn",
+        "usage": usage,
+        "metrics": {"latencyMs": 1},
+    }
+
+
+def _make_api(model_name: str) -> tuple[BedrockAPI, _FakeClient]:
+    api = BedrockAPI.__new__(BedrockAPI)
+    api.model_name = model_name
+    api.base_url = None
+    api.model_args = {}
+    api.read_timeout = 60
+    api.connect_timeout = 60
+    client = _FakeClient()
+    api.session = cast(Any, _FakeSession(client))
+    api._http_hooks = cast(Any, _FakeHooks())
+    return api, client
+
+
+async def _request(
+    *,
+    model_name: str = "anthropic.claude-sonnet-4-6",
+    input: list[ChatMessageSystem | ChatMessageUser | ChatMessageAssistant],
+    config: GenerateConfig = GenerateConfig(),
+    tools: list[ToolInfo] = [],
+) -> dict[str, Any]:
+    api, client = _make_api(model_name)
+    await api.generate(cast(Any, input), tools, "auto", config)
+    assert client.request is not None
+    return client.request
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "anthropic.claude-sonnet-4-6",
+        "amazon.nova-pro-v1:0",
+    ],
+)
+@pytest.mark.parametrize("cache_prompt", [None, "auto", True])
+async def test_cache_prompt_marks_stable_message_prefix_by_default(
+    model_name: str, cache_prompt: Literal["auto"] | bool | None
+) -> None:
+    request = await _request(
+        model_name=model_name,
+        input=[
+            ChatMessageUser(content="stable context"),
+            ChatMessageAssistant(content="stable answer"),
+            ChatMessageUser(content="dynamic question"),
+        ],
+        config=GenerateConfig(cache_prompt=cache_prompt),
+    )
+
+    assert request["messages"][1]["content"][-1] == {"cachePoint": {"type": "default"}}
+    assert "cachePoint" not in json.dumps(request["messages"][2])
+
+
+async def test_cache_prompt_false_preserves_request_shape() -> None:
+    request = await _request(
+        input=[
+            ChatMessageUser(content="stable context"),
+            ChatMessageAssistant(content="stable answer"),
+            ChatMessageUser(content="dynamic question"),
+        ],
+        config=GenerateConfig(cache_prompt=False),
+    )
+
+    assert "cachePoint" not in json.dumps(request)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "meta.llama3-1-70b-instruct-v1:0",
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+        "anthropic.claude-3-haiku-20240307-v1:0",
+        "anthropic.claude-3-opus-20240229-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    ],
+)
+async def test_unsupported_models_preserve_request_shape(model_name: str) -> None:
+    request = await _request(
+        model_name=model_name,
+        input=[
+            ChatMessageUser(content="stable context"),
+            ChatMessageAssistant(content="stable answer"),
+            ChatMessageUser(content="dynamic question"),
+        ],
+    )
+
+    assert "cachePoint" not in json.dumps(request)
+
+
+async def test_single_dynamic_message_preserves_request_shape() -> None:
+    request = await _request(input=[ChatMessageUser(content="dynamic question")])
+
+    assert "cachePoint" not in json.dumps(request)
+
+
+async def test_cache_prompt_falls_back_to_system_prefix() -> None:
+    request = await _request(
+        input=[
+            ChatMessageSystem(content="stable instructions"),
+            ChatMessageUser(content="dynamic question"),
+        ]
+    )
+
+    assert request["system"][-1] == {"cachePoint": {"type": "default"}}
+    assert "cachePoint" not in json.dumps(request["messages"])
+
+
+async def test_cache_prompt_falls_back_to_tools_prefix() -> None:
+    request = await _request(
+        input=[ChatMessageUser(content="dynamic question")],
+        tools=[ToolInfo(name="lookup", description="Look up a value")],
+    )
+
+    assert request["toolConfig"]["tools"][-1] == {"cachePoint": {"type": "default"}}
+    assert "cachePoint" not in json.dumps(request["messages"])
+
+
+async def test_nova_does_not_fall_back_to_unsupported_tools_prefix() -> None:
+    request = await _request(
+        model_name="amazon.nova-pro-v1:0",
+        input=[ChatMessageUser(content="dynamic question")],
+        tools=[ToolInfo(name="lookup", description="Look up a value")],
+    )
+
+    assert "cachePoint" not in json.dumps(request)
+
+
+def test_cache_usage_is_preserved_and_counted_in_total() -> None:
+    response = ConverseResponse.model_validate(_response(cache_read=13, cache_write=17))
+
+    usage = model_output_from_response("model", response, []).usage
+
+    assert usage is not None
+    assert usage.input_tokens == 11
+    assert usage.input_tokens_cache_read == 13
+    assert usage.input_tokens_cache_write == 17
+    assert usage.output_tokens == 7
+    assert usage.total_tokens == 48
+
+
+def test_missing_cache_usage_fields_remain_compatible() -> None:
+    response = ConverseResponse.model_validate(_response())
+
+    usage = model_output_from_response("model", response, []).usage
+
+    assert usage is not None
+    assert usage.input_tokens_cache_read is None
+    assert usage.input_tokens_cache_write is None
+    assert usage.total_tokens == 18
+
+
+def test_zero_cache_usage_fields_are_preserved() -> None:
+    response = ConverseResponse.model_validate(_response(cache_read=0, cache_write=0))
+
+    usage = model_output_from_response("model", response, []).usage
+
+    assert usage is not None
+    assert usage.input_tokens_cache_read == 0
+    assert usage.input_tokens_cache_write == 0
+    assert usage.total_tokens == 18


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Bedrock Converse requests ignore `cache_prompt`, and Converse response parsing drops `cacheReadInputTokens` and `cacheWriteInputTokens`. As a result, prompt prefixes cannot be cached through this provider and total usage undercounts cached input tokens.

Fixes #4961.

### What is the new behavior?

- Enables prompt caching by default (and for `"auto"`/`True`) on AWS-documented Claude and Nova model families; explicit `False` and unsupported models preserve the existing request shape.
- Adds one legal `cachePoint` after the latest stable message prefix, with system and model-compatible tool fallbacks when needed.
- Preserves cache read/write token counts. `input_tokens` remains uncached input, while `total_tokens` includes uncached input, cache reads, cache writes, and output.
- Handles missing and zero-valued cache usage fields and documents the Bedrock support in `GenerateConfig` and the changelog.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation:

- Focused Bedrock prompt-cache regressions: 28 passed, 25 skipped.
- Adjacent model/provider regressions: 111 passed, 36 skipped.
- `uv run make check`: Ruff passed; mypy reported no issues in 1,388 source files.
- `uv run make test`: 9,510 passed, 3,838 skipped, 0 failed.
- Botocore Converse parameter validation accepted the generated message, system, and Claude tool cache-point shapes.

The tests exercise the real Bedrock `generate` request-building path with a mocked client; no live Bedrock credentials were used.

Agent disclosure: developed with Codex. A separate fresh-context Codex Agent performed two independent review passes before submission. It identified two model-capability/request-shape P1 findings and one supported-model P2 omission; all were addressed test-first. The reviewer made no code or GitHub changes.
