### PR TITLE
Fix flaky tests from cross-module model registry wipes (ACP UsageUpdate under xdist)

### DIFF
--- a/tests/agent/test_acp/test_router_phase2.py
+++ b/tests/agent/test_acp/test_router_phase2.py
@@ -16,11 +16,9 @@ things that Phase 6 left optional/absent:
   looked up via ``get_model_info``.
 """
 
-from collections.abc import Iterator
 from typing import Any
 from uuid import UUID
 
-import pytest
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
@@ -52,7 +50,6 @@ from inspect_ai.model import (
     set_model_info,
 )
 from inspect_ai.model._generate_config import GenerateConfig
-from inspect_ai.model._model_info import _custom_models, _result_cache
 from inspect_ai.model._model_output import (
     ChatCompletionChoice,
     ModelOutput,
@@ -65,25 +62,17 @@ from inspect_ai.tool._tool_call import ToolCall
 # broken by changes to the canonical model data files.
 _TEST_MODEL = "phase2-router-test/synthetic"
 _TEST_CONTEXT_LENGTH = 100_000
-_NOT_REGISTERED = "registry lost the test model (see _register_test_model)"
+_NOT_REGISTERED = (
+    "registry lost the test model (see isolate_custom_model_info in conftest)"
+)
 
 
-# Re-registered before every test: other modules' fixtures call
-# clear_model_info_cache(), which wipes a one-off registration whenever
-# one of their tests runs before ours in the same process (no xdist
-# needed — worksteal interleaving is just how CI hits it).
-@pytest.fixture(autouse=True)
-def _register_test_model() -> Iterator[None]:
-    set_model_info(
-        _TEST_MODEL,
-        ModelInfo(context_length=_TEST_CONTEXT_LENGTH, output_tokens=4096),
-    )
-    yield
-    # Drop only our synthetic entries; clearing the whole registry is the
-    # cross-module pollution this fixture exists to defend against.
-    for name in [n for n in _custom_models if n.startswith("phase2-router-test/")]:
-        del _custom_models[name]
-    _result_cache.clear()
+# Import-time registration is safe: conftest's isolate_custom_model_info
+# heals the wipe when another module's fixture calls clear_model_info_cache().
+set_model_info(
+    _TEST_MODEL,
+    ModelInfo(context_length=_TEST_CONTEXT_LENGTH, output_tokens=4096),
+)
 
 
 def _new_session() -> LiveAcpTransport:
@@ -306,7 +295,7 @@ def test_chunks_from_different_events_can_carry_different_models() -> None:
 
 def test_usage_update_emitted_after_text_chunk() -> None:
     # Named precondition: without it a wiped registration fails four tests
-    # with an opaque `assert 0 == 1` (how the xdist flake first presented).
+    # with an opaque `assert 0 == 1` (how the #4972 xdist flake presented).
     assert get_model_info(_TEST_MODEL) is not None, _NOT_REGISTERED
     tr = Transcript()
     token = _transcript.set(tr)

--- a/tests/agent/test_acp/test_router_phase2.py
+++ b/tests/agent/test_acp/test_router_phase2.py
@@ -16,6 +16,7 @@ things that Phase 6 left optional/absent:
   looked up via ``get_model_info``.
 """
 
+from collections.abc import Iterator
 from typing import Any
 from uuid import UUID
 
@@ -44,8 +45,14 @@ from inspect_ai.agent._acp.transport_live import LiveAcpTransport
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.event._tool import ToolEvent
 from inspect_ai.log._transcript import Transcript, _transcript
-from inspect_ai.model import ChatMessageAssistant, ModelInfo, set_model_info
+from inspect_ai.model import (
+    ChatMessageAssistant,
+    ModelInfo,
+    get_model_info,
+    set_model_info,
+)
 from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_info import _custom_models, _result_cache
 from inspect_ai.model._model_output import (
     ChatCompletionChoice,
     ModelOutput,
@@ -58,17 +65,25 @@ from inspect_ai.tool._tool_call import ToolCall
 # broken by changes to the canonical model data files.
 _TEST_MODEL = "phase2-router-test/synthetic"
 _TEST_CONTEXT_LENGTH = 100_000
+_NOT_REGISTERED = "registry lost the test model (see _register_test_model)"
 
 
 # Re-registered before every test: other modules' fixtures call
-# clear_model_info_cache(), which wipes a one-off registration when
-# xdist interleaves their tests with ours on the same worker.
+# clear_model_info_cache(), which wipes a one-off registration whenever
+# one of their tests runs before ours in the same process (no xdist
+# needed — worksteal interleaving is just how CI hits it).
 @pytest.fixture(autouse=True)
-def _register_test_model() -> None:
+def _register_test_model() -> Iterator[None]:
     set_model_info(
         _TEST_MODEL,
         ModelInfo(context_length=_TEST_CONTEXT_LENGTH, output_tokens=4096),
     )
+    yield
+    # Drop only our synthetic entries; clearing the whole registry is the
+    # cross-module pollution this fixture exists to defend against.
+    for name in [n for n in _custom_models if n.startswith("phase2-router-test/")]:
+        del _custom_models[name]
+    _result_cache.clear()
 
 
 def _new_session() -> LiveAcpTransport:
@@ -290,6 +305,9 @@ def test_chunks_from_different_events_can_carry_different_models() -> None:
 
 
 def test_usage_update_emitted_after_text_chunk() -> None:
+    # Named precondition: without it a wiped registration fails four tests
+    # with an opaque `assert 0 == 1` (how the xdist flake first presented).
+    assert get_model_info(_TEST_MODEL) is not None, _NOT_REGISTERED
     tr = Transcript()
     token = _transcript.set(tr)
     try:
@@ -312,6 +330,7 @@ def test_usage_update_emitted_after_text_chunk() -> None:
 
 
 def test_usage_update_includes_cached_tokens() -> None:
+    assert get_model_info(_TEST_MODEL) is not None, _NOT_REGISTERED
     tr = Transcript()
     token = _transcript.set(tr)
     try:
@@ -367,6 +386,7 @@ def test_usage_update_order_after_chunks() -> None:
     updates so the chip change visually corresponds to the model call
     just rendered.
     """
+    assert get_model_info(_TEST_MODEL) is not None, _NOT_REGISTERED
     tr = Transcript()
     token = _transcript.set(tr)
     try:
@@ -397,6 +417,7 @@ def test_usage_update_emitted_for_tool_call_only_response() -> None:
     real flow: pending fires when the model call begins, complete
     fires when it returns (tool-only).
     """
+    assert get_model_info(_TEST_MODEL) is not None, _NOT_REGISTERED
     tr = Transcript()
     token = _transcript.set(tr)
     try:

--- a/tests/agent/test_acp/test_router_phase2.py
+++ b/tests/agent/test_acp/test_router_phase2.py
@@ -19,6 +19,7 @@ things that Phase 6 left optional/absent:
 from typing import Any
 from uuid import UUID
 
+import pytest
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
@@ -58,10 +59,16 @@ from inspect_ai.tool._tool_call import ToolCall
 _TEST_MODEL = "phase2-router-test/synthetic"
 _TEST_CONTEXT_LENGTH = 100_000
 
-set_model_info(
-    _TEST_MODEL,
-    ModelInfo(context_length=_TEST_CONTEXT_LENGTH, output_tokens=4096),
-)
+
+# Re-registered before every test: other modules' fixtures call
+# clear_model_info_cache(), which wipes a one-off registration when
+# xdist interleaves their tests with ours on the same worker.
+@pytest.fixture(autouse=True)
+def _register_test_model() -> None:
+    set_model_info(
+        _TEST_MODEL,
+        ModelInfo(context_length=_TEST_CONTEXT_LENGTH, output_tokens=4096),
+    )
 
 
 def _new_session() -> LiveAcpTransport:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,6 +181,30 @@ def fresh_concurrency_registry():
     yield
 
 
+@pytest.fixture(autouse=True)
+def isolate_custom_model_info() -> Iterator[None]:
+    """Snapshot/restore the custom model-info registry around each test.
+
+    `clear_model_info_cache()` wipes the process-global `_custom_models`
+    dict — including registrations other modules made at import time. Any
+    test whose fixtures clear the registry therefore starves later tests
+    in the same process that rely on an import-time `set_model_info`
+    (order-dependent, so under xdist worksteal it surfaces as a flake —
+    see #4972). Restore the pre-test snapshot so neither wipes nor leaked
+    registrations cross test boundaries. `_result_cache` must go with the
+    restore: it can hold a negative lookup memoized while the registry was
+    wiped, which would otherwise keep masking the restored entry.
+    """
+    from inspect_ai.model._model_info import _custom_models, _result_cache
+
+    snapshot = dict(_custom_models)
+    yield
+    if _custom_models != snapshot:
+        _custom_models.clear()
+        _custom_models.update(snapshot)
+        _result_cache.clear()
+
+
 @pytest.fixture(scope="session")
 def registrations_at_session_start() -> dict[str, object]:
     """Load extension entry points up front, then snapshot the registry.


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

`tests/agent/test_acp/test_router_phase2.py` registers its synthetic model with `set_model_info` at module import time. Other modules' autouse fixtures call `clear_model_info_cache()`, which wipes the whole process-global custom registry (`_custom_models.clear()`) — including registrations the caller didn't create. Whenever one of those tests runs before the router tests in the same process, the four `UsageUpdate` tests fail with an opaque `assert 0 == 1` — the router sees the model as unknown and skips the update. Latent on main: under xdist worksteal it fires whenever the test distribution shuffles unfavourably, which adding or removing tests anywhere in the suite can do (#4265 turned CI red this way — all four victims landed on gw3 after `test_sample_limits`).

Reproduce on main without xdist:

```
pytest tests/test_sample_limits.py::test_token_limit \
  "tests/agent/test_acp/test_router_phase2.py::test_usage_update_emitted_after_text_chunk"
```

### What is the new behavior?

The class of bug is fixed in conftest rather than per-victim: an autouse `isolate_custom_model_info` fixture snapshots `_custom_models` before each test and restores it after (mirroring the existing `protect_registrations`), so neither wipes nor leaked registrations cross test boundaries — any module can safely register at import time. The restore also drops `_result_cache`, which can hold a negative lookup memoized while the registry was wiped and would otherwise keep masking the restored entry. The router module keeps its plain import-time registration, and its four `UsageUpdate` tests assert the registration up front so any future wipe fails with a named message instead of `assert 0 == 1`.

Verified: the repro above passes in both orderings and under `-n 2 --dist worksteal` across the registry-touching modules; negative control — with the conftest fixture removed, router → wiper → router fails on the third test (with the new named message).

### Does this PR introduce a breaking change?

No — test-only.

### Other information:

Split out of #4265 (whose CI first exposed the flake). First landed as a per-module re-registration fixture; widened to the conftest-level class fix at review, since any future module registering a model at import scope would have re-lived the same flake. #4973 independently bundled an equivalent per-test fixture into this file on main; this PR removes it as superseded (the conftest fixture is what protects the registration now).

### Agent review
- Reviewer: Claude Fable 5, recall-biased multi-angle review (8 finder angles + per-candidate verification, each in a fresh context; same model family as the author), 1 pass over the original 11-line diff
- Findings: 4 — all addressed (comment implied xdist was required for the failure mode when the repro is serial; fixture had no teardown, diverging from the suite's clear/yield/clear convention; UsageUpdate failures were undiagnosable when the registration is wiped; per-module fix left the bug class open — now fixed at conftest altitude, which superseded the first two). One further candidate refuted (leaked registry entries breaking other tests — lookup is exact-key and registry-sensitive modules clear at setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
