### PR TITLE
fix: make sandbox timeout self-check spawn child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Sandbox: Self-check now actually spawns a background child when checking timeout cleanup, so leaked children are reported instead of passing vacuously.
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)
 - Tools: The `grep` tool now supports extended regex via a new `extended_regexp` option (patterns remain basic regex by default).

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -479,11 +479,7 @@ async def test_exec_timeout_kills_child_processes(
 
     with Raises(TimeoutError):
         await sandbox_env.exec(
-            [
-                "sh",
-                "-c",
-                f"sleep 30 # {child_marker} & sleep 30 # {parent_marker}",
-            ],
+            _timeout_child_process_command(parent_marker, child_marker),
             timeout=2,
         )
 
@@ -497,6 +493,20 @@ async def test_exec_timeout_kills_child_processes(
             f"Process with marker '{marker}' should have been killed after timeout, "
             f"but it's still running. ps output: [{result.stdout}]"
         )
+
+
+def _timeout_child_process_command(
+    parent_marker: str, child_marker: str, sleep_seconds: int = 30
+) -> list[str]:
+    return [
+        "sh",
+        "-c",
+        (
+            f"sh -c \"echo '{child_marker}' >/dev/null && "
+            f'sleep {sleep_seconds}; :" & '
+            f"echo '{parent_marker}' >/dev/null && sleep {sleep_seconds}; :"
+        ),
+    ]
 
 
 async def test_exec_permission_error(sandbox_env: SandboxEnvironment) -> None:

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -88,8 +88,6 @@ SANDBOX_CONFIGS = [
         config=_compose("test_sandbox_compose_alpine.yaml"),
         requires_docker=True,
         xfails={
-            "test_write_text_file_without_permissions": "Alpine root can overwrite a read-only file",
-            "test_write_binary_file_without_permissions": "Alpine root can overwrite a read-only file",
             "test_exec_timeout_kills_child_processes": (
                 "Alpine BusyBox timeout leaves background children running when it "
                 "terminates the direct child shell"

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -87,6 +87,14 @@ SANDBOX_CONFIGS = [
         env_type=DockerSandboxEnvironment,
         config=_compose("test_sandbox_compose_alpine.yaml"),
         requires_docker=True,
+        xfails={
+            "test_write_text_file_without_permissions": "Alpine root can overwrite a read-only file",
+            "test_write_binary_file_without_permissions": "Alpine root can overwrite a read-only file",
+            "test_exec_timeout_kills_child_processes": (
+                "Alpine BusyBox timeout leaves background children running when it "
+                "terminates the direct child shell"
+            ),
+        },
     ),
 ]
 

--- a/tests/tools/test_sandbox_self_check.py
+++ b/tests/tools/test_sandbox_self_check.py
@@ -1,0 +1,56 @@
+import os
+import signal
+import subprocess
+import time
+
+from inspect_ai.util._sandbox.self_check import _timeout_child_process_command
+
+
+def test_timeout_child_process_command_spawns_marker_processes() -> None:
+    parent_marker = "timeout_parent_probe"
+    child_marker = "timeout_child_probe"
+    process = subprocess.Popen(
+        _timeout_child_process_command(parent_marker, child_marker, sleep_seconds=5),
+        start_new_session=True,
+    )
+
+    try:
+        ps_output = ""
+        group_output = ""
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            ps_output = subprocess.run(
+                ["ps", "-axo", "pid=,pgid=,command="],
+                capture_output=True,
+                check=True,
+                text=True,
+            ).stdout
+            group_lines = []
+            for line in ps_output.splitlines():
+                columns = line.split(maxsplit=2)
+                if len(columns) >= 3 and columns[1] == str(process.pid):
+                    group_lines.append(line)
+            group_output = "\n".join(group_lines)
+            if parent_marker in group_output and any(
+                child_marker in line and parent_marker not in line
+                for line in group_lines
+            ):
+                break
+            time.sleep(0.05)
+
+        assert parent_marker in group_output
+        assert any(
+            child_marker in line and parent_marker not in line
+            for line in group_output.splitlines()
+        ), group_output
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        else:
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=2)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4971.

`test_exec_timeout_kills_child_processes` intends to verify timeout cleanup kills both the foreground command and a background child process. Its command currently places the markers and the backgrounded `& sleep ...` segment after `#`, so the shell treats them as a comment. The check runs a single foreground sleep, and the marker sweep can pass even if child cleanup is broken.

### What is the new behavior?

The self-check now builds a command that:

- starts a background child shell with the child marker in its command line
- keeps a foreground parent shell with the parent marker in its command line
- appends a trailing `; :` in both shells so the shell does not replace itself with `sleep`

A focused regression test starts the command with a short sleep and verifies that both the marker-bearing parent shell and a separate marker-bearing child shell exist before cleanup. The Alpine Docker slow-test harness now records the BusyBox `timeout` child-cleanup gap as a known self-check failure, so the self-check reports that provider limitation without failing unrelated slow-tool CI.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. It tightens an existing sandbox self-check without changing the sandbox API.

### Other information:

Changelog: Added a Sandbox entry under `Unreleased`.

Validation:

- Targeted:
  - `uv run pytest tests/tools/test_sandbox_self_check.py -q`
    - Passed: 1 passed.
    - Proves the timeout self-check command actually creates a marker-bearing child shell separate from the parent.
- Adjacent/self-check:
  - `uv run pytest tests/tools/test_sandbox_self_check.py tests/tools/test_sandbox_docker_and_local.py -q`
    - Passed: 1 passed, 8 skipped.
    - Confirms the new regression is included while the slow/trio sandbox matrix remains skipped by default.
  - `uv run pytest tests/tools/test_sandbox_docker_and_local.py::test_self_check_local -q --runslow`
    - The local self-check ran through `test_exec_timeout_kills_child_processes` successfully, then failed later in pre-existing `test_exec_large_command` with `OSError(7, 'Argument list too long')` on this host.
- Regression:
  - `uv run make check`
    - Passed: ruff, format, inspect-tool-support checks, and mypy over 1393 source files.
  - `uv run make test`
    - Passed: full pytest suite, 13,388 tests collected.
- CI feedback handled:
  - The first CI run exposed the now-real Alpine BusyBox `timeout` limitation in `slow-tool-tests-dev`.
  - This PR records `test_exec_timeout_kills_child_processes` as a known Alpine self-check failure while preserving the stricter check for local and non-Alpine Docker environments.
- Hygiene:
  - `git diff --cached --check`
    - Passed.

CI/CD coverage expected:

- Build: ruff, pre-commit, mypy, package inspection, Python 3.10/3.11 tests, and slow-test detection.
- Changelog Lint: verifies the changelog entry remains under `Unreleased`.
- Validate Embedded Viewer: expected standard checks; no viewer/schema artifacts changed.
- No sandbox-tools version bump: this touches core sandbox self-check code, not injectable sandbox-tools binaries.

### Agent review

- Tooling: AI-assisted implementation and review.
- Findings: The old command never started the intended child because `#` commented out the background segment. The regression now checks for a marker-bearing child process line that is distinct from the parent before relying on timeout cleanup.
