### PR TITLE
Fix S3 log listing aborting on credential errors instead of degrading like Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Docker Sandbox: New `--sandbox-prebuilt` option (`sandbox_prebuilt` on `eval()`) skips image builds and fails fast at task startup when a prebuilt image is missing.
 - Docker Sandbox: `x-local: false` on a compose service is now treated the same as omitting `x-local` (the image is pulled) rather than marking the image as local.
 - Control Channel: New `inspect ctl sample cancel-tool-call` cancels one hung tool call (the model sees an ordinary tool timeout and the sample continues), with pending tool calls now visible in `inspect ctl sample list --json`.
+- View: Log listing against `s3://` paths with expired or missing credentials now degrades to a diagnostic warning (like Azure already did) instead of aborting with the raw provider error.
 
 ## 0.3.260 (21 August 2026)
 

--- a/src/inspect_ai/_view/s3.py
+++ b/src/inspect_ai/_view/s3.py
@@ -1,0 +1,47 @@
+"""S3-specific helpers used across Inspect view components."""
+
+_S3_AUTH_KEYWORDS = (
+    # botocore ClientError strings embed the camel-case code, e.g.
+    # "An error occurred (AccessDenied) when calling ..."
+    "accessdenied",
+    # s3fs raises bare PermissionError("Access Denied") for the same condition
+    "access denied",
+    "invalidaccesskeyid",
+    "signaturedoesnotmatch",
+    "expiredtoken",
+    "auth failure",
+    "unable to locate credentials",
+    "no credentials were found",
+    "the security token included in the request is invalid",
+)
+
+
+def is_s3_path(path: str) -> bool:
+    """Return True if the path targets an S3 filesystem."""
+    return path.lower().startswith(("s3://", "s3a://"))
+
+
+def should_suppress_s3_error(path: str, error: Exception) -> bool:
+    """Return True if an S3 auth/credential issue should be downgraded to a warning.
+
+    Mirrors :func:`should_suppress_azure_error`: any denial-class failure
+    (wrong credentials *or* insufficient IAM permissions on the bucket) is
+    degraded to a diagnostic warning with an empty/partial listing rather
+    than aborting the whole log view with a raw provider error.
+    """
+    if not is_s3_path(path):
+        return False
+    lowered = str(error).lower()
+    return any(keyword in lowered for keyword in _S3_AUTH_KEYWORDS)
+
+
+def s3_warning_hint(path: str, error: Exception) -> str:
+    """Diagnostic guidance for S3 listing/authentication issues."""
+    return (
+        "S3 authentication failed while probing "
+        f"'{path}'. Suppressed stack trace. Guidance: (a) verify credentials with "
+        "'aws sts get-caller-identity' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY "
+        "(plus AWS_SESSION_TOKEN for temporary credentials); (b) confirm the identity "
+        "has s3:ListBucket and s3:GetObject permission on the bucket; (c) ensure "
+        f"AWS_REGION/AWS_DEFAULT_REGION match the bucket. Original error: {error}"
+    )

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -269,6 +269,9 @@ async def _list_eval_logs_async(
             if should_suppress_azure_error(log_dir, ex):
                 logger.warning(azure_warning_hint(log_dir, ex))
                 exists = True
+            elif should_suppress_s3_error(log_dir, ex):
+                logger.warning(s3_warning_hint(log_dir, ex))
+                exists = True
             else:
                 raise
         if not exists:
@@ -284,8 +287,10 @@ async def _list_eval_logs_async(
                 if should_suppress_azure_error(log_dir, ex):
                     logger.warning(azure_warning_hint(log_dir, ex))
                     exists = True
+                elif should_suppress_s3_error(log_dir, ex):
+                    logger.warning(s3_warning_hint(log_dir, ex))
+                    exists = True
                 else:
-                    # TODO: Add S3 login error catching, as well as any other remote file system of interest
                     # Re-raise non-auth related issues
                     raise
 

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -11,7 +11,7 @@ from typing import IO, Any, AsyncIterator, Callable, Generator, Literal, cast
 
 import anyio.to_thread
 import fsspec  # type: ignore
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 from fsspec.asyn import AsyncFileSystem  # type: ignore
 from fsspec.core import split_protocol  # type: ignore
 from pydantic import (
@@ -33,6 +33,7 @@ from inspect_ai._util.file import (
     filesystem,
 )
 from inspect_ai._util.json import to_json_safe
+from inspect_ai._view.s3 import s3_warning_hint, should_suppress_s3_error
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._resolve import rebind_sample_timelines, resolve_sample_events_data
@@ -242,7 +243,17 @@ async def _list_eval_logs_async(
                 "NotFound",
             ):
                 return []
+            # auth/credential class failures degrade to a warning + empty
+            # listing, mirroring the Azure handling in the async branches
+            # below (a view should keep working when log credentials are
+            # expired or missing instead of aborting the whole listing)
+            if should_suppress_s3_error(log_dir, ex):
+                logger.warning(s3_warning_hint(log_dir, ex))
+                return []
             raise
+        except NoCredentialsError as ex:
+            logger.warning(s3_warning_hint(log_dir, ex))
+            return []
         # resolve to eval logs (async fan-out so header reads on
         # non-conforming filenames don't block the event loop)
         return await log_files_from_ls_async(logs, formats, descending)

--- a/tests/_view/test_s3.py
+++ b/tests/_view/test_s3.py
@@ -1,0 +1,68 @@
+"""Unit tests for the S3 view helpers (issue #4914)."""
+
+import pytest
+
+from inspect_ai._view.s3 import (
+    is_s3_path,
+    s3_warning_hint,
+    should_suppress_s3_error,
+)
+
+
+class TestIsS3Path:
+    def test_s3_scheme(self) -> None:
+        assert is_s3_path("s3://bucket/logs")
+
+    def test_s3a_scheme(self) -> None:
+        assert is_s3_path("s3a://bucket/logs")
+
+    @pytest.mark.parametrize(
+        "path",
+        ["az://container/logs", "abfs://container/logs", "/local/path", "gs://bucket"],
+    )
+    def test_non_s3_paths(self, path: str) -> None:
+        assert not is_s3_path(path)
+
+
+class TestShouldSuppressS3Error:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # botocore ClientError str() embeds the camel-case code
+            "An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied",
+            "An error occurred (InvalidAccessKeyId) when calling the ListObjectsV2 operation",
+            "An error occurred (SignatureDoesNotMatch) when calling the ListObjectsV2 operation",
+            "An error occurred (ExpiredToken) when calling the ListObjectsV2 operation: The provided token has expired",
+            # botocore credential errors surface as plain messages
+            "Unable to locate credentials",
+            "No credentials were found for profile default",
+            # s3fs raises bare PermissionError("Access Denied")
+            "Access Denied",
+            "Auth failure. Credentials were only partially specified.",
+        ],
+    )
+    def test_auth_errors_are_suppressed_on_s3_paths(self, message: str) -> None:
+        error = PermissionError(message)
+        assert should_suppress_s3_error("s3://bucket/logs", error)
+
+    def test_suppressed_on_s3a_scheme(self) -> None:
+        assert should_suppress_s3_error(
+            "s3a://bucket/logs", PermissionError("Access Denied")
+        )
+
+    def test_non_auth_error_is_not_suppressed(self) -> None:
+        error = OSError("connection reset by peer")
+        assert not should_suppress_s3_error("s3://bucket/logs", error)
+
+    def test_auth_error_is_not_suppressed_on_non_s3_path(self) -> None:
+        error = PermissionError("Access Denied")
+        assert not should_suppress_s3_error("/local/logs", error)
+
+
+class TestS3WarningHint:
+    def test_hint_includes_path_and_original_error(self) -> None:
+        error = PermissionError("Access Denied")
+        hint = s3_warning_hint("s3://bucket/logs", error)
+        assert "s3://bucket/logs" in hint
+        assert "Access Denied" in hint
+        assert "aws sts get-caller-identity" in hint

--- a/tests/log/test_list_logs.py
+++ b/tests/log/test_list_logs.py
@@ -269,7 +269,13 @@ def _client_error() -> Exception:
     return ClientError(
         {
             "Error": {"Code": "AccessDenied", "Message": "Access Denied"},
-            "ResponseMetadata": {"HTTPStatusCode": 403},
+            "ResponseMetadata": {
+                "HTTPStatusCode": 403,
+                "RequestId": "test-request-id",
+                "HostId": "test-host-id",
+                "HTTPHeaders": {},
+                "RetryAttempts": 0,
+            },
         },
         "ListObjectsV2",
     )
@@ -367,5 +373,3 @@ def test_list_logs_async_s3_auth_error_degrades_with_fs_options(
     # fs_options must actually reach the generic branch for this test to be
     # meaningful — it is what forces the slow path in production.
     assert captured["fs_options"] == {"endpoint": "https://minio.local"}
-
-

--- a/tests/log/test_list_logs.py
+++ b/tests/log/test_list_logs.py
@@ -261,3 +261,111 @@ async def test_list_logs_async_s3_no_credentials_degrades(
 
     logs = await list_eval_logs_async("s3://bucket/logs", formats=["eval"])
     assert logs == []
+
+
+def _client_error() -> Exception:
+    from botocore.exceptions import ClientError
+
+    return ClientError(
+        {
+            "Error": {"Code": "AccessDenied", "Message": "Access Denied"},
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        },
+        "ListObjectsV2",
+    )
+
+
+def test_list_logs_trio_sync_s3_auth_error_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Generic trio-sync branch: S3 auth errors degrade to an empty listing (#4914)."""
+    import anyio
+
+    class _SyncErrorFs:
+        def is_async(self) -> bool:
+            return True
+
+        def is_s3(self) -> bool:
+            return True
+
+        def exists(self, path: str) -> bool:
+            raise _client_error()
+
+        def ls(self, path: str, recursive: bool = False) -> list:
+            return []
+
+    monkeypatch.setattr(
+        "inspect_ai.log._file.filesystem",
+        lambda path, fs_options={}: _SyncErrorFs(),
+    )
+    monkeypatch.setattr(
+        "inspect_ai.log._file.current_async_backend",
+        lambda: "trio",
+    )
+
+    async def check() -> None:
+        logs = await list_eval_logs_async(
+            "s3://bucket/logs", formats=["eval"], fs_options={"endpoint": "https://x"}
+        )
+        assert logs == []
+
+    anyio.run(check, backend="trio")
+
+
+def test_list_logs_async_s3_auth_error_degrades_with_fs_options(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Generic asyncio branch (fs_options set): S3 auth errors degrade to empty (#4914)."""
+    import asyncio
+
+    class _AsyncErrorFs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args) -> None:
+            return None
+
+        async def _exists(self, path: str) -> bool:
+            raise _client_error()
+
+        def invalidate_cache(self, path: str) -> None:
+            pass
+
+        async def _ls(self, path: str, detail: bool = True) -> list:
+            return []
+
+    captured: dict[str, Any] = {}
+
+    def fake_async_filesystem(path: str, fs_options=None):
+        captured["fs_options"] = fs_options
+        return _AsyncErrorFs()
+
+    def s3_style_filesystem(path: str, fs_options: dict[str, Any] = {}) -> Any:
+        fs = filesystem(path, fs_options)
+        monkeypatch.setattr(fs, "is_s3", lambda: True)
+        monkeypatch.setattr(fs, "is_async", lambda: True)
+        return fs
+
+    monkeypatch.setattr("inspect_ai.log._file.filesystem", s3_style_filesystem)
+    monkeypatch.setattr(
+        "inspect_ai.log._file.async_filesystem",
+        fake_async_filesystem,
+    )
+    monkeypatch.setattr(
+        "inspect_ai.log._file.current_async_backend",
+        lambda: "asyncio",
+    )
+
+    async def check() -> list:
+        return await list_eval_logs_async(
+            "s3://bucket/logs",
+            formats=["eval"],
+            fs_options={"endpoint": "https://minio.local"},
+        )
+
+    assert asyncio.run(check()) == []
+    # fs_options must actually reach the generic branch for this test to be
+    # meaningful — it is what forces the slow path in production.
+    assert captured["fs_options"] == {"endpoint": "https://minio.local"}
+
+

--- a/tests/log/test_list_logs.py
+++ b/tests/log/test_list_logs.py
@@ -184,3 +184,80 @@ def test_list_logs_async_remote_fs_trio(monkeypatch: pytest.MonkeyPatch):
         assert len(logs) == 3
 
     anyio.run(check, backend="trio")
+
+
+def _s3_error_fs(monkeypatch: pytest.MonkeyPatch, error_factory):
+    """Return a filesystem that raises the given error on iter_files (S3 path)."""
+
+    def s3_style_filesystem(path: str, fs_options: dict[str, Any] = {}) -> Any:
+        fs = filesystem(path, fs_options)
+        monkeypatch.setattr(fs, "is_s3", lambda: True)
+        monkeypatch.setattr(fs, "is_async", lambda: True)
+        # Force the code path down the `fs.is_s3() and not fs_options` branch
+        return fs
+
+    monkeypatch.setattr("inspect_ai.log._file.filesystem", s3_style_filesystem)
+    monkeypatch.setattr(
+        "inspect_ai.log._file.AsyncFilesystem",
+        error_factory,
+    )
+    return s3_style_filesystem
+
+
+@pytest.mark.anyio
+async def test_list_logs_async_s3_auth_error_degrades(monkeypatch: pytest.MonkeyPatch):
+    """An S3 credential/denial error must degrade to an empty listing, not raise."""
+    from botocore.exceptions import ClientError
+
+    class _RaisesClientError:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDenied",
+                        "Message": "Access Denied",
+                    },
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                },
+                "ListObjectsV2",
+            )
+
+        async def __aexit__(self, *args):
+            return False
+
+    def error_factory(*args, **kwargs):
+        return _RaisesClientError()
+
+    _s3_error_fs(monkeypatch, error_factory)
+
+    logs = await list_eval_logs_async("s3://bucket/logs", formats=["eval"])
+    assert logs == []
+
+
+@pytest.mark.anyio
+async def test_list_logs_async_s3_no_credentials_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Missing credentials must degrade to an empty listing, not raise."""
+    from botocore.exceptions import NoCredentialsError
+
+    class _RaisesNoCredentials:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            raise NoCredentialsError()
+
+        async def __aexit__(self, *args):
+            return False
+
+    def error_factory(*args, **kwargs):
+        return _RaisesNoCredentials()
+
+    _s3_error_fs(monkeypatch, error_factory)
+
+    logs = await list_eval_logs_async("s3://bucket/logs", formats=["eval"])
+    assert logs == []


### PR DESCRIPTION
Fixes #4914

## Motivation

S3 log listings abort with raw auth errors where Azure listings degrade to a warning, breaking the view server for users whose S3 credentials expire. This PR makes S3 behave like Azure at every listing site.

## Changes

- New `_view/s3.py` module: `should_suppress_s3_error(path, error)` + `s3_warning_hint(path, error)`, functionally mirroring `_util/azure.py` (helpers consumed by the listing path; same shape idea as `_view/azure.py`). Keywords are documented against real botocore (`ClientError.AccessDenied`, `ExpiredToken`, `NoCredentialsError`, …) and s3fs-translated message shapes.
- **All three sites in `log/_file.py` now degrade consistently**:
  - the S3 fast path (`fs.is_s3() and not fs_options`),
  - the generic trio-sync branch,
  - the generic asyncio branch (the old `TODO: Add S3 login error catching` is removed).
  The two generic branches consult `should_suppress_s3_error` alongside `should_suppress_azure_error`, mirroring the existing Azure two-liners.
- `CHANGELOG.md` entry.

## Testing

- `tests/log/test_list_logs.py`: fast-path ClientError/NoCredentialsError degradation, plus new regression tests for both generic branches — `fs_options` forces the slow path, and one test asserts `fs_options` actually reached the branch so the coverage can't silently rot. Trio variant verified via `pytest --runtrio`.
- `tests/_view/test_s3.py`: 18-case keyword/scheme matrix for the helper.
- Local: pytest green (asyncio + trio variants), ruff clean.

## Follow-up noted

`read_eval_set_info_async` (`_view/common.py:146`) still suppresses only Azure errors; filed separately so the "view keeps working" story is complete.