### PR TITLE
fix(openai-responses): handle ResponseToolSearchOutputItem output type (#4968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fixed Linux evaluations slowing down as model clients open more HTTPS connections.
+- Bugfix: The OpenAI Responses provider no longer raises `ValueError("Unexpected output type: ResponseToolSearchOutputItem")` when an agent uses native OpenAI deferred tool search; the response-item handler now recognises the `tool_search_output` item without overwriting the cached `tool_search_call`. (#4968)
 - Sample selection: `--sample-id` now accepts ids containing colons (e.g. `user:cybergym/arvo_6008`); a `task:` prefix is stripped only when it names a task in the run.
 - Multiple choice: A dataset target of `0` now raises an error instead of being interpreted as option Z on tasks with 26 or more choices.
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -39,6 +39,7 @@ from openai.types.responses import (
     ResponseReasoningItem,
     ResponseReasoningItemParam,
     ResponseToolSearchCall,
+    ResponseToolSearchOutputItem,
     ResponseUsage,
     ToolChoiceFunctionParam,
     ToolChoiceTypesParam,
@@ -1025,6 +1026,11 @@ def _process_response_output_items(
                     ToolSearchCall, output.model_dump(exclude_none=True)
                 )
                 tool_calls.append(tool_call)
+            case ResponseToolSearchOutputItem():
+                # Companion result of a ResponseToolSearchCall. Tool-message replay
+                # rebuilds this from the cached call and ChatMessageTool content, so
+                # do not cache it under call_id or it will overwrite the call.
+                pass
             case _:
                 raise ValueError(f"Unexpected output type: {output.__class__}")
 

--- a/tests/agent/test_bridge_tool_search.py
+++ b/tests/agent/test_bridge_tool_search.py
@@ -514,6 +514,69 @@ def test_process_response_output_items_tool_search_call() -> None:
     assert cached["type"] == "tool_search_call"
 
 
+def test_process_response_output_items_tool_search_output_does_not_clobber_call() -> (
+    None
+):
+    from openai.types.responses import (
+        ResponseToolSearchCall,
+        ResponseToolSearchOutputItem,
+    )
+
+    from inspect_ai.model._openai_responses import assistant_internal
+
+    init_sample_openai_assistant_internal()
+
+    _process_response_output_items(
+        [
+            ResponseToolSearchCall(
+                id="x1",
+                call_id="ts_1",
+                arguments={"query": "file tools"},
+                execution="client",
+                status="completed",
+                type="tool_search_call",
+            ),
+            ResponseToolSearchOutputItem(
+                id="o1",
+                call_id="ts_1",
+                execution="client",
+                status="completed",
+                tools=[],
+                type="tool_search_output",
+            ),
+        ],
+        [],
+    )
+
+    cached = assistant_internal().tool_calls.get("ts_1")
+    assert cached is not None
+    assert cached["type"] == "tool_search_call"
+
+
+def test_process_response_output_items_tool_search_output() -> None:
+    from openai.types.responses import ResponseToolSearchOutputItem
+
+    from inspect_ai.model._openai_responses import assistant_internal
+
+    init_sample_openai_assistant_internal()
+
+    output = ResponseToolSearchOutputItem(
+        id="o1",
+        call_id="ts_1",
+        execution="client",
+        status="completed",
+        tools=[],
+        type="tool_search_output",
+    )
+    # Before the fix, this raised ValueError("Unexpected output type: ...").
+    _content, tool_calls, _logprobs, has_tool_calls = _process_response_output_items(
+        [output], []
+    )
+    assert has_tool_calls is False
+    assert tool_calls == []
+    assert "ts_1" not in assistant_internal().tool_calls
+
+
 # 7b. tool-message replay only emits native tool_search_output when the original
 # call was a tool_search_call. A user/function tool named "tool_search" (cached as
 # a function_call, or uncached) must replay as a normal function_call_output.


### PR DESCRIPTION
## Bugfix

Fixes [#4968](https://github.com/UKGovernmentBEIS/inspect_ai/issues/4968) — `ValueError: Unexpected output type: ResponseToolSearchOutputItem` when evaluating an agent that exercises native OpenAI tool search, such as Pydantic AI deferred tool search.

## Reproducer

`tests/agent/test_bridge_tool_search.py::test_process_response_output_items_tool_search_output` reproduces the parser-side crash directly without needing a model call.

## Before / After

- **Before**: `_process_response_output_items` fell through to `case _:` and raised `ValueError` whenever OpenAI emitted a `ResponseToolSearchOutputItem` alongside the `tool_search_call`.
- **After**: the handler recognises the companion `tool_search_output` item and skips it without caching. Tool-message replay continues to rebuild native `tool_search_output` from the cached `tool_search_call` plus the `ChatMessageTool` content.

## Files

| File | Change |
| --- | --- |
| `src/inspect_ai/model/_openai_responses.py` | Add `ResponseToolSearchOutputItem` handling without writing it into `_AssistantInternal.tool_calls`. |
| `tests/agent/test_bridge_tool_search.py` | Add regression coverage for the standalone output item and for call+output processed together without clobbering the cached call. |
| `CHANGELOG.md` | Add a `Bugfix:` line under `## Unreleased`. |

## Local verification

- `/opt/homebrew/bin/python3.10 -m ruff check src/inspect_ai/model/_openai_responses.py tests/agent/test_bridge_tool_search.py` — passed.
- `/opt/homebrew/bin/python3.10 -m pytest tests/agent/test_bridge_tool_search.py -q` — 19 passed.

### Agent review

- Reviewer: Codex in this follow-up context.
- Findings: Addressed the maintainer review checklist directly: removed output caching, added a call+output cache-clobber regression test, rebased onto current `main`, and moved the changelog entry under `## Unreleased`.
- Separate fresh-context review: not run for this follow-up; scope is limited to the requested review fix.
