### PR TITLE
Fix checkpoint e2e tests force-removing other tests' live sandbox containers under xdist

### DIFF
--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -146,8 +146,23 @@ def _run_interrupted_attempt(
         )
 
 
-def _inspect_projects() -> set[str]:
-    """Names of inspect docker compose projects currently known to docker."""
+def _project_prefix(task_name: str) -> str:
+    """Compose-project name prefix for evals of `task_name`.
+
+    Mirrors `task_project_name` in inspect's docker provider
+    (`inspect-{task[:12].rstrip('_')}-i{suffix}`), minus the random suffix.
+    """
+    return f"inspect-{task_name[:12].rstrip('_')}-"
+
+
+def _inspect_projects(prefix: str) -> set[str]:
+    """Names of this harness's docker compose projects currently known to docker.
+
+    Must be scoped to this test's own task (`prefix`): docker state is
+    machine-global, and under xdist a global before/after diff sweeps up —
+    and force-removes — live containers belonging to concurrently running
+    tests on other workers (meridianlabs-ai/actions#264).
+    """
     result = subprocess.run(
         ["docker", "compose", "ls", "--all", "--format", "json"],
         capture_output=True,
@@ -159,9 +174,7 @@ def _inspect_projects() -> set[str]:
         projects = json.loads(result.stdout or "[]")
     except json.JSONDecodeError:
         return set()
-    return {
-        p.get("Name", "") for p in projects if p.get("Name", "").startswith("inspect-")
-    }
+    return {p.get("Name", "") for p in projects if p.get("Name", "").startswith(prefix)}
 
 
 def _project_container_ids(name: str) -> list[str]:
@@ -275,7 +288,8 @@ def test_checkpoint_resume_restores_assistant_internal(
     crash_file.unlink(missing_ok=True)
     shutil.rmtree(log_dir, ignore_errors=True)
 
-    projects_before = _inspect_projects()
+    prefix = _project_prefix("resume_thinking_task")
+    projects_before = _inspect_projects(prefix)
     try:
         _run_interrupted_attempt(
             log_dir, None, tests_dir, harness_name="resume_kill_thinking_harness.py"
@@ -292,7 +306,7 @@ def test_checkpoint_resume_restores_assistant_internal(
             read_eval_log(killed_log), log_dir=log_dir, display="plain"
         )[0]
     finally:
-        for name in _inspect_projects() - projects_before:
+        for name in _inspect_projects(prefix) - projects_before:
             _force_remove_project(name)
 
     assert resume.status == "success"
@@ -334,16 +348,18 @@ def test_checkpoint_resume_rehydrated_event_layout(
     tests_dir = Path(__file__).parent.parent
 
     # A hard kill skips sandbox teardown, so each killed attempt leaks its
-    # sandbox container. Track inspect projects before/after and force-remove
-    # the ones this test leaks (the final resume cleans up its own).
-    projects_before = _inspect_projects()
+    # sandbox container. Track this harness's projects before/after and
+    # force-remove the ones this test leaks (the final resume cleans up its
+    # own).
+    prefix = _project_prefix("resume_decode_task")
+    projects_before = _inspect_projects(prefix)
     try:
         # --- attempt #0: fresh eval, interrupted at turn 2 (after ck1/ck2) --
         _run_interrupted_attempt(log_dir, None, tests_dir, interrupt)
 
         leaked = [
             cid
-            for name in _inspect_projects() - projects_before
+            for name in _inspect_projects(prefix) - projects_before
             for cid in _project_container_ids(name)
         ]
         if interrupt == "SIGKILL":
@@ -361,7 +377,7 @@ def test_checkpoint_resume_rehydrated_event_layout(
         reset_generates()
         resume = eval_retry(read_eval_log(_latest_log(log_dir)), log_dir=log_dir)[0]
     finally:
-        for name in _inspect_projects() - projects_before:
+        for name in _inspect_projects(prefix) - projects_before:
             _force_remove_project(name)
 
     assert resume.status == "success"

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -161,7 +161,7 @@ def _inspect_projects(prefix: str) -> set[str]:
     Must be scoped to this test's own task (`prefix`): docker state is
     machine-global, and under xdist a global before/after diff sweeps up —
     and force-removes — live containers belonging to concurrently running
-    tests on other workers (meridianlabs-ai/actions#264).
+    tests on other workers (#264).
     """
     result = subprocess.run(
         ["docker", "compose", "ls", "--all", "--format", "json"],

--- a/tests/checkpoint/test_checkpoint_scoring_resume_e2e.py
+++ b/tests/checkpoint/test_checkpoint_scoring_resume_e2e.py
@@ -74,8 +74,19 @@ def _run_killed_attempt(log_dir: str, retry_from: str | None, tests_dir: Path) -
     )
 
 
+# compose-project name prefix for the harness's `resume_scoring_task` evals
+# (mirrors `task_project_name`: `inspect-{task[:12].rstrip('_')}-i{suffix}`)
+_PROJECT_PREFIX = "inspect-resume_scori-"
+
+
 def _inspect_projects() -> set[str]:
-    """Names of inspect docker compose projects currently known to docker."""
+    """Names of this harness's docker compose projects currently known to docker.
+
+    Must be scoped to this test's own task: docker state is machine-global,
+    and under xdist a global before/after diff sweeps up — and force-removes —
+    live containers belonging to concurrently running tests on other workers
+    (meridianlabs-ai/actions#264).
+    """
     result = subprocess.run(
         ["docker", "compose", "ls", "--all", "--format", "json"],
         capture_output=True,
@@ -88,7 +99,9 @@ def _inspect_projects() -> set[str]:
     except json.JSONDecodeError:
         return set()
     return {
-        p.get("Name", "") for p in projects if p.get("Name", "").startswith("inspect-")
+        p.get("Name", "")
+        for p in projects
+        if p.get("Name", "").startswith(_PROJECT_PREFIX)
     }
 
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#264.

Scheduled full-suite CI runs have been failing intermittently for weeks with docker sandbox containers that die mid-test with no output. The victim test changed from run to run, the container was always gone from `docker ps --all` before anything could examine it, and the failure never reproduced locally.

The cause is in the checkpoint e2e tests. They hard-kill an eval on purpose, which leaks its sandbox container, and they clean up by listing every `inspect-*` compose project on the machine before and after the test, then running `docker rm -f` on the difference. Docker state is machine-wide. When the suite runs under pytest-xdist, any sandbox that another worker starts while a checkpoint test is running lands in that difference and gets force-removed out from under a live test. The same list also feeds the tests' own "did the kill leak a container" assertions, so those could match another worker's container as well.

A `docker events` recording from a failing run shows the mechanism directly. Each victim container is created, started, killed with SIGKILL, and destroyed within the same second, with several projects swept in one batch a moment after a checkpoint test finished. The affected test then fails in whatever way fits where it was: an exec that returns a signal exit code with no output, or `compose up` reporting "No such container".

### What is the new behavior?

The cleanup and the leak assertions only consider compose projects whose name starts with the prefix of the harness task that the test itself runs (`inspect-resume_decod-`, `inspect-resume_think-`, `inspect-resume_scori-`, matching how `task_project_name` builds project names). Containers belonging to other tests can no longer be selected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This changes test code only. No CHANGELOG entry for the same reason.

### Other information:

### Agent review
- Reviewer: none separate. The change is a two-file, test-only scoping fix. The mechanism was verified against the captured docker event stream by tracing the victim container ids end to end, and the fix was checked with ruff, mypy, and test collection.
- Authored by Claude (Fable 5) driven by a human (@epatey).
