### PR TITLE
Fix Anthropic evals failing with anthropic SDK 1.0 (temperature TypeError, raw-response parse, httpx2 type errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Metrics: Add `ci()` metric reporting a confidence interval for the mean (as `{"lower", "upper"}`). Defaults to `mean ± t · stderr` with a Student-t critical value (`n - 1` degrees of freedom; `clusters - 1` when `cluster=` is set) so small samples get honest widths; `method="bootstrap"` gives a percentile (cluster) bootstrap interval. (#4160)
-- Anthropic: Compatibility with anthropic SDK 0.124.0, which is now the minimum supported version (browser state tool results and file-based image/document sources no longer fail type checking).
+- Anthropic: Compatibility with anthropic SDK 1.0.0, which is now the minimum supported version (`temperature`/`top_p`/`top_k` continue to work on models that support them; browser state tool results and file-based image/document sources no longer fail type checking).
 - OpenAI: Responses API usage now records `cache_write_tokens` as `ModelUsage.input_tokens_cache_write` and excludes it from full-rate `input_tokens` (generate and compaction responses); compaction usage also now excludes cache reads and records reasoning tokens. (#4855)
 - Sandbox: Editable installs now avoid spurious `-dev` sandbox-tools binaries when local main refs are missing, stale, or unavailable.
 - Eval Log: Log directory manifests now strip Windows-style directory prefixes before normalizing paths, avoiding parent directories in bundled listings.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 adlfs>=2025.8.0
-anthropic>=0.124.0
+anthropic>=1.0.0
 antlr4-python3-runtime>=4.9.3,<=4.13.2,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1
 apprise
 aws-bedrock-token-generator

--- a/src/inspect_ai/_cli/ctl/_group.py
+++ b/src/inspect_ai/_cli/ctl/_group.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import copy
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import Any, Literal, NoReturn
 
 import click
 from click.core import ParameterSource
@@ -20,16 +20,12 @@ from inspect_ai._control.discovery import discovery_dir
 from ._failure import _fail
 from ._render import _echo
 
-if TYPE_CHECKING:
-    # click 8.4 made ParamType generic in its stubs, but subscripting it at
-    # runtime raises on the older click versions the package still supports
-    # (>=8.1.3), so the parametrized base is typing-only.
-    _IntOrClearBase = click.ParamType[int | Literal["clear"]]
-else:
-    _IntOrClearBase = click.ParamType
 
-
-class _IntOrClearType(_IntOrClearBase):
+# click 8.4 made ParamType generic in its stubs, but the package supports
+# older click (>=8.1.3) whose stubs reject the subscript (and CI can resolve
+# such versions, e.g. via inspect-scout's click pin), so subclass the
+# unparametrized base; convert() carries the concrete return type.
+class _IntOrClearType(click.ParamType):
     """Non-negative integer, or the keyword ``clear`` (restore launch config).
 
     The override knobs' value domain (the retry overrides and the per-sample

--- a/src/inspect_ai/_util/httpx.py
+++ b/src/inspect_ai/_util/httpx.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import TYPE_CHECKING, Callable
 
 import httpcore
@@ -13,6 +14,49 @@ if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
 logger = logging.getLogger(__name__)
+
+# transport-level errors (from httpx, or raised directly by httpcore, the
+# lower-level library it uses) that should be retried despite carrying no
+# HTTP status code
+_RETRYABLE_NO_STATUS_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.TransportError,
+    httpcore.NetworkError,
+    httpcore.TimeoutException,
+    httpcore.ProtocolError,
+)
+_httpx2_errors_added = False
+
+
+def _retryable_no_status_errors() -> tuple[type[BaseException], ...]:
+    """Exception types (without an HTTP status code) that warrant a retry.
+
+    httpx2/httpcore2 are not direct dependencies of inspect_ai — they arrive
+    transitively with openai >= 3 and anthropic >= 1, whose SDKs are built on
+    them and can surface their exception types; classify those exactly like
+    their legacy httpx/httpcore counterparts. Resolved lazily (an httpx2
+    exception can only exist if httpx2 is already imported) so that importing
+    inspect_ai doesn't pay for importing httpx2. No lock needed: inspect runs
+    on a single event loop thread, and re-running the extension is harmless.
+    """
+    global _RETRYABLE_NO_STATUS_ERRORS, _httpx2_errors_added
+    if not _httpx2_errors_added and "httpx2" in sys.modules:
+        import httpx2
+
+        additions: tuple[type[BaseException], ...] = (httpx2.TransportError,)
+        try:
+            import httpcore2
+
+            additions = additions + (
+                httpcore2.NetworkError,
+                httpcore2.TimeoutException,
+                httpcore2.ProtocolError,
+            )
+        except ImportError:
+            # httpx2's httpcore2 dependency is platform-conditional
+            pass
+        _RETRYABLE_NO_STATUS_ERRORS = _RETRYABLE_NO_STATUS_ERRORS + additions
+        _httpx2_errors_added = True
+    return _RETRYABLE_NO_STATUS_ERRORS
 
 
 def httpx_should_retry(ex: BaseException) -> bool:
@@ -151,20 +195,4 @@ def httpx_should_retry_no_status_code(ex: BaseException) -> bool:
         +-- ReadError
         +-- WriteError
     """
-    # Base class for all exceptions that occur at the level of the Transport API.
-    is_transport_error = isinstance(ex, httpx.TransportError)
-
-    # Sometimes exceptions are raised directly by httpcore, the lower-level library that httpx uses
-    is_httpcore_network_error = isinstance(ex, httpcore.NetworkError)
-    is_httpcore_timeout_error = isinstance(ex, httpcore.TimeoutException)
-    is_httpcore_protocol_error = isinstance(ex, httpcore.ProtocolError)
-
-    # extensible in case we notice other cases
-    return any(
-        [
-            is_transport_error,
-            is_httpcore_network_error,
-            is_httpcore_timeout_error,
-            is_httpcore_protocol_error,
-        ]
-    )
+    return isinstance(ex, _retryable_no_status_errors())

--- a/src/inspect_ai/_util/httpx.py
+++ b/src/inspect_ai/_util/httpx.py
@@ -15,49 +15,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# transport-level errors (from httpx, or raised directly by httpcore, the
-# lower-level library it uses) that should be retried despite carrying no
-# HTTP status code
-_RETRYABLE_NO_STATUS_ERRORS: tuple[type[BaseException], ...] = (
-    httpx.TransportError,
-    httpcore.NetworkError,
-    httpcore.TimeoutException,
-    httpcore.ProtocolError,
-)
-_httpx2_errors_added = False
-
-
-def _retryable_no_status_errors() -> tuple[type[BaseException], ...]:
-    """Exception types (without an HTTP status code) that warrant a retry.
-
-    httpx2/httpcore2 are not direct dependencies of inspect_ai — they arrive
-    transitively with openai >= 3 and anthropic >= 1, whose SDKs are built on
-    them and can surface their exception types; classify those exactly like
-    their legacy httpx/httpcore counterparts. Resolved lazily (an httpx2
-    exception can only exist if httpx2 is already imported) so that importing
-    inspect_ai doesn't pay for importing httpx2. No lock needed: inspect runs
-    on a single event loop thread, and re-running the extension is harmless.
-    """
-    global _RETRYABLE_NO_STATUS_ERRORS, _httpx2_errors_added
-    if not _httpx2_errors_added and "httpx2" in sys.modules:
-        import httpx2
-
-        additions: tuple[type[BaseException], ...] = (httpx2.TransportError,)
-        try:
-            import httpcore2
-
-            additions = additions + (
-                httpcore2.NetworkError,
-                httpcore2.TimeoutException,
-                httpcore2.ProtocolError,
-            )
-        except ImportError:
-            # httpx2's httpcore2 dependency is platform-conditional
-            pass
-        _RETRYABLE_NO_STATUS_ERRORS = _RETRYABLE_NO_STATUS_ERRORS + additions
-        _httpx2_errors_added = True
-    return _RETRYABLE_NO_STATUS_ERRORS
-
 
 def httpx_should_retry(ex: BaseException) -> bool:
     """Check whether an exception raised from httpx should be retried.
@@ -196,3 +153,47 @@ def httpx_should_retry_no_status_code(ex: BaseException) -> bool:
         +-- WriteError
     """
     return isinstance(ex, _retryable_no_status_errors())
+
+
+# transport-level errors (from httpx, or raised directly by httpcore, the
+# lower-level library it uses) that should be retried despite carrying no
+# HTTP status code
+_RETRYABLE_NO_STATUS_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.TransportError,
+    httpcore.NetworkError,
+    httpcore.TimeoutException,
+    httpcore.ProtocolError,
+)
+_httpx2_errors_added = False
+
+
+def _retryable_no_status_errors() -> tuple[type[BaseException], ...]:
+    """Exception types (without an HTTP status code) that warrant a retry.
+
+    httpx2/httpcore2 are not direct dependencies of inspect_ai — they arrive
+    transitively with openai >= 3 and anthropic >= 1, whose SDKs are built on
+    them and can surface their exception types; classify those exactly like
+    their legacy httpx/httpcore counterparts. Resolved lazily (an httpx2
+    exception can only exist if httpx2 is already imported) so that importing
+    inspect_ai doesn't pay for importing httpx2. No lock needed: inspect runs
+    on a single event loop thread, and re-running the extension is harmless.
+    """
+    global _RETRYABLE_NO_STATUS_ERRORS, _httpx2_errors_added
+    if not _httpx2_errors_added and "httpx2" in sys.modules:
+        import httpx2
+
+        additions: tuple[type[BaseException], ...] = (httpx2.TransportError,)
+        try:
+            import httpcore2
+
+            additions = additions + (
+                httpcore2.NetworkError,
+                httpcore2.TimeoutException,
+                httpcore2.ProtocolError,
+            )
+        except ImportError:
+            # httpx2's httpcore2 dependency is platform-conditional
+            pass
+        _RETRYABLE_NO_STATUS_ERRORS = _RETRYABLE_NO_STATUS_ERRORS + additions
+        _httpx2_errors_added = True
+    return _RETRYABLE_NO_STATUS_ERRORS

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
 )
 
-import httpx
 from pydantic import BaseModel, Field, ValidationError
 from pydantic_core import to_json
 
@@ -380,6 +379,9 @@ def init_anthropic_request_patch() -> None:
 
     validate_anthropic_client("agent bridge")
 
+    # httpx2 deferred for the same reason as in init_openai_request_patch
+    # above (it arrives transitively via anthropic >= 1)
+    import httpx2
     from anthropic._base_client import AsyncAPIClient, _AsyncStreamT
     from anthropic._constants import RAW_RESPONSE_HEADER
     from anthropic._models import FinalRequestOptions
@@ -422,7 +424,7 @@ def init_anthropic_request_patch() -> None:
         if not raw_response:
             return result
 
-        response = httpx.Response(
+        response = httpx2.Response(
             status_code=200,
             headers={"content-type": "application/json"},
             content=result.model_dump_json().encode(),
@@ -461,6 +463,13 @@ def init_anthropic_request_patch() -> None:
         ):
             # must also be an explicit request for an inspect model
             json_data = cast(dict[str, Any], options.json_data)
+            # anthropic >= 1.0 removed temperature/top_p/top_k from the method
+            # signatures, so callers send them via extra_body — which the SDK
+            # carries in options.extra_json and merges into the body only in
+            # _build_request, below this interception point. merge here so
+            # the bridge sees those fields.
+            if options.extra_json:
+                json_data = json_data | dict(options.extra_json)
             if targets_inspect_model(json_data):
                 if stream:
                     raise_stream_error()

--- a/src/inspect_ai/model/_providers/_anthropic_batch.py
+++ b/src/inspect_ai/model/_providers/_anthropic_batch.py
@@ -1,6 +1,6 @@
-from typing import TypeAlias, cast
+from typing import Any, TypeAlias, cast
 
-import httpx
+import httpx2
 from anthropic import (
     APIConnectionError,
     APITimeoutError,
@@ -69,10 +69,18 @@ class AnthropicBatcher(Batcher[Message, CompletedBatchInfo]):
             request_id = extra_headers.pop(HttpxHooks.REQUEST_ID_HEADER, None)
             if request_id is not None:
                 request.custom_id = request_id
+            # the Batches API has no extra_body: merge it into the request
+            # body root, which is where the SDK would put it on the direct
+            # path (e.g. temperature/top_p/top_k, which anthropic >= 1.0
+            # removed from the method signatures but the API still accepts)
+            params: dict[str, Any] = request.request
+            extra_body = params.pop("extra_body", None)
+            if extra_body:
+                params.update(extra_body)
             requests.append(
                 AnthropicBatchRequest(
                     custom_id=request.custom_id,
-                    params=cast(MessageCreateParamsNonStreaming, request.request),
+                    params=cast(MessageCreateParamsNonStreaming, params),
                 )
             )
 
@@ -145,10 +153,10 @@ def _get_individual_result(
                 error_class = anthropic.InternalServerError
         response = error_class(
             message=message,
-            response=httpx.Response(
+            response=httpx2.Response(
                 status_code=500,
                 text=message,
-                request=httpx.Request(
+                request=httpx2.Request(
                     method="POST",
                     url="https://api.anthropic.com/v1/messages/batches",
                 ),
@@ -159,14 +167,14 @@ def _get_individual_result(
         return response
     elif individual_response.result.type == "canceled":
         return APIConnectionError(
-            request=httpx.Request(
+            request=httpx2.Request(
                 method="POST",
                 url="https://api.anthropic.com/v1/messages/batches",
             )
         )
     elif individual_response.result.type == "expired":
         return APITimeoutError(
-            request=httpx.Request(
+            request=httpx2.Request(
                 method="POST",
                 url="https://api.anthropic.com/v1/messages/batches",
             )

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -922,21 +922,19 @@ class AnthropicAPI(ModelAPI):
                 )
             return _THINKING_WARNING.format(parameter=parameter)
 
-        if config.temperature is not None:
-            if forbid_sampling_params:
-                warn_once(logger, sampling_param_warning("temperature"))
-            else:
-                params["temperature"] = config.temperature
-        if config.top_p is not None:
-            if forbid_sampling_params:
-                warn_once(logger, sampling_param_warning("top_p"))
-            else:
-                params["top_p"] = config.top_p
-        if config.top_k is not None:
-            if forbid_sampling_params:
-                warn_once(logger, sampling_param_warning("top_k"))
-            else:
-                params["top_k"] = config.top_k
+        # anthropic >= 1.0 removed temperature/top_p/top_k from the method
+        # signatures (the API still accepts them for models that support
+        # them), so route via extra_body rather than params
+        for parameter, value in (
+            ("temperature", config.temperature),
+            ("top_p", config.top_p),
+            ("top_k", config.top_k),
+        ):
+            if value is not None:
+                if forbid_sampling_params:
+                    warn_once(logger, sampling_param_warning(parameter))
+                else:
+                    extra_body[parameter] = value
 
         # effort
         if config.effort is not None:

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -377,7 +377,9 @@ def validate_openai_client(feature: str) -> None:
 
 def validate_anthropic_client(feature: str) -> None:
     PACKAGE = "anthropic"
-    MIN_VERSION = "0.124.0"
+    # 1.0.0 removed temperature/top_p/top_k from method signatures, removed
+    # LegacyAPIResponse, and moved from httpx to httpx2 — inspect requires it
+    MIN_VERSION = "1.0.0"
 
     # verify we have the package
     try:

--- a/src/inspect_ai/model/_providers/util/hooks.py
+++ b/src/inspect_ai/model/_providers/util/hooks.py
@@ -278,9 +278,9 @@ class ConverseHooks(HttpHooks):
 
 
 # Structural stand-ins for httpx types, covering only what the hooks touch.
-# The openai SDK is built on `httpx2` while other SDKs (anthropic, google,
-# mistral, groq) hand us legacy `httpx` clients; both flavors satisfy these
-# protocols.
+# The openai (>= 3) and anthropic (>= 1) SDKs are built on `httpx2` while
+# other SDKs (google, mistral, groq) hand us legacy `httpx` clients; both
+# flavors satisfy these protocols.
 class HttpxRequestLike(Protocol):
     @property
     def method(self) -> str: ...

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -385,8 +385,9 @@ def anthropic_agent(
                 await client.messages.create(  # type: ignore[call-overload]
                     model="inspect",
                     max_tokens=4096,
-                    temperature=0.8,
-                    top_k=2,
+                    # anthropic >= 1.0 removed temperature/top_k from the
+                    # method signatures; user code sends them via extra_body
+                    extra_body={"temperature": 0.8, "top_k": 2},
                     thinking={"type": "enabled", "budget_tokens": 2048}
                     if reasoning == "budget"
                     else ANTHROPIC_NOT_GIVEN,
@@ -878,11 +879,7 @@ def test_responses_bridge_computer_use_incompatible_model():
 #   - claude-sonnet-4-5 (pre-4.7): request reasoning depth via a thinking token
 #     budget; the bridge maps `thinking.budget_tokens` -> `reasoning_tokens`.
 #   - claude-sonnet-5 (4.7+): a budget is rejected, so request depth via
-#     `output_config={"effort": ...}`; the bridge maps it -> `effort`. The effort
-#     must go through the SDK's *typed* `output_config` param: the bridge reads the
-#     typed request body, whereas anything passed via `extra_body` is merged into
-#     the wire body only at serialization time (downstream of the bridge) and would
-#     be silently dropped.
+#     `output_config={"effort": ...}`; the bridge maps it -> `effort`.
 @pytest.mark.parametrize(
     "model, reasoning",
     [
@@ -904,6 +901,47 @@ def test_bridged_agent_anthropic_tools():
         "anthropic/claude-sonnet-4-5", agent=anthropic_agent(True)
     )
     check_anthropic_bridge_log_json(log_json, "anthropic/claude-sonnet-4-5", tools=True)
+
+
+def test_anthropic_bridge_forwards_extra_body_sampling_params():
+    """The bridge must see sampling params sent via extra_body.
+
+    anthropic >= 1.0 removed temperature/top_p/top_k from the method
+    signatures, so bridged agents can only send them via extra_body. The SDK
+    carries extra_body in options.extra_json and merges it into the request
+    body downstream of the bridge's interception point, so the bridge must
+    merge it itself or the params are silently dropped.
+    """
+
+    @agent
+    def extra_body_agent() -> Agent:
+        async def execute(state: AgentState) -> AgentState:
+            async with agent_bridge(state, forward_generation_config=True) as bridge:
+                # requests are intercepted by the bridge, so the key is unused
+                async with AsyncAnthropic(api_key="test") as client:
+                    await client.messages.create(
+                        model="inspect",
+                        max_tokens=4096,
+                        extra_body={"temperature": 0.8, "top_k": 2},
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": user_prompt(state.messages).text,
+                            }
+                        ],
+                    )
+                return bridge.state
+
+        return execute
+
+    log = eval(
+        bridged_task(extra_body_agent()),
+        model="mockllm/model",
+    )[0]
+    assert log.status == "success"
+    log_json = log.model_dump_json(exclude_none=True, indent=2)
+    assert r'"temperature": 0.8' in log_json
+    assert r'"top_k": 2' in log_json
 
 
 @skip_if_no_anthropic

--- a/tests/agent/test_bridge_raw_response.py
+++ b/tests/agent/test_bridge_raw_response.py
@@ -232,7 +232,9 @@ async def consume_anthropic_raw_response() -> AnthropicMessage:
             messages=ANTHROPIC_MESSAGES,  # type: ignore[arg-type]
         )
         assert raw.headers is not None
-        message = raw.parse()
+        # anthropic >= 1.0: with_raw_response returns AsyncAPIResponse (not
+        # LegacyAPIResponse), whose parse() is a coroutine
+        message = await raw.parse()
         assert isinstance(message, AnthropicMessage)
         return message
 
@@ -283,7 +285,7 @@ def anthropic_raw_response_beta_agent() -> Agent:
                     messages=ANTHROPIC_MESSAGES,  # type: ignore[arg-type]
                 )
                 assert raw.headers is not None
-                message = raw.parse()
+                message = await raw.parse()
                 assert isinstance(message, BetaMessage)
                 block = message.content[0]
                 assert isinstance(block, BetaTextBlock)

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -330,14 +330,14 @@ def test_anthropic_full_thinking_beta_via_client_default_header() -> None:
 
 
 @skip_if_no_anthropic
-def test_anthropic_should_retry():
-    import httpx
+def test_anthropic_should_retry() -> None:
+    import httpx2
     from anthropic import APIStatusError
 
     # scaffold for should_retry
     model = get_model("anthropic/claude-sonnet-4-6")
-    response = httpx.Response(
-        status_code=405, request=httpx.Request("GET", "https://example.com")
+    response = httpx2.Response(
+        status_code=405, request=httpx2.Request("GET", "https://example.com")
     )
 
     # check whether we handle overloaded_error correctly
@@ -355,8 +355,8 @@ def test_anthropic_should_retry():
     model.api.should_retry(ex)
 
     # truncated request body (TCP interruption) should be retried
-    truncation_response = httpx.Response(
-        status_code=400, request=httpx.Request("POST", "https://example.com")
+    truncation_response = httpx2.Response(
+        status_code=400, request=httpx2.Request("POST", "https://example.com")
     )
     ex = APIStatusError(
         "error",
@@ -372,8 +372,8 @@ def test_anthropic_should_retry():
     assert model.api.should_retry(ex)
 
     # genuine 400 errors should NOT be retried
-    genuine_400_response = httpx.Response(
-        status_code=400, request=httpx.Request("POST", "https://example.com")
+    genuine_400_response = httpx2.Response(
+        status_code=400, request=httpx2.Request("POST", "https://example.com")
     )
     ex = APIStatusError(
         "error",
@@ -391,8 +391,8 @@ def test_anthropic_should_retry():
     # deterministic encoding errors (e.g. surrogate pairs) should NOT be retried
     ex = APIStatusError(
         "error",
-        response=httpx.Response(
-            status_code=400, request=httpx.Request("POST", "https://example.com")
+        response=httpx2.Response(
+            status_code=400, request=httpx2.Request("POST", "https://example.com")
         ),
         body={
             "type": "error",
@@ -414,7 +414,7 @@ def test_anthropic_handle_bad_request_content_filter_apistatuserror() -> None:
     rather than BadRequestError. handle_bad_request() must still convert
     "content filtering" messages into a content_filter refusal.
     """
-    import httpx
+    import httpx2
     from anthropic import APIStatusError
 
     from inspect_ai.model._model_output import ModelOutput
@@ -422,9 +422,9 @@ def test_anthropic_handle_bad_request_content_filter_apistatuserror() -> None:
     api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
     ex = APIStatusError(
         "Output blocked by content filtering policy",
-        response=httpx.Response(
+        response=httpx2.Response(
             status_code=200,
-            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+            request=httpx2.Request("POST", "https://api.anthropic.com/v1/messages"),
         ),
         body={
             "type": "error",
@@ -448,7 +448,7 @@ async def test_anthropic_generate_handles_midstream_content_filter() -> None:
     status_code == 413 and re-raised everything else, so content-filter errors
     that surfaced mid-stream killed the eval instead of becoming a refusal.
     """
-    import httpx
+    import httpx2
     from anthropic import APIStatusError
 
     from inspect_ai.model._model_output import ModelOutput
@@ -466,9 +466,9 @@ async def test_anthropic_generate_handles_midstream_content_filter() -> None:
     ) -> tuple[dict[str, Any], ModelOutput]:
         raise APIStatusError(
             "Output blocked by content filtering policy",
-            response=httpx.Response(
+            response=httpx2.Response(
                 status_code=200,
-                request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+                request=httpx2.Request("POST", "https://api.anthropic.com/v1/messages"),
             ),
             body={
                 "type": "error",
@@ -978,7 +978,10 @@ async def test_anthropic_top_level_cache_control_skipped_on_bedrock_vertex(
     """
     import os
 
-    os.environ.setdefault("AWS_REGION", "us-east-1")
+    # anthropic >= 1.0 requires a region for Bedrock (no more us-east-1
+    # default) and treats an empty AWS_REGION as unset — so must we here
+    if not os.environ.get("AWS_REGION"):
+        os.environ["AWS_REGION"] = "us-east-1"
     os.environ.setdefault("AWS_ACCESS_KEY_ID", "fake")
     os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "fake")
     os.environ.setdefault("ANTHROPIC_VERTEX_PROJECT_ID", "fake")
@@ -1138,10 +1141,9 @@ def test_anthropic_claude_4_7_strips_sampling_params(
 ) -> None:
     """Claude 4.7+ rejects temperature/top_p/top_k outright; the provider must omit them."""
     api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
-    params, _extra_body, _headers, _betas = api.completion_config(
-        _cfg(**{param: value})
-    )
+    params, extra_body, _headers, _betas = api.completion_config(_cfg(**{param: value}))
     assert param not in params
+    assert param not in extra_body
 
 
 @pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
@@ -1150,10 +1152,11 @@ def test_anthropic_claude_4_7_strips_sampling_params_with_reasoning_effort_none(
 ) -> None:
     """reasoning_effort='none' must not re-enable sending sampling params on 4.7."""
     api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
-    params, _extra_body, _headers, _betas = api.completion_config(
+    params, extra_body, _headers, _betas = api.completion_config(
         _cfg(reasoning_effort="none", **{param: value})
     )
     assert param not in params
+    assert param not in extra_body
 
 
 @pytest.mark.parametrize(
@@ -1163,12 +1166,15 @@ def test_anthropic_claude_4_7_strips_sampling_params_with_reasoning_effort_none(
 def test_anthropic_pre_4_7_keeps_sampling_params_without_thinking(
     model_name: str, param: str, value: float | int
 ) -> None:
-    """Pre-4.7 models still accept sampling params when thinking is off."""
+    """Pre-4.7 models still send sampling params when thinking is off.
+
+    anthropic >= 1.0 removed them from the method signatures, so they are
+    routed via extra_body rather than params.
+    """
     api = AnthropicAPI(model_name=model_name, api_key="test-key")
-    params, _extra_body, _headers, _betas = api.completion_config(
-        _cfg(**{param: value})
-    )
-    assert params[param] == value
+    params, extra_body, _headers, _betas = api.completion_config(_cfg(**{param: value}))
+    assert param not in params
+    assert extra_body[param] == value
 
 
 @pytest.mark.parametrize(
@@ -1187,10 +1193,51 @@ def test_anthropic_future_4_7_plus_strips_sampling_params(
 ) -> None:
     """All 4.7+ models inherit the adaptive-thinking restriction."""
     api = AnthropicAPI(model_name=model_name, api_key="test-key")
-    params, _extra_body, _headers, _betas = api.completion_config(
-        _cfg(**{param: value})
-    )
+    params, extra_body, _headers, _betas = api.completion_config(_cfg(**{param: value}))
     assert param not in params
+    assert param not in extra_body
+
+
+@pytest.mark.anyio
+async def test_anthropic_batch_merges_extra_body_into_params() -> None:
+    """The Batches API has no extra_body — its fields (e.g. sampling params) must land directly in each request's params."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import anyio
+
+    from inspect_ai.model._generate_config import BatchConfig
+    from inspect_ai.model._providers._anthropic_batch import AnthropicBatcher
+    from inspect_ai.model._providers.util.batch import BatchRequest
+    from inspect_ai.model._retry import model_retry_config
+
+    client = MagicMock()
+    client.messages.batches.create = AsyncMock(return_value=MagicMock(id="batch_1"))
+    batcher = AnthropicBatcher(
+        client,
+        BatchConfig(size=1, send_delay=0.01, tick=0.001),
+        model_retry_config(
+            "test", 3, None, lambda e: True, lambda ex: None, lambda m, s: None
+        ),
+    )
+    send_stream, _receive_stream = anyio.create_memory_object_stream[Any]()
+    request: BatchRequest[Any] = BatchRequest(
+        request={
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+            "extra_headers": {"x-header": "y"},
+            "extra_body": {"temperature": 0.5, "top_k": 10},
+        },
+        result_stream=send_stream,
+    )
+    batch_id = await batcher._create_batch([request])
+    assert batch_id == "batch_1"
+    (call,) = client.messages.batches.create.call_args_list
+    params = call.kwargs["requests"][0]["params"]
+    assert params["temperature"] == 0.5
+    assert params["top_k"] == 10
+    assert "extra_body" not in params
+    assert call.kwargs["extra_headers"] == {"x-header": "y"}
 
 
 @pytest.fixture

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -27,10 +27,10 @@ def _http_response(
     )
 
 
-def _openai_http_response(
+def _httpx2_response(
     status: int, headers: dict[str, str] | None = None
 ) -> httpx2.Response:
-    """Like _http_response, but httpx2-flavored (what openai >= 3 is built on)."""
+    """Like _http_response, but httpx2-flavored (what openai >= 3 and anthropic >= 1 are built on)."""
     request = httpx2.Request("POST", "https://example.com/v1/chat/completions")
     return httpx2.Response(
         status_code=status,
@@ -117,7 +117,7 @@ def test_openai_classify_rate_limit_429() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _openai_http_response(429, {"retry-after": "30"})
+    response = _httpx2_response(429, {"retry-after": "30"})
     ex = APIStatusError(message="rate limited", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -133,7 +133,7 @@ def test_openai_classify_transient_5xx() -> None:
 
     ex = APIStatusError(
         message="internal error",
-        response=_openai_http_response(503),
+        response=_httpx2_response(503),
         body=None,
     )
     decision = openai_classify_retry(ex)
@@ -149,7 +149,7 @@ def test_openai_classify_non_retryable_4xx_returns_none() -> None:
 
     ex = APIStatusError(
         message="bad request",
-        response=_openai_http_response(400),
+        response=_httpx2_response(400),
         body=None,
     )
     assert openai_classify_retry(ex) is None
@@ -160,7 +160,7 @@ def test_openai_classify_rate_limit_error_subclass() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _openai_http_response(429, {"retry-after": "5"})
+    response = _httpx2_response(429, {"retry-after": "5"})
     ex = RateLimitError(message="too many", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -177,7 +177,7 @@ def test_openai_provider_quota_exceeded_does_not_retry() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)  # avoid full init
     ex = RateLimitError(
         message="You exceeded your current quota, please check your plan.",
-        response=_openai_http_response(429),
+        response=_httpx2_response(429),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -193,7 +193,7 @@ def test_openai_provider_429_classifies_as_rate_limit() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)
     ex = RateLimitError(
         message="rate limited",
-        response=_openai_http_response(429, {"retry-after": "10"}),
+        response=_httpx2_response(429, {"retry-after": "10"}),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -228,7 +228,7 @@ def test_anthropic_429_classifies_as_rate_limit() -> None:
     api = AnthropicAPI.__new__(AnthropicAPI)
     ex = APIStatusError(
         message="rate limited",
-        response=_http_response(429, {"retry-after": "20"}),
+        response=_httpx2_response(429, {"retry-after": "20"}),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -245,7 +245,7 @@ def test_anthropic_503_classifies_as_transient() -> None:
     api = AnthropicAPI.__new__(AnthropicAPI)
     ex = APIStatusError(
         message="overloaded",
-        response=_http_response(503),
+        response=_httpx2_response(503),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -262,9 +262,21 @@ def test_anthropic_streaming_overloaded_body_classifies_as_transient() -> None:
     api = AnthropicAPI.__new__(AnthropicAPI)
     ex = APIStatusError(
         message="overloaded",
-        response=_http_response(200),
+        response=_httpx2_response(200),
         body={"error": {"message": "overloaded"}},
     )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
+def test_anthropic_httpx2_transport_error_classifies_as_transient() -> None:
+    """Anthropic >= 1 is built on httpx2 — raw httpx2 transport errors that escape the SDK unwrapped must still retry."""
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = httpx2.ConnectError("connection reset")
     decision = api.should_retry(ex)
     assert isinstance(decision, RetryDecision)
     assert decision.retry is True
@@ -695,7 +707,7 @@ def test_together_openai_compatible_429_classifies_as_rate_limit() -> None:
     api = TogetherAIAPI.__new__(TogetherAIAPI)
     ex = APIStatusError(
         message="rate limited",
-        response=_openai_http_response(429, {"retry-after": "15"}),
+        response=_httpx2_response(429, {"retry-after": "15"}),
         body=None,
     )
     decision = api.should_retry(ex)

--- a/uv.lock
+++ b/uv.lock
@@ -291,21 +291,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.124.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/44/2afd86c9aac387b41f1b133cd3f595e0b110a2b980625f7987e897cee543/anthropic-0.124.0.tar.gz", hash = "sha256:b5c855a2912b157829a667ce21e10561f2b23bca98bb03af6abee2aa7f4a4cf3", size = 1054437, upload-time = "2026-08-19T16:51:31.493809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/aa/4978e58035bd6c638c7b483450a68b7ef2d732ab78885e27bb9db0cff1a2/anthropic-1.0.0.tar.gz", hash = "sha256:42be3c97604af7252c5898413aee076ace6c46e9bca0d0d90ceb77c7d3719027", size = 1077769, upload-time = "2026-08-20T19:59:00.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/6a/3ab35f7bb9a2c512c80638eb108fbbcee21c433a00baca8ab0ded485e007/anthropic-0.124.0-py3-none-any.whl", hash = "sha256:e7f86e3182c4173edf09fd8f42aa328d1aa9246355a90a300287c355228bb356", size = 1147647, upload-time = "2026-08-19T16:51:33.459733Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5b/db4a854aebf5d33a5ab714c46af6eb85ee44f390ed29b7b325c00b9f11ed/anthropic-1.0.0-py3-none-any.whl", hash = "sha256:32dd52e9e1d774393b27182f451398ba4262287a4d0eab30887f89f1481b3ae4", size = 1171725, upload-time = "2026-08-20T19:58:58.725Z" },
 ]
 
 [[package]]
@@ -946,14 +945,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -2169,7 +2168,7 @@ requires-dist = [
     { name = "adlfs", marker = "extra == 'dev'", specifier = ">=2025.8.0" },
     { name = "agent-client-protocol", specifier = ">=0.12.0" },
     { name = "aioboto3", specifier = ">=13.0.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.124.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "antlr4-python3-runtime", marker = "extra == 'dev'", specifier = ">=4.9.3,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1,<=4.13.2" },
     { name = "antlr4-python3-runtime", marker = "extra == 'math'", specifier = ">=4.9.3,!=4.10.*,!=4.12.*,!=4.13.0,!=4.13.1,<=4.13.2" },
     { name = "anyio", specifier = ">=4.14.0" },
@@ -2284,7 +2283,7 @@ dev = [{ name = "inspect-ai", extras = ["dev"] }]
 
 [[package]]
 name = "inspect-scout"
-version = "0.4.46"
+version = "0.4.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2320,9 +2319,9 @@ dependencies = [
     { name = "wrapt" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/31/441f2451635387d3651122cd5826e7ea4b5d288f1691738f137cd26c86f1/inspect_scout-0.4.46.tar.gz", hash = "sha256:7b79c035573123b5499b204773b5132521d900c00c08900805a24199c48c2d97", size = 2667285, upload-time = "2026-08-05T12:45:45.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/31/73651382b9c436efe8bd8e4f200466f8a82207b0c3e87ba089efd21e86a2/inspect_scout-0.4.39.tar.gz", hash = "sha256:9b9aef307ab0ff4edd2f9cd947d6eb950f93aae68f3c13db3fa2193c2e9841bc", size = 2532922, upload-time = "2026-06-02T14:05:15.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/54/d841bcd68b5d03b267307a8e6b07595538f9e2623ddb8ea3f83daa7bd0a6/inspect_scout-0.4.46-py3-none-any.whl", hash = "sha256:9ef4882dbc7b112b7434cdbdbdf3ef8a067139ddec9b1c9169e1e938b0239bdc", size = 2757084, upload-time = "2026-08-05T12:45:42.408Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/eb/f156b6f23ccbb47dec0085582dbb1008689ea1968161d6e8e798be54766c/inspect_scout-0.4.39-py3-none-any.whl", hash = "sha256:ea8211af58c9faba10bcc3a8730dbe197e8b54a25df0cf1f069e3a9cb6edcbc0", size = 2643655, upload-time = "2026-06-02T14:05:14.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#296

`anthropic` 1.0.0 (published 2026-08-20) is a major release with three breaking changes, and since `requirements-dev.txt` pinned only `anthropic>=0.124.0`, CI now resolves it and fails (10 asyncio + 4 trio test failures, 10 mypy errors across three jobs — full triage in the issue):

1. **`temperature`/`top_p`/`top_k` removed from the `messages.create()`/`stream()` signatures** (the API still accepts them for models that support them) → any eval setting them on a pre-4.7 Anthropic model dies with `TypeError: AsyncMessages.create() got an unexpected keyword argument 'temperature'`.
2. **`LegacyAPIResponse` removed** — `.with_raw_response` now returns `AsyncAPIResponse` whose `parse()` is a coroutine.
3. **SDK moved from `httpx` to `httpx2`** (same move `openai` 3.0.0 made, #198) → `arg-type` mypy errors everywhere we hand `httpx.Request`/`Response` to anthropic SDK types.

### What is the new behavior?

inspect requires and works with `anthropic>=1.0.0` (floor bumped in `requirements-dev.txt` and in `validate_anthropic_client()`, mirroring the openai bump in #198):

- **Sampling params still work**: `completion_config` routes `temperature`/`top_p`/`top_k` via `extra_body` (which all of `create()`/`stream()`/`count_tokens()` still accept and merge into the body root). The Claude 4.7+ / thinking stripping behavior is unchanged.
- **Batch requests**: the Batches API has no `extra_body` param, so `AnthropicBatcher._create_batch` now merges `extra_body` fields directly into each request's `params` (per the SDK migration guide). This also fixes a pre-existing bug where the whole request dict — including a literal `extra_body` key — leaked into batch params.
- **Agent bridge**: with the typed kwargs gone, `extra_body` is the *only* way a bridged agent can send sampling params — and the SDK carries `extra_body` in `options.extra_json`, merging it into the body only *downstream* of the bridge's `request()` interception point. The anthropic bridge patch now merges `options.extra_json` into the intercepted body so those params reach the inspect model config instead of being silently dropped (found by a pre-PR review pass; covered by a new offline mockllm regression test).
- **Retry classification**: raw `httpx2`/`httpcore2` transport errors (which can escape the SDK unwrapped, e.g. during streaming) are classified as retryable, same as their legacy `httpx`/`httpcore` counterparts. Resolved lazily via `sys.modules` so `import inspect_ai` doesn't pay ~130ms to import `httpx2` (it isn't a direct dependency — it arrives transitively with `openai>=3`/`anthropic>=1`). This also fixes the same gap for openai, pre-existing since #198.
- **httpx2 type/constructor switches** in `_anthropic_batch.py`, the anthropic bridge patch, and the affected tests; `await raw.parse()` in the anthropic raw-response bridge tests (openai keeps sync `parse()` — it still ships `LegacyAPIResponse`).
- **Bedrock**: 1.0 requires a region (no more implicit `us-east-1`). No code change needed — the SDK reads `AWS_REGION`/`AWS_DEFAULT_REGION` itself and raises a clear, actionable error when unset. One unit test that relied on the old implicit default now sets the region explicitly (treating an empty `AWS_REGION` as unset, as the SDK does).

New tests: batch `extra_body`→`params` merge, httpx2 transport-error retry classification, and offline bridge forwarding of `extra_body` sampling params.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes: `anthropic>=1.0.0` is now required to use the Anthropic provider (older versions get a clear version error from `validate_anthropic_client`). Users on Bedrock without any region configured will get the SDK's new "No AWS region was provided" error instead of an implicit `us-east-1` default — that change comes from the SDK itself.

### Other information:

**Verification** (local, `anthropic==1.0.0` + `httpx2==2.12.0` installed):
- `pytest tests/model/providers/test_anthropic.py tests/model/test_should_retry_classification.py tests/agent/test_bridge_raw_response.py tests/agent/test_agent_bridge.py` → 182 passed (including all 13 tests that fail on main under anthropic 1.0.0); trio variants pass with `--runtrio`.
- `mypy --exclude tests/test_package src tests` → the 10 httpx2 `arg-type` errors from the failing CI runs are gone; 5 unrelated pre-existing errors remain that appear to be local stub-environment drift (e.g. missing `types-requests`), none in files this PR touches — all files changed here type-check clean.
- `ruff check` / `ruff format --check` clean on all changed files.
- One test fails only in the sandboxed agent runner used to author this PR (`test_anthropic_bridge_computer_use_incompatible_model`): the runner's `ANTHROPIC_CONFIG_DIR` workload-identity config trips the 1.0 SDK's new config-file auth. Verified it passes with those env vars cleared and fails identically on the unmodified tree — environment-only, unrelated to this change.
- `make check`/`make test` were not run as such; the commands above are their constituent parts scoped to the affected areas plus a full-repo mypy.

**CI-unblock follow-up commit** (`93cdcc340`): re-locking with the new floor re-enforces inspect-scout's `inspect-ai>=0.3.252` requirement against this fork's scm-computed version (the fork's tags stop at 0.3.239), downgrading `inspect-scout` to 0.4.39 and `click` to 8.2.1 in both `uv.lock` and the CI envs. Two consequences handled: (1) `uv.lock` regenerated to match the new floor (note for whoever promotes this upstream: upstream's version satisfies the constraint, so run `uv lock` there — it will keep inspect-scout 0.4.46); (2) click 8.2.1's stubs predate generic `ParamType`, so the typing-only `click.ParamType[...]` subscript in `_cli/ctl/_group.py` failed mypy — it now subclasses the unparametrized base, which type-checks under both stub generations (`convert()` already carries the concrete return type).

**Pre-existing issues noticed but deliberately not bundled** (found during review passes; happy to file issues):
- The openai bridge patch has the same `options.extra_json` gap (bridged openai agents' `extra_body` fields are dropped) — pre-existing since openai 3.x, lower impact because openai kept its typed sampling kwargs.
- `OpenAIBatcher._jsonl_line_for_request` emits a literal nested `"extra_body"` key into batch JSONL bodies (the openai twin of the anthropic batch bug fixed here).
- `AnthropicBatcher._create_batch`'s destructive `pop("extra_headers")` drops beta headers if tenacity retries batch creation (the new `extra_body` pop/merge added here is idempotent and retry-safe; the headers pop predates this PR).
- `httpx_classify_retry` matches only legacy `httpx.HTTPStatusError`, not `httpx2.HTTPStatusError` — dismissed as currently unreachable (both SDKs always wrap status errors in `APIStatusError`; no in-repo code calls `raise_for_status()` on an httpx2 response).

### Agent review
- Reviewer: Claude Fable 5 via /code-review at high effort (fresh-context finder agents, same model as author), 1 orchestrated pass with 7 independent finder agents (conventions, simplification, efficiency, reuse, removed-behavior audit, altitude, cross-file tracer), each verifying empirically against the installed anthropic 1.0.0 wheel.
- Findings: 10 —
  - **Fixed (6):** bridge dropped `extra_body` sampling params (`options.extra_json` never merged — high severity, would have failed the live bridged-agent tests); eager module-level `httpx2` import added ~130ms to every `import inspect_ai` (made lazy); contradictory duplicate "minimum supported version" CHANGELOG entries (merged); triplicated sampling-param if/else (collapsed to a loop); httpx2 registration coupled to `httpcore2` importability (decoupled — `httpcore2` is platform-conditional); missing `-> None` on a rewritten test.
  - **Dismissed (4):** `httpx2.HTTPStatusError` classification gap (unreachable today — SDKs wrap status errors in `APIStatusError`); openai bridge/batch twins of the fixed bugs (pre-existing, out of scope — listed above as follow-ups); duplicated deferred-import comment (shortened to reference its openai twin); shared httpx2 test-response helper for `test_anthropic.py` (matches the file's existing inline style).
- Disclosure: this PR was authored end-to-end by Claude (Fable 5) via the repo's @auto workflow, triggered by a maintainer on issue #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)