### PR TITLE
Add ci_wilson() Wilson score interval metric for binary scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Metrics: Add `ci_wilson()` metric reporting the Wilson score confidence interval for the mean of binary scores (as `{"lower", "upper"}`), with bounds always within [0, 1]; `cluster=` computes an effective-sample-size interval accounting for within-cluster correlation. (#4980)
+
 - Metrics: Add `ci()` metric reporting a confidence interval for the mean (as `{"lower", "upper"}`). Defaults to `mean ± t · stderr` with a Student-t critical value (`n - 1` degrees of freedom; `clusters - 1` when `cluster=` is set) so small samples get honest widths; `method="bootstrap"` gives a percentile (cluster) bootstrap interval. (#4160)
 - Anthropic: Compatibility with anthropic SDK 0.124.0, which is now the minimum supported version (browser state tool results and file-based image/document sources no longer fail type checking).
 - OpenAI: Responses API usage now records `cache_write_tokens` as `ModelUsage.input_tokens_cache_write` and excludes it from full-rate `input_tokens` (generate and compaction responses); compaction usage also now excludes cache reads and records reasoning tokens. (#4855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Metrics: Add `ci_wilson()` metric reporting the Wilson score confidence interval for the mean of binary scores (as `{"lower", "upper"}`), with bounds always within [0, 1]; `cluster=` computes an effective-sample-size interval accounting for within-cluster correlation. (#4980)
+- Metrics: Add `ci_wilson()` metric reporting the Wilson score confidence interval for the mean of binary scores (as `{"lower", "upper"}`), with bounds always within [0, 1]; `cluster=` computes an effective-sample-size interval accounting for within-cluster correlation.
 
 - Metrics: Add `ci()` metric reporting a confidence interval for the mean (as `{"lower", "upper"}`). Defaults to `mean ± t · stderr` with a Student-t critical value (`n - 1` degrees of freedom; `clusters - 1` when `cluster=` is set) so small samples get honest widths; `method="bootstrap"` gives a percentile (cluster) bootstrap interval. (#4160)
 - Anthropic: Compatibility with anthropic SDK 0.124.0, which is now the minimum supported version (browser state tool results and file-based image/document sources no longer fail type checking).

--- a/docs/metrics.qmd
+++ b/docs/metrics.qmd
@@ -57,7 +57,11 @@ Inspect includes some simple built in metrics for calculating accuracy, mean, et
 
 -   `ci()`
 
-    Confidence interval for the mean, reported as a mapping with `lower` and `upper` bounds. Defaults to a 95% Student-t interval (`mean ± t · stderr`, with `n - 1` degrees of freedom, or `clusters - 1` when `cluster=` is set); pass `level=` to change the confidence level or `method="bootstrap"` for a percentile (cluster) bootstrap interval. Useful for deciding, for example, whether two models' accuracy intervals overlap.
+    Confidence interval for the mean, reported as a mapping with `lower` and `upper` bounds. Defaults to a 95% Student-t interval (`mean ± t · stderr`, with `n - 1` degrees of freedom, or `clusters - 1` when `cluster=` is set); pass `level=` to change the confidence level or `method="bootstrap"` for a percentile (cluster) bootstrap interval. Useful for deciding, for example, whether two models' accuracy intervals overlap. For binary scores, prefer `ci_wilson()`.
+
+-   `ci_wilson()`
+
+    Wilson score confidence interval for the mean of binary (0/1) scores, treating it as a binomial proportion. Prefer this over `ci()` for binary scores such as accuracy: the bounds always stay within [0, 1] and remain well calibrated for small samples and proportions near 0 or 1. Pass `level=` to change the confidence level; with `cluster=` the interval uses an effective sample size derived from the clustered standard error.
 
 -   `frequency()`
 

--- a/docs/reference/inspect_ai.scorer.qmd
+++ b/docs/reference/inspect_ai.scorer.qmd
@@ -32,6 +32,7 @@ description: Task scoring and metrics.
 ### stderr
 ### bootstrap_stderr
 ### ci
+### ci_wilson
 ### perplexity_per_token
 ### perplexity_per_seq
 ### krippendorff_alpha

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -28,7 +28,7 @@ from ._metrics.grouped import grouped
 from ._metrics.krippendorff import krippendorff_alpha
 from ._metrics.mean import mean
 from ._metrics.perplexity import perplexity_per_seq, perplexity_per_token
-from ._metrics.std import bootstrap_stderr, ci, std, stderr, var
+from ._metrics.std import bootstrap_stderr, ci, ci_wilson, std, stderr, var
 from ._model import model_graded_fact, model_graded_qa
 from ._multi import multi_scorer
 from ._pattern import pattern
@@ -78,6 +78,7 @@ __all__ = [
     "categorical",
     "choice",
     "ci",
+    "ci_wilson",
     "collect_score",
     "exact",
     "f1",

--- a/src/inspect_ai/scorer/_metrics/__init__.py
+++ b/src/inspect_ai/scorer/_metrics/__init__.py
@@ -5,7 +5,7 @@ from .grouped import grouped
 from .krippendorff import krippendorff_alpha
 from .mean import mean
 from .perplexity import perplexity_per_seq, perplexity_per_token
-from .std import bootstrap_stderr, ci, std, stderr, var
+from .std import bootstrap_stderr, ci, ci_wilson, std, stderr, var
 
 __all__ = [
     "accuracy",
@@ -19,6 +19,7 @@ __all__ = [
     "perplexity_per_seq",
     "bootstrap_stderr",
     "ci",
+    "ci_wilson",
     "std",
     "stderr",
     "var",

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -55,18 +55,22 @@ def bootstrap_stderr(
 
 
 def _cluster_partition(
-    scores: list[SampleScore], cluster: str, to_float: ValueToFloat, metric_name: str
+    scores: list[SampleScore], cluster: str, values: list[float], metric_name: str
 ) -> list[list[float]]:
-    """Validate cluster metadata and partition score values by cluster id.
+    """Validate cluster metadata and partition pre-converted values by cluster id.
 
     Single source of truth for cluster identity: every consumer (clustered
     standard error, t degrees of freedom, cluster bootstrap) must derive its
     cluster count from the same partition, so equality semantics cannot drift
     between them. A missing key, `None`, or float NaN cluster id raises
     (float NaN metadata means "missing", matching the dataset convention).
+
+    Takes the already-converted `values` (aligned with `scores`) rather than a
+    `ValueToFloat`: converters are arbitrary callables and need not be pure, so
+    each score must be converted exactly once per metric evaluation.
     """
     groups: dict[object, list[float]] = {}
-    for sample_score in scores:
+    for sample_score, value in zip(scores, values):
         metadata = sample_score.sample_metadata
         cluster_id = metadata.get(cluster) if metadata is not None else None
         if cluster_id is None or (
@@ -75,7 +79,7 @@ def _cluster_partition(
             raise ValueError(
                 f"Sample {sample_score.sample_id} has no cluster metadata. To compute `{metric_name}` with clustering, each sample metadata must have a value for '{cluster}'"
             )
-        groups.setdefault(cluster_id, []).append(to_float(sample_score.score.value))
+        groups.setdefault(cluster_id, []).append(value)
     return list(groups.values())
 
 
@@ -136,9 +140,8 @@ def stderr(
 
     def clustered_metric(scores: list[SampleScore]) -> float:
         assert cluster is not None
-        return _clustered_stderr(
-            _cluster_partition(scores, cluster, to_float, "stderr")
-        )
+        values = [to_float(score.score.value) for score in scores]
+        return _clustered_stderr(_cluster_partition(scores, cluster, values, "stderr"))
 
     def metric(scores: list[SampleScore]) -> float:
         import numpy as np
@@ -226,7 +229,7 @@ def ci(
         # of truth for cluster identity across the SE, the degrees of
         # freedom, and the cluster bootstrap.
         partition = (
-            _cluster_partition(scores, cluster, to_float, "ci")
+            _cluster_partition(scores, cluster, values, "ci")
             if cluster is not None
             else None
         )
@@ -288,15 +291,16 @@ def ci_wilson(
        cluster (str | None): The key from the Sample metadata corresponding to
           a cluster identifier for computing
           [clustered](https://en.wikipedia.org/wiki/Clustered_standard_errors)
-          intervals. When set, the interval uses the effective sample size
-          `n / DEFF` (Korn & Graubard), where the design effect `DEFF` is the
-          ratio of the clustered variance of the mean to the Bessel-corrected
-          simple-random-sampling variance `p̂(1 − p̂)/(n − 1)`, so the interval
-          accounts for within-cluster correlation. The effective sample size
-          is capped at `n`, and whenever the design effect cannot be estimated
-          (either variance is zero: `p̂` exactly 0 or 1, fewer than two
-          clusters, or perfectly cancelling clusters) the unadjusted `n` is
-          used.
+          intervals. When set, the interval uses the Korn-Graubard effective
+          sample size `p̂(1 − p̂) / v̂` (capped at `n`), where `v̂` is the
+          clustered variance of the mean, and a Student-t critical value with
+          `clusters − 1` degrees of freedom in place of the normal one, so the
+          interval accounts for within-cluster correlation and for the
+          uncertainty of the variance estimate when clusters are few. Requires
+          at least two clusters (the clustered variance is unestimable
+          otherwise); when the effective size cannot be estimated (`p̂` exactly
+          0 or 1, or zero clustered variance) the unadjusted `n` is used. See
+          Franco et al. (https://pmc.ncbi.nlm.nih.gov/articles/PMC6690503/).
 
     Returns:
        ci_wilson metric returning a mapping `{"lower": ..., "upper": ...}`.
@@ -308,18 +312,15 @@ def ci_wilson(
             f"ci_wilson `level` must be in the open interval (0, 1), got {level}"
         )
 
-    z = NormalDist().inv_cdf(1.0 - (1.0 - level) / 2.0)
+    tail = (1.0 - level) / 2.0
+    # compute z from the lower tail: 1 - tail can round to exactly 1.0 for
+    # levels within one ulp of 1, which inv_cdf rejects
+    z = -NormalDist().inv_cdf(tail)
 
     def metric_fn(scores: list[SampleScore]) -> Value:
-        # validate and partition clusters before any short-circuit, so a
-        # misconfigured cluster key fails loudly even on singleton inputs
-        # (mirroring ci()'s behavior)
-        partition = (
-            _cluster_partition(scores, cluster, to_float, "ci_wilson")
-            if cluster is not None
-            else None
-        )
-
+        # convert (and range-validate) each score exactly once: converters
+        # are arbitrary callables and need not be pure, so p_hat and the
+        # cluster partition must see the same values
         values: list[float] = []
         for sample_score in scores:
             value = to_float(sample_score.score.value)
@@ -331,37 +332,54 @@ def ci_wilson(
                 )
             values.append(value)
 
+        # validate and partition clusters before any short-circuit, so a
+        # misconfigured cluster key fails loudly even on degenerate inputs
+        # (mirroring ci()'s behavior)
+        partition = (
+            _cluster_partition(scores, cluster, values, "ci_wilson")
+            if cluster is not None
+            else None
+        )
+        if partition is not None and len(partition) < 2:
+            raise ValueError(
+                "Computing `ci_wilson` with clustering requires at least two "
+                f"clusters, but the '{cluster}' metadata contains "
+                f"{len(partition)}. The clustered variance is unestimable "
+                "from a single cluster."
+            )
+
         if len(values) == 0:
             return {"lower": 0.0, "upper": 0.0}
 
         n = float(len(values))
         p_hat = sum(values) / n
 
-        # clustered intervals use the effective sample size n / DEFF, where
-        # the design effect compares the clustered variance of the mean to
-        # the simple-random-sampling variance. The SRS reference uses the
-        # Bessel-corrected p(1-p)/(n-1) to match the finite-cluster
-        # correction inside _clustered_stderr — with the uncorrected p(1-p)/n
-        # reference, singleton clusters (which carry no correlation
-        # information) would produce a spurious DEFF of exactly n/(n-1)
-        # instead of 1.
-        if partition is not None and len(values) > 1:
-            srs_variance = p_hat * (1.0 - p_hat) / (n - 1.0)
+        if partition is None:
+            critical = z
+        else:
+            # Korn-Graubard: effective sample size p(1-p) / clustered_var,
+            # capped at n so negative intra-cluster correlation cannot
+            # produce an interval narrower than the unclustered one
             clustered_variance = _clustered_stderr(partition) ** 2
-            # zero variance on either side makes the ratio meaningless
-            # (p_hat of exactly 0 or 1, a single cluster, or perfectly
-            # cancelling clusters): fall back to the unadjusted sample size
-            if srs_variance > 0.0 and clustered_variance > 0.0:
-                design_effect = clustered_variance / srs_variance
-                # cap at n so negative intra-cluster correlation cannot
-                # produce an interval narrower than the unclustered one
-                n = min(n / design_effect, n)
+            numerator = p_hat * (1.0 - p_hat)
+            # zero on either side makes the ratio meaningless (p_hat exactly
+            # 0 or 1, or perfectly cancelling clusters): use the unadjusted n
+            if numerator > 0.0 and clustered_variance > 0.0:
+                n = min(numerator / clustered_variance, n)
+            # t critical value with clusters - 1 degrees of freedom accounts
+            # for the uncertainty of the variance estimate with few clusters.
+            # _t_inv_cdf takes the upper-tail argument, which rounds to 1.0
+            # for levels within one ulp of 1: degrade to the largest float
+            # below 1 (a huge but finite critical value) rather than raise
+            critical = _t_inv_cdf(
+                min(1.0 - tail, math.nextafter(1.0, 0.0)), len(partition) - 1
+            )
 
-        denominator = 1.0 + z * z / n
-        center = (p_hat + z * z / (2.0 * n)) / denominator
+        denominator = 1.0 + critical * critical / n
+        center = (p_hat + critical * critical / (2.0 * n)) / denominator
         half_width = (
-            z
-            * math.sqrt(p_hat * (1.0 - p_hat) / n + z * z / (4.0 * n * n))
+            critical
+            * math.sqrt(p_hat * (1.0 - p_hat) / n + critical * critical / (4.0 * n * n))
             / denominator
         )
         # bounds are analytically within [0, 1]; clamp for float safety only

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -255,6 +255,124 @@ def ci(
     return metric_fn
 
 
+@metric
+def ci_wilson(
+    level: float = 0.95,
+    to_float: ValueToFloat = value_to_float(),
+    cluster: str | None = None,
+) -> Metric:
+    """Wilson score confidence interval for the mean of binary (0/1) scores.
+
+    Treats the mean score as a binomial proportion and reports the two-sided
+    `level` Wilson score interval as a mapping with `lower` and `upper`
+    bounds. Unlike the t interval from `ci()`, the bounds are always within
+    [0, 1] and remain well calibrated for small samples and for proportions
+    near 0 or 1 — prefer this metric over `ci()` for binary scores such as
+    accuracy.
+
+    Score values must lie in [0, 1]: values outside that range raise a
+    `ValueError` (there is no binomial reading of such data). Non-binary
+    values within [0, 1] (e.g. PARTIAL scored as 0.5) are accepted; because
+    the variance of any [0, 1]-bounded variable is at most `p̂(1 − p̂)`, the
+    resulting interval is conservative (a little wider than necessary) rather
+    than misleadingly narrow.
+
+    Args:
+       level: Confidence level for the interval (e.g. `0.95` for a 95%
+          interval). Must be in the open interval (0, 1).
+       to_float: Function for mapping `Value` to float for computing metrics. The
+          default `value_to_float()` maps CORRECT ("C") to 1.0, INCORRECT ("I") to
+          0, PARTIAL ("P") to 0.5, and NOANSWER ("N") to 0, casts numeric values to
+          float directly, and prints a warning and returns 0 if the `Value` is a
+          complex object (list or dict).
+       cluster (str | None): The key from the Sample metadata corresponding to
+          a cluster identifier for computing
+          [clustered](https://en.wikipedia.org/wiki/Clustered_standard_errors)
+          intervals. When set, the interval uses the effective sample size
+          `n / DEFF` (Korn & Graubard), where the design effect `DEFF` is the
+          ratio of the clustered variance of the mean to the Bessel-corrected
+          simple-random-sampling variance `p̂(1 − p̂)/(n − 1)`, so the interval
+          accounts for within-cluster correlation. The effective sample size
+          is capped at `n`, and whenever the design effect cannot be estimated
+          (either variance is zero: `p̂` exactly 0 or 1, fewer than two
+          clusters, or perfectly cancelling clusters) the unadjusted `n` is
+          used.
+
+    Returns:
+       ci_wilson metric returning a mapping `{"lower": ..., "upper": ...}`.
+    """
+    from statistics import NormalDist
+
+    if not 0.0 < level < 1.0:
+        raise ValueError(
+            f"ci_wilson `level` must be in the open interval (0, 1), got {level}"
+        )
+
+    z = NormalDist().inv_cdf(1.0 - (1.0 - level) / 2.0)
+
+    def metric_fn(scores: list[SampleScore]) -> Value:
+        # validate and partition clusters before any short-circuit, so a
+        # misconfigured cluster key fails loudly even on singleton inputs
+        # (mirroring ci()'s behavior)
+        partition = (
+            _cluster_partition(scores, cluster, to_float, "ci_wilson")
+            if cluster is not None
+            else None
+        )
+
+        values: list[float] = []
+        for sample_score in scores:
+            value = to_float(sample_score.score.value)
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"Sample {sample_score.sample_id} has score value {value}. "
+                    "`ci_wilson` treats the mean score as a binomial proportion, "
+                    "so all score values must be between 0 and 1."
+                )
+            values.append(value)
+
+        if len(values) == 0:
+            return {"lower": 0.0, "upper": 0.0}
+
+        n = float(len(values))
+        p_hat = sum(values) / n
+
+        # clustered intervals use the effective sample size n / DEFF, where
+        # the design effect compares the clustered variance of the mean to
+        # the simple-random-sampling variance. The SRS reference uses the
+        # Bessel-corrected p(1-p)/(n-1) to match the finite-cluster
+        # correction inside _clustered_stderr — with the uncorrected p(1-p)/n
+        # reference, singleton clusters (which carry no correlation
+        # information) would produce a spurious DEFF of exactly n/(n-1)
+        # instead of 1.
+        if partition is not None and len(values) > 1:
+            srs_variance = p_hat * (1.0 - p_hat) / (n - 1.0)
+            clustered_variance = _clustered_stderr(partition) ** 2
+            # zero variance on either side makes the ratio meaningless
+            # (p_hat of exactly 0 or 1, a single cluster, or perfectly
+            # cancelling clusters): fall back to the unadjusted sample size
+            if srs_variance > 0.0 and clustered_variance > 0.0:
+                design_effect = clustered_variance / srs_variance
+                # cap at n so negative intra-cluster correlation cannot
+                # produce an interval narrower than the unclustered one
+                n = min(n / design_effect, n)
+
+        denominator = 1.0 + z * z / n
+        center = (p_hat + z * z / (2.0 * n)) / denominator
+        half_width = (
+            z
+            * math.sqrt(p_hat * (1.0 - p_hat) / n + z * z / (4.0 * n * n))
+            / denominator
+        )
+        # bounds are analytically within [0, 1]; clamp for float safety only
+        return {
+            "lower": max(center - half_width, 0.0),
+            "upper": min(center + half_width, 1.0),
+        }
+
+    return metric_fn
+
+
 def _clt_stderr(values: list[float]) -> float:
     """Central Limit Theorem standard error of the mean of `values`."""
     import numpy as np

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -32,7 +32,7 @@ from inspect_ai.scorer._metric import (
     metric_create,
 )
 from inspect_ai.scorer._metrics import aggregate, grouped
-from inspect_ai.scorer._metrics.std import _t_inv_cdf, ci, stderr
+from inspect_ai.scorer._metrics.std import _t_inv_cdf, ci, ci_wilson, stderr
 from inspect_ai.scorer._target import Target
 from inspect_ai.solver._task_state import TaskState
 
@@ -1322,3 +1322,227 @@ def test_ci_metric_end_to_end():
     half_width = _t_inv_cdf(0.975, 3) * se
     assert metrics["lower"].value == pytest.approx(0.5 - half_width, rel=1e-9)
     assert metrics["upper"].value == pytest.approx(0.5 + half_width, rel=1e-9)
+
+
+# --- ci_wilson() binomial-proportion confidence interval --------------------
+
+
+Z_975 = 1.959963984540054  # scipy.stats.norm.ppf(0.975), for test-side references
+
+
+def binary_scores(successes: int, n: int) -> list[SampleScore]:
+    return [
+        SampleScore(score=Score(value=1.0 if i < successes else 0.0)) for i in range(n)
+    ]
+
+
+def wilson_reference(p_hat: float, n: float, z: float) -> tuple[float, float]:
+    """Test-side closed-form Wilson interval for cross-checking."""
+    denom = 1.0 + z * z / n
+    center = (p_hat + z * z / (2.0 * n)) / denom
+    half_width = (
+        z * math.sqrt(p_hat * (1.0 - p_hat) / n + z * z / (4.0 * n * n)) / denom
+    )
+    return center - half_width, center + half_width
+
+
+def test_ci_wilson_reference_values():
+    # references: scipy.stats.binomtest(k, n).proportion_ci(level, "wilson")
+    # computed externally
+    known = [
+        (8, 10, 0.95, 0.4901624715366418, 0.9433178485456248),
+        (0, 20, 0.95, 0.0, 0.16112515805281935),
+        (20, 20, 0.95, 0.8388748419471808, 1.0),
+        (5, 50, 0.90, 0.04952903447744518, 0.1915375141515709),
+        (5, 50, 0.99, 0.03399088377841833, 0.2597307895956841),
+        (49, 100, 0.95, 0.3942199893044114, 0.5865198806597284),
+    ]
+    for successes, n, level, lower, upper in known:
+        interval = ci_wilson(level=level)(binary_scores(successes, n))
+        assert interval["lower"] == pytest.approx(lower, rel=1e-9), (successes, n)
+        assert interval["upper"] == pytest.approx(upper, rel=1e-9), (successes, n)
+
+
+def test_ci_wilson_symmetric_at_half():
+    interval = ci_wilson()(binary_scores(10, 20))
+    assert interval["lower"] == pytest.approx(1.0 - interval["upper"], rel=1e-12)
+
+
+def test_ci_wilson_bounded_where_t_overshoots():
+    # 19/20 correct: the t interval's upper bound exceeds 1.0; Wilson must not
+    scores = binary_scores(19, 20)
+    t_interval = ci()(scores)
+    wilson_interval = ci_wilson()(scores)
+    assert t_interval["upper"] > 1.0
+    assert wilson_interval["upper"] <= 1.0
+    assert 0.0 <= wilson_interval["lower"] < wilson_interval["upper"]
+
+
+def test_ci_wilson_level_widens_interval():
+    narrow = ci_wilson(level=0.80)(binary_scores(15, 30))
+    wide = ci_wilson(level=0.99)(binary_scores(15, 30))
+    assert (wide["upper"] - wide["lower"]) > (narrow["upper"] - narrow["lower"])
+
+
+def test_ci_wilson_invalid_level_raises():
+    with pytest.raises(ValueError):
+        ci_wilson(level=0.0)
+    with pytest.raises(ValueError):
+        ci_wilson(level=1.5)
+
+
+def test_ci_wilson_out_of_range_value_raises():
+    with pytest.raises(ValueError, match="0 and 1"):
+        ci_wilson()([SampleScore(score=Score(value=2.0))])
+    with pytest.raises(ValueError, match="0 and 1"):
+        ci_wilson()(
+            [SampleScore(score=Score(value=0.0)), SampleScore(score=Score(value=-0.5))]
+        )
+
+
+def test_ci_wilson_tolerates_graded_values():
+    # values in [0, 1] that are not 0/1 (e.g. PARTIAL -> 0.5) are accepted;
+    # the interval treats the mean as a proportion (conservative)
+    scores = [SampleScore(score=Score(value=v)) for v in (0.0, 0.5, 0.5, 1.0)]
+    interval = ci_wilson()(scores)
+    assert 0.0 <= interval["lower"] < 0.5 < interval["upper"] <= 1.0
+
+
+def test_ci_wilson_empty_and_singleton():
+    assert ci_wilson()([]) == {"lower": 0.0, "upper": 0.0}
+    # unlike t/bootstrap, Wilson is well-defined at n=1: reference from
+    # scipy binomtest(1, 1).proportion_ci(0.95, "wilson")
+    interval = ci_wilson()(binary_scores(1, 1))
+    assert interval["lower"] == pytest.approx(0.20654931437723745, rel=1e-9)
+    assert interval["upper"] == pytest.approx(1.0)
+
+
+def test_ci_wilson_clustered_widens_with_positive_icc():
+    # perfectly correlated clusters: strong design effect, interval must be
+    # wider than the unclustered one and match the effective-sample-size
+    # construction computed from the (public) clustered stderr
+    scores = [
+        SampleScore(score=Score(value=float(c % 2)), sample_metadata={"c": c})
+        for c in range(6)
+        for _ in range(4)
+    ]
+    unclustered = ci_wilson()(scores)
+    clustered = ci_wilson(cluster="c")(scores)
+    assert (clustered["upper"] - clustered["lower"]) > (
+        unclustered["upper"] - unclustered["lower"]
+    )
+
+    n = len(scores)
+    p_hat = 0.5
+    se_clustered = stderr(cluster="c")(scores)
+    # the DEFF reference is the Bessel-corrected SRS variance of the mean,
+    # matching the finite-cluster-corrected clustered variance
+    deff = (se_clustered**2) / (p_hat * (1.0 - p_hat) / (n - 1))
+    n_eff = min(n / deff, n)
+    lower, upper = wilson_reference(p_hat, n_eff, Z_975)
+    assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
+    assert clustered["upper"] == pytest.approx(upper, rel=1e-9)
+
+
+def test_ci_wilson_singleton_clusters_match_unclustered():
+    # one sample per cluster carries no correlation information: DEFF must be
+    # exactly 1 (dof-consistent variance estimators), not n/(n-1)
+    scores = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i})
+        for i in range(4)
+    ]
+    clustered = ci_wilson(cluster="c")(scores)
+    unclustered = ci_wilson()(scores)
+    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
+    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+
+
+def test_ci_wilson_clustered_capped_at_unclustered():
+    # negative intra-cluster correlation with strictly positive clustered
+    # variance (0 < DEFF < 1): n_eff is capped at n, so the clustered
+    # interval must equal (not be narrower than) the unclustered one
+    scores = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i // 2})
+        for i in range(16)
+    ] + [
+        SampleScore(score=Score(value=1.0), sample_metadata={"c": "x"}),
+        SampleScore(score=Score(value=0.0), sample_metadata={"c": "y"}),
+    ]
+    n = len(scores)
+    p_hat = 0.5
+    se_clustered = stderr(cluster="c")(scores)
+    deff = (se_clustered**2) / (p_hat * (1.0 - p_hat) / (n - 1))
+    assert 0.0 < deff < 1.0  # the config must actually reach the cap branch
+    clustered = ci_wilson(cluster="c")(scores)
+    unclustered = ci_wilson()(scores)
+    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
+    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+
+
+def test_ci_wilson_zero_clustered_variance_falls_back():
+    # perfectly cancelling clusters make the clustered variance exactly 0
+    # (0/0 design effect): fall back to the unadjusted sample size
+    scores = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i // 2})
+        for i in range(20)
+    ]
+    clustered = ci_wilson(cluster="c")(scores)
+    unclustered = ci_wilson()(scores)
+    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
+    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+
+
+def test_ci_wilson_clustered_degenerate_proportion_falls_back():
+    # p_hat of 0 or 1 makes DEFF 0/0: fall back to the unadjusted n
+    scores = [
+        SampleScore(score=Score(value=1.0), sample_metadata={"c": i // 5})
+        for i in range(20)
+    ]
+    clustered = ci_wilson(cluster="c")(scores)
+    unclustered = ci_wilson()(scores)
+    assert clustered == pytest.approx(unclustered)
+    assert clustered["upper"] == pytest.approx(1.0)
+
+
+def test_ci_wilson_cluster_validation():
+    # missing/None/NaN cluster ids raise (shared _cluster_partition semantics),
+    # and validation is not masked by the empty/singleton short-circuit
+    with pytest.raises(ValueError, match="has no cluster metadata"):
+        ci_wilson(cluster="c")([SampleScore(score=Score(value=1.0))])
+    with pytest.raises(ValueError, match="has no cluster metadata"):
+        ci_wilson(cluster="c")(
+            [
+                SampleScore(
+                    score=Score(value=1.0), sample_metadata={"c": float("nan")}
+                ),
+                SampleScore(score=Score(value=0.0), sample_metadata={"c": "a"}),
+            ]
+        )
+
+
+def test_ci_wilson_metric_end_to_end():
+    # verify the dict value flattens into per-key EvalMetric entries with
+    # group "ci_wilson" (distinct from ci()'s group) in a real eval log
+    from inspect_ai.scorer import scorer
+
+    @scorer(metrics=[ci_wilson()])
+    def binary_value_scorer():
+        async def score(state: TaskState, target: Target) -> Score:
+            return Score(value=float(state.input_text))
+
+        return score
+
+    task = Task(
+        dataset=[Sample(input=str(v), target="-") for v in (0, 1, 1, 1)],
+        scorer=binary_value_scorer(),
+    )
+    log = eval(task, model="mockllm/model", display="none")[0]
+
+    assert log.results is not None
+    metrics = log.results.scores[0].metrics
+    assert set(metrics) >= {"lower", "upper"}
+    assert metrics["lower"].group == "ci_wilson"
+    assert metrics["upper"].group == "ci_wilson"
+    lower, upper = wilson_reference(0.75, 4, Z_975)
+    assert metrics["lower"].value == pytest.approx(lower, rel=1e-9)
+    assert metrics["upper"].value == pytest.approx(upper, rel=1e-9)

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -1417,10 +1417,27 @@ def test_ci_wilson_empty_and_singleton():
     assert interval["upper"] == pytest.approx(1.0)
 
 
+def test_ci_wilson_extreme_level_does_not_round_to_one():
+    # the largest float below 1.0 passes 0 < level < 1 but makes
+    # 1 - (1 - level)/2 round to exactly 1.0; the z computation must use the
+    # lower tail so inv_cdf never sees 1.0
+    level = math.nextafter(1.0, 0.0)
+    interval = ci_wilson(level=level)(binary_scores(5, 10))
+    assert 0.0 <= interval["lower"] < interval["upper"] <= 1.0
+    # clustered path (t critical value) must not crash either
+    scores = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i % 4})
+        for i in range(16)
+    ]
+    interval = ci_wilson(level=level, cluster="c")(scores)
+    assert 0.0 <= interval["lower"] <= interval["upper"] <= 1.0
+
+
 def test_ci_wilson_clustered_widens_with_positive_icc():
     # perfectly correlated clusters: strong design effect, interval must be
-    # wider than the unclustered one and match the effective-sample-size
-    # construction computed from the (public) clustered stderr
+    # wider than the unclustered one and match the Korn-Graubard construction
+    # (n_eff = p(1-p) / clustered_var, t critical value with clusters - 1 df)
+    # computed from the (public) clustered stderr
     scores = [
         SampleScore(score=Score(value=float(c % 2)), sample_metadata={"c": c})
         for c in range(6)
@@ -1432,35 +1449,49 @@ def test_ci_wilson_clustered_widens_with_positive_icc():
         unclustered["upper"] - unclustered["lower"]
     )
 
-    n = len(scores)
     p_hat = 0.5
-    se_clustered = stderr(cluster="c")(scores)
-    # the DEFF reference is the Bessel-corrected SRS variance of the mean,
-    # matching the finite-cluster-corrected clustered variance
-    deff = (se_clustered**2) / (p_hat * (1.0 - p_hat) / (n - 1))
-    n_eff = min(n / deff, n)
-    lower, upper = wilson_reference(p_hat, n_eff, Z_975)
+    n_eff = p_hat * (1.0 - p_hat) / stderr(cluster="c")(scores) ** 2
+    t_crit = _t_inv_cdf(0.975, 5)  # 6 clusters -> df = 5
+    lower, upper = wilson_reference(p_hat, n_eff, t_crit)
     assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
     assert clustered["upper"] == pytest.approx(upper, rel=1e-9)
 
 
-def test_ci_wilson_singleton_clusters_match_unclustered():
-    # one sample per cluster carries no correlation information: DEFF must be
-    # exactly 1 (dof-consistent variance estimators), not n/(n-1)
+def test_ci_wilson_perfectly_correlated_pair_of_clusters():
+    # two clusters [0, 0] and [1, 1]: each perfectly-correlated cluster is one
+    # effective observation, so n_eff must be exactly 1 (not 4/3, the artifact
+    # of a dof-inconsistent design-effect reference)
+    scores = [
+        SampleScore(score=Score(value=v), sample_metadata={"c": c})
+        for c, v in (("a", 0.0), ("a", 0.0), ("b", 1.0), ("b", 1.0))
+    ]
+    interval = ci_wilson(cluster="c")(scores)
+    lower, upper = wilson_reference(0.5, 1.0, _t_inv_cdf(0.975, 1))
+    assert interval["lower"] == pytest.approx(lower, rel=1e-9)
+    assert interval["upper"] == pytest.approx(upper, rel=1e-9)
+
+
+def test_ci_wilson_singleton_clusters_slightly_conservative():
+    # one sample per cluster: the finite-cluster-corrected variance gives
+    # n_eff = n - 1 (mildly conservative), with t on n - 1 df
     scores = [
         SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i})
         for i in range(4)
     ]
     clustered = ci_wilson(cluster="c")(scores)
     unclustered = ci_wilson()(scores)
-    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
-    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+    assert (clustered["upper"] - clustered["lower"]) > (
+        unclustered["upper"] - unclustered["lower"]
+    )
+    lower, upper = wilson_reference(0.5, 3.0, _t_inv_cdf(0.975, 3))
+    assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
+    assert clustered["upper"] == pytest.approx(upper, rel=1e-9)
 
 
-def test_ci_wilson_clustered_capped_at_unclustered():
+def test_ci_wilson_clustered_n_eff_capped_at_n():
     # negative intra-cluster correlation with strictly positive clustered
-    # variance (0 < DEFF < 1): n_eff is capped at n, so the clustered
-    # interval must equal (not be narrower than) the unclustered one
+    # variance: p(1-p)/clustered_var exceeds n, so n_eff is capped at n
+    # (only the t critical value differs from the unclustered interval)
     scores = [
         SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i // 2})
         for i in range(16)
@@ -1470,38 +1501,56 @@ def test_ci_wilson_clustered_capped_at_unclustered():
     ]
     n = len(scores)
     p_hat = 0.5
-    se_clustered = stderr(cluster="c")(scores)
-    deff = (se_clustered**2) / (p_hat * (1.0 - p_hat) / (n - 1))
-    assert 0.0 < deff < 1.0  # the config must actually reach the cap branch
+    clustered_var = stderr(cluster="c")(scores) ** 2
+    assert p_hat * (1.0 - p_hat) / clustered_var > n  # must actually hit the cap
     clustered = ci_wilson(cluster="c")(scores)
-    unclustered = ci_wilson()(scores)
-    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
-    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+    lower, upper = wilson_reference(p_hat, float(n), _t_inv_cdf(0.975, 9))
+    assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
+    assert clustered["upper"] == pytest.approx(upper, rel=1e-9)
 
 
 def test_ci_wilson_zero_clustered_variance_falls_back():
     # perfectly cancelling clusters make the clustered variance exactly 0
-    # (0/0 design effect): fall back to the unadjusted sample size
+    # (n_eff would be infinite): fall back to the unadjusted sample size,
+    # keeping the clusters - 1 df critical value
     scores = [
         SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i // 2})
         for i in range(20)
     ]
     clustered = ci_wilson(cluster="c")(scores)
-    unclustered = ci_wilson()(scores)
-    assert clustered["lower"] == pytest.approx(unclustered["lower"], rel=1e-12)
-    assert clustered["upper"] == pytest.approx(unclustered["upper"], rel=1e-12)
+    lower, upper = wilson_reference(0.5, 20.0, _t_inv_cdf(0.975, 9))
+    assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
+    assert clustered["upper"] == pytest.approx(upper, rel=1e-9)
 
 
 def test_ci_wilson_clustered_degenerate_proportion_falls_back():
-    # p_hat of 0 or 1 makes DEFF 0/0: fall back to the unadjusted n
+    # p_hat of 0 or 1 makes the design effect 0/0: fall back to the
+    # unadjusted n, keeping the clusters - 1 df critical value
     scores = [
         SampleScore(score=Score(value=1.0), sample_metadata={"c": i // 5})
         for i in range(20)
     ]
     clustered = ci_wilson(cluster="c")(scores)
-    unclustered = ci_wilson()(scores)
-    assert clustered == pytest.approx(unclustered)
+    lower, upper = wilson_reference(1.0, 20.0, _t_inv_cdf(0.975, 3))
+    assert clustered["lower"] == pytest.approx(lower, rel=1e-9)
     assert clustered["upper"] == pytest.approx(1.0)
+
+
+def test_ci_wilson_fewer_than_two_clusters_raises():
+    # cluster variance is unestimable from a single cluster (or none): raise
+    # rather than silently reporting the unclustered interval
+    single_cluster = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": "only"})
+        for i in range(10)
+    ]
+    with pytest.raises(ValueError, match="at least two clusters"):
+        ci_wilson(cluster="c")(single_cluster)
+    with pytest.raises(ValueError, match="at least two clusters"):
+        ci_wilson(cluster="c")(
+            [SampleScore(score=Score(value=1.0), sample_metadata={"c": "only"})]
+        )
+    with pytest.raises(ValueError, match="at least two clusters"):
+        ci_wilson(cluster="c")([])
 
 
 def test_ci_wilson_cluster_validation():
@@ -1518,6 +1567,27 @@ def test_ci_wilson_cluster_validation():
                 SampleScore(score=Score(value=0.0), sample_metadata={"c": "a"}),
             ]
         )
+
+
+def test_ci_wilson_converts_values_exactly_once():
+    # ValueToFloat is an arbitrary callable and need not be pure: the metric
+    # must convert each score exactly once and reuse the cached values for
+    # p_hat and the cluster partition
+    calls = {"count": 0}
+
+    def counting_to_float(value):
+        calls["count"] += 1
+        return float(value)
+
+    scores = [
+        SampleScore(score=Score(value=float(i % 2)), sample_metadata={"c": i % 3})
+        for i in range(12)
+    ]
+    ci_wilson(to_float=counting_to_float, cluster="c")(scores)
+    assert calls["count"] == len(scores)
+    calls["count"] = 0
+    ci_wilson(to_float=counting_to_float)(scores)
+    assert calls["count"] == len(scores)
 
 
 def test_ci_wilson_metric_end_to_end():


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #4161** — the base branch `feature/ci-metric` is an upstream mirror of that PR's head, so the diff shown here is exactly the `ci_wilson` changes. Once #4161 merges: retarget base to `main`, rebase, delete the mirror branch, and mark ready for review.

## This PR contains:

- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`ci()` (#4161) reports t or bootstrap confidence intervals for the mean of arbitrary scores. For binary (0/1) scores — the common eval case, accuracy — the t interval can overshoot the [0, 1] bounds (e.g. 19/20 correct yields an upper bound above 1.0) and is poorly calibrated for small samples and proportions near 0 or 1.

### What is the new behavior?

New `ci_wilson()` metric reporting the two-sided Wilson score confidence interval for the mean of binary scores, treating it as a binomial proportion. Same `{"lower", "upper"}` mapping shape as `ci()`, so it flattens into per-key metric entries with `group="ci_wilson"` — displayed as its own grouped header in the viewer and unambiguous columns in analysis dataframes, distinguishable from `ci()` at a glance.

- Bounds are always within [0, 1]; well calibrated at small `n` (well-defined even at `n = 1`) and at proportions near 0/1. Docs cross-reference: prefer `ci_wilson()` over `ci()` for binary scores.
- `level=` sets the confidence level (default 0.95); invalid levels fail at construction. The normal quantile comes from stdlib `statistics.NormalDist` (no new dependency), computed from the lower tail so valid levels within one float ulp of 1.0 don't collapse the quantile argument to exactly 1.
- Score values must lie in [0, 1] (`ValueError` otherwise — there is no binomial reading of such data). Non-binary values within [0, 1] (e.g. PARTIAL as 0.5) are accepted: variance of any [0,1]-bounded variable is at most `p̂(1−p̂)`, so the interval is conservative rather than misleadingly narrow.
- `cluster=` computes a clustered interval (Korn & Graubard; Franco et al. §2.8/§3.3; Dean & Pagano 2015): the effective sample size `n_eff = min(p̂(1−p̂)/v̂, n)` — `v̂` being the clustered variance of the mean from the shared `_clustered_stderr`/`_cluster_partition` helpers of #4161 — with a Student-t critical value on `clusters − 1` degrees of freedom in place of z, accounting for both within-cluster correlation and the uncertainty of the variance estimate when clusters are few. Requires at least two clusters (`ValueError` otherwise: the clustered variance is unestimable, and silently reporting the independence interval would understate uncertainty). When the effective size cannot be estimated (`p̂` exactly 0/1, or zero clustered variance from perfectly cancelling clusters) the unadjusted `n` is used, still with the t critical value. Singleton clusters yield `n_eff = n − 1` (mildly conservative). Cluster-id validation (missing/None/NaN raise) is shared with `ci()`/`stderr()`.

Rationale for a separate metric rather than `ci(method="wilson")`: metric identity propagates to results surfaces via the registry name (viewer group headers, terminal keys, dataframe columns), while constructor params propagate almost nowhere — a Wilson variant hidden behind `method=` would be indistinguishable from a t interval everywhere results are displayed. Also principled: t/bootstrap estimate the same estimand (mean CI); Wilson targets a different one (binomial proportion).

### Does this PR introduce a breaking change?

No.

### Other information:

Tests: 19 covering scipy-referenced interval values (six (k, n, level) combos at 1e-9, computed externally via `scipy.stats.binomtest(...).proportion_ci(method="wilson")`), symmetry at p̂ = 0.5, boundedness where the t interval overshoots, level monotonicity (plus the within-one-ulp-of-1.0 level edge on both paths), construction-time validation, out-of-range and graded-value input policy, empty/singleton behavior, clustered widening under positive intra-cluster correlation (cross-checked against `stderr(cluster=)`), the perfectly-correlated two-cluster case (n_eff exactly 1), singleton clusters (n_eff = n − 1), the n_eff cap under negative correlation (asserted to actually reach the cap branch), zero-variance and degenerate-proportion fallbacks, the fewer-than-two-clusters rejection, exactly-once `to_float` conversion, cluster-id validation, and an end-to-end `eval()` verifying flattened `lower`/`upper` entries with `group="ci_wilson"`. `ruff check`/`ruff format` clean; `mypy` clean for `std.py`; `tests/scorer` 554 passed.

### Agent review

AI tooling: implemented by Claude Code (Fable 5) on dragonstyle's behalf, TDD (tests written and observed failing before implementation). Two review passes:

1. **Pre-open adversarial pass** (Fable 5, fresh context, separate session from the implementer) over the implementation commit: 2 findings, both fixed and regression-tested before opening — (a) a dof-inconsistent design-effect reference giving singleton clusters a spurious DEFF of n/(n−1); (b) an incomplete docstring description of the zero-variance fallback. Also flagged that the n_eff-cap test never reached the cap branch; replaced with a configuration asserted to exercise it.
2. **Maintainer-side review** (GPT-5.6 Sol, extra-high reasoning effort, posted as PR review comments): 4 findings, all addressed in bbc6d8842 and threads resolved — (a) the clustered construction under-adjusted uncertainty (superseded the pass-1 DEFF construction entirely: now the cited Korn–Graubard effective sample size p̂(1−p̂)/v̂ capped at n, Student-t critical value on clusters−1 df, and ≥2 clusters required rather than a silent independence fallback); (b) score values were converted via `to_float` twice (fixed — `_cluster_partition` now takes pre-converted values, which also removes `ci()`'s pre-existing double conversion); (c) levels within one ulp of 1.0 crashed `inv_cdf` via upper-tail cancellation (fixed — lower-tail form, regression-tested; the analogous cancellation in `ci()`'s `_t_inv_cdf` is noted for #4161); (d) changelog entry violated the no-PR-refs rule (fixed).

No findings dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
