### PR TITLE
fix: preserve OpenAI chat cache token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- OpenAI: Chat Completions usage now preserves prompt-cache read and write tokens for accurate cache-aware costing.
 - Scoring: `model_graded_qa`/`model_graded_fact` no longer score a malformed multi-character verdict such as `GRADE: CI` as correct; such verdicts now leave the sample unscored with `grade_parse_failure` recorded.
 
 - Eval Log: `local_path()` now percent-decodes `file://` URLs, restoring the `to_uri()` round trip for paths with spaces or other encoded characters (affects every consumer of file URLs: log recorders, control-channel state, checkpoint restore, approval policy files). (#5025)

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -49,7 +49,7 @@ from openai.types.chat import (
 from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
 from openai.types.chat.chat_completion_content_part_param import File, FileFile
 from openai.types.chat.chat_completion_message_function_tool_call import Function
-from openai.types.completion_usage import CompletionUsage
+from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 from openai.types.shared_params.function_definition import FunctionDefinition
 from pydantic import JsonValue
 
@@ -483,9 +483,23 @@ def openai_chat_choices(choices: list[ChatCompletionChoice]) -> list[Choice]:
 
 
 def openai_completion_usage(usage: ModelUsage) -> CompletionUsage:
+    input_tokens_cache_read = usage.input_tokens_cache_read or 0
+    input_tokens_cache_write = usage.input_tokens_cache_write or 0
+    prompt_tokens_details = (
+        PromptTokensDetails(
+            cached_tokens=input_tokens_cache_read,
+            cache_write_tokens=input_tokens_cache_write,
+        )
+        if usage.input_tokens_cache_read is not None
+        or usage.input_tokens_cache_write is not None
+        else None
+    )
     return CompletionUsage(
         completion_tokens=usage.output_tokens,
-        prompt_tokens=usage.input_tokens,
+        prompt_tokens=(
+            usage.input_tokens + input_tokens_cache_read + input_tokens_cache_write
+        ),
+        prompt_tokens_details=prompt_tokens_details,
         total_tokens=usage.total_tokens,
     )
 
@@ -914,23 +928,38 @@ def model_output_from_openai(
     completion: ChatCompletion,
     choices: list[ChatCompletionChoice],
 ) -> ModelOutput:
+    cached_tokens = (
+        completion.usage.prompt_tokens_details.cached_tokens
+        if completion.usage
+        and completion.usage.prompt_tokens_details is not None
+        and completion.usage.prompt_tokens_details.cached_tokens is not None
+        else 0
+    )
+    cache_write_tokens = (
+        completion.usage.prompt_tokens_details.cache_write_tokens
+        if completion.usage
+        and completion.usage.prompt_tokens_details is not None
+        and completion.usage.prompt_tokens_details.cache_write_tokens is not None
+        else 0
+    )
     return ModelOutput(
         model=completion.model,
         choices=choices,
         usage=(
             ModelUsage(
-                input_tokens=completion.usage.prompt_tokens
-                - (
-                    completion.usage.prompt_tokens_details.cached_tokens
-                    if completion.usage.prompt_tokens_details is not None
-                    and completion.usage.prompt_tokens_details.cached_tokens is not None
-                    else 0
+                input_tokens=(
+                    completion.usage.prompt_tokens - cached_tokens - cache_write_tokens
                 ),
                 output_tokens=completion.usage.completion_tokens,
                 input_tokens_cache_read=(
                     completion.usage.prompt_tokens_details.cached_tokens
                     if completion.usage.prompt_tokens_details is not None
-                    else None  # openai only have cache read stats/pricing.
+                    else None
+                ),
+                input_tokens_cache_write=(
+                    completion.usage.prompt_tokens_details.cache_write_tokens
+                    if completion.usage.prompt_tokens_details is not None
+                    else None
                 ),
                 reasoning_tokens=(
                     completion.usage.completion_tokens_details.reasoning_tokens

--- a/tests/model/test_openai_convert.py
+++ b/tests/model/test_openai_convert.py
@@ -36,8 +36,11 @@ from inspect_ai.model import (
 from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
 )
-from inspect_ai.model._model_output import ModelOutput
-from inspect_ai.model._openai import chat_message_assistant_from_openai
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.model._openai import (
+    chat_message_assistant_from_openai,
+    openai_completion_usage,
+)
 from inspect_ai.model._openai_responses import (
     mcp_call_to_tool_use,
     reasoning_from_responses_reasoning,
@@ -494,6 +497,64 @@ async def test_model_output_from_openai_cache_token_normalization() -> None:
     assert result.usage.input_tokens_cache_read == 600
     assert result.usage.output_tokens == 50
     assert result.usage.total_tokens == 1050
+
+
+async def test_model_output_from_openai_cache_write_token_normalization() -> None:
+    """Test that cache writes are preserved and excluded from input tokens."""
+    completion = ChatCompletion(
+        id="chatcmpl-cache-write",
+        model="gpt-5.6",
+        object="chat.completion",
+        created=1234567890,
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="Hello!",
+                ),
+                finish_reason="stop",
+                logprobs=None,
+            )
+        ],
+        usage=CompletionUsage(
+            prompt_tokens=1000,
+            completion_tokens=50,
+            total_tokens=1050,
+            prompt_tokens_details=PromptTokensDetails(
+                cached_tokens=600, cache_write_tokens=80
+            ),
+        ),
+    )
+
+    result = await model_output_from_openai(completion)
+
+    assert result.usage is not None
+    assert result.usage.input_tokens == 320
+    assert result.usage.input_tokens_cache_read == 600
+    assert result.usage.input_tokens_cache_write == 80
+    assert result.usage.output_tokens == 50
+    assert result.usage.total_tokens == 1050
+
+
+def test_openai_completion_usage_round_trips_cache_details() -> None:
+    """Test outbound Chat Completions usage keeps cache reads and writes."""
+    usage = ModelUsage(
+        input_tokens=320,
+        output_tokens=50,
+        total_tokens=1050,
+        input_tokens_cache_read=600,
+        input_tokens_cache_write=80,
+    )
+
+    result = openai_completion_usage(usage)
+
+    assert result.prompt_tokens == 1000
+    assert result.completion_tokens == 50
+    assert result.total_tokens == 1050
+    assert result.prompt_tokens_details is not None
+    assert result.prompt_tokens_details.cached_tokens == 600
+    assert result.prompt_tokens_details.cache_write_tokens == 80
 
 
 async def test_model_output_from_openai_no_cache_tokens() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4960.

OpenAI Chat Completions usage separates cached prompt reads from full-rate input tokens, but does not preserve `prompt_tokens_details.cache_write_tokens`. Cache-write tokens remain inside `ModelUsage.input_tokens`, so cache-aware costing cannot apply the cache-write rate. The outbound Chat Completions usage conversion also drops prompt-token cache details.

### What is the new behavior?

Chat Completions inbound conversion now subtracts cache reads and cache writes from full-rate `input_tokens`, and records both as `input_tokens_cache_read` / `input_tokens_cache_write`. Outbound `openai_completion_usage()` now restores full prompt tokens and emits `PromptTokensDetails` when cache read or write usage is present.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This preserves previously dropped usage detail and keeps non-cache usage unchanged.

### Other information:

Changelog: Added an OpenAI entry under `## Unreleased`.

Validation:
- Targeted:
  - `uv run pytest tests/model/test_openai_convert.py::test_model_output_from_openai_cache_token_normalization tests/model/test_openai_convert.py::test_model_output_from_openai_cache_write_token_normalization tests/model/test_openai_convert.py::test_openai_completion_usage_round_trips_cache_details -v`
    - Passed: 3 passed, 2 skipped.
    - Proves the existing cache-read normalization remains intact, cache writes are separated from full-rate input tokens, and outbound Chat Completions usage includes cache details.
- Regression:
  - `uv run pytest tests/model/test_openai_convert.py -q`
    - Passed: 27 passed, 14 skipped.
  - `uv run pytest tests/model/test_model_output.py -q`
    - Passed: 9 passed.
  - `uv run make check`
    - Passed: ruff, ruff format, inspect-tool-support ruff/format, and mypy over 1392 source files.
  - `uv run make test`
    - Passed: full pytest suite completed successfully, collecting 13,390 tests.

CI/CD coverage expected:
- Build should cover ruff, mypy, pre-commit, package inspection, and Python 3.10/3.11 tests.
- Changelog Lint should cover the `## Unreleased` entry.
- Validate Embedded Viewer should run schema/type/dist checks; no viewer, docs, or sandbox-tool files are touched.

### Agent review

- Tooling: AI-assisted implementation and review.
- Findings: No separate fresh-context review pass was run. The change is narrowly scoped to OpenAI usage conversion and is covered by focused inbound/outbound usage regression tests, adjacent model usage tests, `make check`, and the full test suite.
