### PR TITLE
eval set: protocol for running a selection of an eval set's tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself. Selected tasks run through the ordinary `eval()` path with no eval-set orchestration; because the runner owns completion decisions, workers neither fail a task on sample errors nor retry a task in-process.
 - Sandbox: Sandbox-tools binaries downloaded from S3 are now verified against SHA256 digests pinned in the package; failures warn by default, or fail when `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` is set.
 - Sandbox: `bash_session` no longer stops returning output for the rest of the session when multibyte output happens to be split mid-character across reads.
 - Docker Sandbox: New `--sandbox-prebuilt` option (`sandbox_prebuilt` on `eval()`) skips image builds and fails fast at task startup when a prebuilt image is missing.

--- a/src/inspect_ai/_eval/eval_set_selection.py
+++ b/src/inspect_ai/_eval/eval_set_selection.py
@@ -40,6 +40,7 @@ Schema changes require a version bump and corresponding golden-test updates
 """
 
 import os
+from collections import Counter
 
 from pydantic import BaseModel, ValidationError
 
@@ -94,7 +95,7 @@ def read_eval_set_selection(selection_path: str) -> EvalSetSelection:
         The selection.
 
     Raises:
-        PrerequisiteError: If the file cannot be read or parsed, or if it uses a schema version this version of inspect does not understand.
+        PrerequisiteError: If the file cannot be read or parsed, if it uses a schema version this version of inspect does not understand, or if it names no tasks or the same task more than once.
     """
     try:
         with file(selection_path, mode="rb") as f:
@@ -114,6 +115,19 @@ def read_eval_set_selection(selection_path: str) -> EvalSetSelection:
     if not selection.tasks:
         raise PrerequisiteError(
             f"The eval set selection at '{selection_path}' names no tasks."
+        )
+
+    # a repeated identifier would run the same task twice in one worker, under
+    # one task id: the two runs share a log filename and a sample-buffer db, so
+    # they overwrite each other's log or fail outright. Reject it here rather
+    # than let the runner's bug surface as a mid-run error.
+    counts = Counter(entry.identifier for entry in selection.tasks)
+    duplicates = sorted(identifier for identifier, count in counts.items() if count > 1)
+    if duplicates:
+        raise PrerequisiteError(
+            f"The eval set selection at '{selection_path}' names the same task "
+            f"more than once: {', '.join(duplicates)}. Each task in a selection "
+            "must appear exactly once."
         )
 
     return selection

--- a/src/inspect_ai/_eval/eval_set_selection.py
+++ b/src/inspect_ai/_eval/eval_set_selection.py
@@ -1,0 +1,119 @@
+"""Eval-set selection (worker) mode.
+
+When the `INSPECT_EVAL_SET_SELECTION` environment variable names a JSON file
+containing an `EvalSetSelection`, `eval_set()` resolves its tasks normally and
+then runs only the selected ones through the ordinary `eval()` path, skipping
+all eval-set orchestration (log directory scanning, `.eval-set-id`,
+`eval-set.json`, `logs.json`, retry partitioning, and log cleanup).
+
+This is the execution counterpart to capture mode (see `eval_set_manifest.py`).
+An external runner first enumerates an eval set with
+`INSPECT_EVAL_SET_CAPTURE`, then launches one worker per task with
+`INSPECT_EVAL_SET_SELECTION`, naming tasks by the `identifier` values from the
+capture manifest. Because a worker performs no eval-set bookkeeping, many
+workers can write into a single flat log directory concurrently: each writes
+exactly one (atomically replaced) `.eval` file, and the runner is the sole
+writer of the directory's eval-set metadata.
+
+The definition still calls `eval_set()` — that is what preserves the side
+effects of executing it (registered models, `set_model_info`, dynamically
+constructed `Model` objects) in every worker process.
+
+Two of the definition's options are overridden in worker mode, because both
+are completion decisions that belong to the runner rather than the worker:
+`fail_on_error` is forced to `False` (so sample errors never fail a task —
+the runner sees them in the log and decides what to do) and task-level retry
+is disabled (the runner retries by respawning a worker with `resume`, and an
+in-process loop would multiply its attempt budget and leave a failed log per
+attempt in the shared directory). `continue_on_fail` needs no override: it is
+moot once `fail_on_error` is `False`. Everything else the definition set is
+honoured, `retry_on_error` in particular — sample-level retry stays under the
+definition author's control. The values the definition asked for are recorded
+in the capture manifest's `options`, so a runner can see what it is honouring
+and what is being overridden.
+
+This module is deliberately not part of the public API: the models here are a
+versioned wire format (see `EVAL_SET_SELECTION_VERSION`) written by external
+runners (currently inspect_steward, which imports them from this module).
+Schema changes require a version bump and corresponding golden-test updates
+(see `tests/test_eval_set_selection.py`).
+"""
+
+import os
+
+from pydantic import BaseModel, ValidationError
+
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.file import file
+
+INSPECT_EVAL_SET_SELECTION = "INSPECT_EVAL_SET_SELECTION"
+
+EVAL_SET_SELECTION_VERSION = 1
+
+
+def eval_set_selection_requested() -> str | None:
+    """Selection path if eval-set selection (worker) mode is active.
+
+    Returns:
+        The path named by the `INSPECT_EVAL_SET_SELECTION` environment variable, or `None` when worker mode is not active (unset or empty are both treated as inactive).
+    """
+    value = os.environ.get(INSPECT_EVAL_SET_SELECTION, "").strip()
+    return value if value else None
+
+
+class EvalSetSelectionTask(BaseModel):
+    """A single task selected for execution by a worker."""
+
+    identifier: str
+    """Task identifier (as produced by `task_identifier()` and recorded in the capture manifest)."""
+
+    resume: str | None = None
+    """Location of a prior log for this task to resume (completed samples are reused)."""
+
+
+class EvalSetSelection(BaseModel):
+    """Tasks an external runner has selected for a worker to run."""
+
+    version: int
+    """Selection schema version."""
+
+    eval_set_id: str
+    """Eval set id to stamp into the logs written by this worker."""
+
+    tasks: list[EvalSetSelectionTask]
+    """Tasks to run (identified by `task_identifier`)."""
+
+
+def read_eval_set_selection(selection_path: str) -> EvalSetSelection:
+    """Read and validate a selection written by an external runner.
+
+    Args:
+        selection_path: Path to the selection JSON file.
+
+    Returns:
+        The selection.
+
+    Raises:
+        PrerequisiteError: If the file cannot be read or parsed, or if it uses a schema version this version of inspect does not understand.
+    """
+    try:
+        with file(selection_path, mode="rb") as f:
+            selection = EvalSetSelection.model_validate_json(f.read())
+    except (OSError, ValidationError, ValueError) as ex:
+        raise PrerequisiteError(
+            f"Unable to read the eval set selection at '{selection_path}' "
+            f"(named by {INSPECT_EVAL_SET_SELECTION}):\n{ex}"
+        ) from ex
+
+    if selection.version > EVAL_SET_SELECTION_VERSION:
+        raise PrerequisiteError(
+            f"The eval set selection at '{selection_path}' uses schema version "
+            f"{selection.version}, but this version of inspect understands at "
+            f"most version {EVAL_SET_SELECTION_VERSION} (upgrade inspect-ai)."
+        )
+    if not selection.tasks:
+        raise PrerequisiteError(
+            f"The eval set selection at '{selection_path}' names no tasks."
+        )
+
+    return selection

--- a/src/inspect_ai/_eval/eval_set_selection.py
+++ b/src/inspect_ai/_eval/eval_set_selection.py
@@ -41,10 +41,11 @@ Schema changes require a version bump and corresponding golden-test updates
 (see `tests/test_eval_set_selection.py`).
 """
 
+import json
 import os
 from collections import Counter
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import file
@@ -64,8 +65,18 @@ def eval_set_selection_requested() -> str | None:
     return value if value else None
 
 
+# Both models forbid extra fields: a selection is hand-built by an external
+# runner, where a misspelled key would otherwise be dropped silently and change
+# what the worker does (`"resuem"` reads as no resume at all, so a resumed task
+# reruns every completed sample). Strictness costs no forward compatibility —
+# any added field bumps EVAL_SET_SELECTION_VERSION, and a document written at a
+# version this inspect doesn't know is refused before it is validated at all.
+
+
 class EvalSetSelectionTask(BaseModel):
     """A single task selected for execution by a worker."""
+
+    model_config = ConfigDict(extra="forbid")
 
     identifier: str
     """Task identifier (as produced by `task_identifier()` and recorded in the capture manifest)."""
@@ -77,6 +88,8 @@ class EvalSetSelectionTask(BaseModel):
 class EvalSetSelection(BaseModel):
     """Tasks an external runner has selected for a worker to run."""
 
+    model_config = ConfigDict(extra="forbid")
+
     version: int
     """Selection schema version."""
 
@@ -85,6 +98,24 @@ class EvalSetSelection(BaseModel):
 
     tasks: list[EvalSetSelectionTask]
     """Tasks to run (identified by `task_identifier`)."""
+
+
+def _document_version(document: object) -> int | None:
+    """Read a selection document's version before it has been validated.
+
+    Args:
+        document: Parsed JSON of a selection document (any shape — it has not been validated yet).
+
+    Returns:
+        The version, read as leniently as pydantic would read it, or `None` when the document doesn't carry one that can be (a malformed version is left for validation to report).
+    """
+    version = document.get("version") if isinstance(document, dict) else None
+    if isinstance(version, (int, str)) and not isinstance(version, bool):
+        try:
+            return int(version)
+        except ValueError:
+            return None
+    return None
 
 
 def read_eval_set_selection(selection_path: str) -> EvalSetSelection:
@@ -99,21 +130,37 @@ def read_eval_set_selection(selection_path: str) -> EvalSetSelection:
     Raises:
         PrerequisiteError: If the file cannot be read or parsed, if it uses a schema version this version of inspect does not understand, or if it names no tasks or the same task more than once.
     """
-    try:
-        with file(selection_path, mode="rb") as f:
-            selection = EvalSetSelection.model_validate_json(f.read())
-    except (OSError, ValidationError, ValueError) as ex:
-        raise PrerequisiteError(
+
+    def unreadable(ex: Exception) -> PrerequisiteError:
+        return PrerequisiteError(
             f"Unable to read the eval set selection at '{selection_path}' "
             f"(named by {INSPECT_EVAL_SET_SELECTION}):\n{ex}"
-        ) from ex
+        )
 
-    if selection.version > EVAL_SET_SELECTION_VERSION:
+    try:
+        with file(selection_path, mode="rb") as f:
+            contents = f.read()
+        document = json.loads(contents)
+    except (OSError, ValueError) as ex:
+        raise unreadable(ex) from ex
+
+    # gate on the version before validating fields, not after: a selection
+    # written at a later version may carry fields this one doesn't know, and
+    # the models forbid extras -- so the mismatch has to be reported as the
+    # version problem it is rather than as an unknown field.
+    version = _document_version(document)
+    if version is not None and version > EVAL_SET_SELECTION_VERSION:
         raise PrerequisiteError(
             f"The eval set selection at '{selection_path}' uses schema version "
-            f"{selection.version}, but this version of inspect understands at "
+            f"{version}, but this version of inspect understands at "
             f"most version {EVAL_SET_SELECTION_VERSION} (upgrade inspect-ai)."
         )
+
+    try:
+        selection = EvalSetSelection.model_validate_json(contents)
+    except ValidationError as ex:
+        raise unreadable(ex) from ex
+
     if not selection.tasks:
         raise PrerequisiteError(
             f"The eval set selection at '{selection_path}' names no tasks."

--- a/src/inspect_ai/_eval/eval_set_selection.py
+++ b/src/inspect_ai/_eval/eval_set_selection.py
@@ -12,8 +12,10 @@ An external runner first enumerates an eval set with
 `INSPECT_EVAL_SET_SELECTION`, naming tasks by the `identifier` values from the
 capture manifest. Because a worker performs no eval-set bookkeeping, many
 workers can write into a single flat log directory concurrently: each writes
-exactly one (atomically replaced) `.eval` file, and the runner is the sole
-writer of the directory's eval-set metadata.
+one (atomically replaced) `.eval` file per selected task, and the runner is the
+sole writer of the directory's eval-set metadata. A selection must therefore
+name each task at most once — one task means one log, and two entries for it
+would have the same task id competing for the same file.
 
 The definition still calls `eval_set()` — that is what preserves the side
 effects of executing it (registered models, `set_model_info`, dynamically

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -3,7 +3,7 @@ import hashlib
 import logging
 import os
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Set, cast
 
@@ -100,10 +100,17 @@ from inspect_ai.util._limit import (
 
 from .eval import eval, eval_init, eval_resolve_tasks
 from .eval_set_manifest import (
+    INSPECT_EVAL_SET_CAPTURE,
     build_eval_set_capture,
     eval_set_capture_requested,
     samples_for_limit,
     task_args_hash,
+)
+from .eval_set_selection import (
+    INSPECT_EVAL_SET_SELECTION,
+    EvalSetSelection,
+    eval_set_selection_requested,
+    read_eval_set_selection,
 )
 from .loader import resolve_task_args, solver_from_spec
 from .task import Epochs
@@ -408,6 +415,7 @@ def eval_set(
         tasks: list[ResolvedTask]
         | list[PreviousTask]
         | list[ResolvedTask | PreviousTask],
+        selection_mode: bool = False,
     ) -> list[EvalLog]:
         # run evals
         results = eval(
@@ -437,7 +445,7 @@ def eval_set(
             sample_id=sample_id,
             sample_shuffle=sample_shuffle,
             epochs=epochs,
-            fail_on_error=fail_on_error,
+            fail_on_error=False if selection_mode else fail_on_error,
             continue_on_fail=continue_on_fail,
             retry_on_error=retry_on_error,
             score_on_error=score_on_error,
@@ -465,7 +473,7 @@ def eval_set(
             score=score,
             score_display=score_display,
             eval_set_id=eval_set_id,
-            task_retry_attempts=task_retry_attempts,
+            task_retry_attempts=0 if selection_mode else task_retry_attempts,
             acp_server=acp_server,
             # Demoted to a plain on/off: eval-set owns the keep-alive park
             # itself (after the display closes), so the inner eval() must
@@ -499,10 +507,21 @@ def eval_set(
         **kwargs,
     )
 
+    # external runner modes (capture enumerates the eval set; selection runs
+    # one worker's share of it). they are two halves of the same protocol but
+    # are never active at once.
+    capture_path = eval_set_capture_requested()
+    selection_path = eval_set_selection_requested()
+    if capture_path is not None and selection_path is not None:
+        raise PrerequisiteError(
+            f"{INSPECT_EVAL_SET_CAPTURE} and {INSPECT_EVAL_SET_SELECTION} "
+            "cannot both be set (capture enumerates an eval set without "
+            "running it; selection runs tasks from an enumerated eval set)."
+        )
+
     # capture mode: resolve tasks, write the manifest, and exit the process
     # without running anything. deliberately placed before any log_dir side
     # effects (mkdir, .eval-set-id, eval-set.json) and before eval-set hooks.
-    capture_path = eval_set_capture_requested()
     if capture_path is not None:
         if isinstance(tasks, TaskSource):
             raise PrerequisiteError(
@@ -549,6 +568,16 @@ def eval_set(
                 epochs=capture_epochs.epochs if capture_epochs else None,
                 tags=tags,
                 metadata=metadata,
+                # error handling as the definition asked for it, so a runner
+                # can see what selection mode honours (retry_on_error) and
+                # what it overrides (fail_on_error) rather than guessing.
+                fail_on_error=fail_on_error,
+                continue_on_fail=continue_on_fail,
+                retry_on_error=retry_on_error,
+                # whether the definition scans. selection mode rejects
+                # scanners, so a runner needs to learn this at enumeration
+                # time rather than when every one of its workers fails.
+                scanners=scanner is not None,
             ),
         )
         with file(capture_path, mode="wb") as f:
@@ -558,6 +587,64 @@ def eval_set(
     # ensure log_dir
     fs = filesystem(log_dir)
     fs.mkdir(log_dir, exist_ok=True)
+
+    # selection (worker) mode: run only the selected tasks through the ordinary
+    # eval() path. everything below this point is eval-set orchestration
+    # (directory scanning, eval-set metadata, retry partitioning, log cleanup,
+    # bundling) and is deliberately skipped -- the external runner owns it, and
+    # skipping it is what lets many workers share one log directory.
+    if selection_path is not None:
+        if isinstance(tasks, TaskSource):
+            raise PrerequisiteError(
+                "Dynamic task sources (TaskSource) cannot be used with "
+                "eval-set selection."
+            )
+        if scanner is not None:
+            raise PrerequisiteError(
+                "Scanners are not supported with eval-set selection. One scan "
+                "directory is shared by a whole eval set, and its bookkeeping "
+                "assumes a single writer: concurrent workers would race to "
+                "create it, and each worker's finalize prunes scan rows whose "
+                "transcripts it cannot see in the log directory yet -- "
+                "deleting the rows of workers still running. Scanning is an "
+                "eval-set level operation, so the runner should perform it "
+                "over the log directory rather than each worker scanning "
+                "its own share."
+            )
+        selection_config = GenerateConfig(**kwargs)
+        selection_tasks, _ = eval_resolve_tasks(
+            tasks,
+            task_args,
+            models,
+            model_roles,
+            selection_config,
+            approval,
+            sandbox,
+            sample_shuffle,
+            notification=notification,
+            input_media_policy="trusted_pre_run",
+        )
+        if len(selection_tasks) == 0:
+            raise PrerequisiteError(
+                "Error: No inspect tasks were found at the specified paths."
+            )
+        return _run_eval_set_selection(
+            selection_path,
+            selection_tasks,
+            EvalSetArgsInTaskIdentifier(
+                config=selection_config,
+                solver=solver,
+                message_limit=message_limit,
+                token_limit=token_limit,
+                turn_limit=turn_limit,
+                time_limit=time_limit,
+                working_limit=working_limit,
+                cost_limit=cost_limit,
+            ),
+            lambda worker_eval_set_id, worker_tasks: run_eval(
+                worker_eval_set_id, worker_tasks, selection_mode=True
+            ),
+        )
 
     # get eval set id (set display name from user-provided value before resolution)
     set_eval_set_id_display(eval_set_id)
@@ -1089,26 +1176,7 @@ def as_previous_tasks(
 
     previous_tasks: list[PreviousTask] = []
     for task, log in zip(tasks, map(task_to_failed_log, tasks)):
-        eval_log = log.header
-        log_info = log.info
-
-        # opportunistically recover crashed logs before retrying
-        if eval_log.status == "started" and eval_log.location:
-            from inspect_ai.log._recover import (
-                RecoveryNotAvailable,
-                recover_eval_log,
-            )
-
-            try:
-                recovered = recover_eval_log(eval_log.location, cleanup=False)
-                eval_log = recovered
-                if recovered.location:
-                    log_info = log_info.model_copy(update={"name": recovered.location})
-            except RecoveryNotAvailable:
-                pass  # no recovery data available
-            except Exception as ex:
-                logger.warning(f"Recovery failed for {eval_log.location}: {ex}")
-
+        eval_log, log_info = _recover_crashed_log(log.header, log.info)
         previous_tasks.append(
             PreviousTask(
                 id=eval_log.eval.task_id,
@@ -1122,6 +1190,160 @@ def as_previous_tasks(
         )
 
     return previous_tasks
+
+
+def _recover_crashed_log(
+    eval_log: EvalLog, log_info: EvalLogInfo
+) -> tuple[EvalLog, EvalLogInfo]:
+    """Opportunistically recover a still-"started" log before retrying it.
+
+    A log left in "started" state was interrupted rather than completed, so its
+    samples may only exist in the buffer database. Recovery folds them back
+    into a readable log; when it isn't possible the original log is returned
+    unchanged (the task simply re-runs the samples).
+
+    Args:
+        eval_log: Header of the log to retry.
+        log_info: File info for that log.
+
+    Returns:
+        The recovered log and file info, or the originals when no recovery was available.
+    """
+    if eval_log.status == "started" and eval_log.location:
+        from inspect_ai.log._recover import (
+            RecoveryNotAvailable,
+            recover_eval_log,
+        )
+
+        try:
+            recovered = recover_eval_log(eval_log.location, cleanup=False)
+            if recovered.location:
+                log_info = log_info.model_copy(update={"name": recovered.location})
+            eval_log = recovered
+        except RecoveryNotAvailable:
+            pass  # no recovery data available
+        except Exception as ex:
+            logger.warning(f"Recovery failed for {eval_log.location}: {ex}")
+
+    return eval_log, log_info
+
+
+# eval-set selection (worker) mode. `eval_set()` delegates here once it has
+# resolved its tasks; everything specific to running a worker's share of an
+# eval set lives in the three functions below. See eval_set_selection.py for
+# the protocol these implement.
+
+
+def _run_eval_set_selection(
+    selection_path: str,
+    resolved_tasks: list[ResolvedTask],
+    eval_set_args: EvalSetArgsInTaskIdentifier,
+    run_eval: Callable[[str, list[ResolvedTask | PreviousTask]], list[EvalLog]],
+) -> tuple[bool, list[EvalLog]]:
+    """Run a worker's share of an eval set.
+
+    Reads the selection, narrows the eval set's resolved tasks to it, and runs
+    just those through the ordinary `eval()` path. No eval-set orchestration is
+    performed: the external runner that wrote the selection owns the log
+    directory, its metadata, and every retry decision.
+
+    Args:
+        selection_path: Path to the selection document (from `INSPECT_EVAL_SET_SELECTION`).
+        resolved_tasks: All tasks resolved by this eval set (tasks × models).
+        eval_set_args: Eval-set level args that participate in task identity.
+        run_eval: Runs the selected tasks under an eval set id, returning their logs.
+
+    Returns:
+        Whether every selected task succeeded, and the logs they produced.
+
+    Raises:
+        PrerequisiteError: If the selection cannot be read, or does not correspond to this eval set's tasks.
+    """
+    selection = read_eval_set_selection(selection_path)
+    selected = _selected_eval_set_tasks(resolved_tasks, selection, eval_set_args)
+    set_eval_set_id_display(selection.eval_set_id)
+    logs = run_eval(selection.eval_set_id, selected)
+    return all_evals_succeeded(logs), logs
+
+
+def _selected_eval_set_tasks(
+    resolved_tasks: list[ResolvedTask],
+    selection: EvalSetSelection,
+    eval_set_args: EvalSetArgsInTaskIdentifier,
+) -> list[ResolvedTask | PreviousTask]:
+    """Pick the tasks named by a worker's selection out of the resolved eval set.
+
+    Args:
+        resolved_tasks: All tasks resolved by this eval set (tasks × models).
+        selection: Selection naming tasks by `task_identifier`.
+        eval_set_args: Eval-set level args that participate in task identity.
+
+    Returns:
+        The selected tasks, in selection order, with any task carrying a `resume` location wrapped as a `PreviousTask` so its completed samples are reused.
+
+    Raises:
+        PrerequisiteError: If an identifier matches no resolved task or more than one of them, or if a `resume` log is missing or belongs to a different task.
+    """
+    by_identifier: dict[str, list[ResolvedTask]] = {}
+    for task in resolved_tasks:
+        by_identifier.setdefault(task_identifier(task, eval_set_args), []).append(task)
+
+    selected: list[ResolvedTask | PreviousTask] = []
+    for entry in selection.tasks:
+        matches = by_identifier.get(entry.identifier, [])
+        if len(matches) == 0:
+            raise PrerequisiteError(
+                f"[bold]ERROR[/bold]: Task identifier '{entry.identifier}' does "
+                f"not match any of the {len(resolved_tasks)} tasks resolved by "
+                "this eval set. The definition may have changed since its "
+                "tasks were enumerated, or it may be running from a different "
+                "path or working directory (a task's source file is part of "
+                "its identity)."
+            )
+        elif len(matches) > 1:
+            raise PrerequisiteError(
+                f"[bold]ERROR[/bold]: Task identifier '{entry.identifier}' "
+                f"matches {len(matches)} tasks in this eval set. Tasks in an "
+                "eval set must be uniquely identified."
+            )
+        selected.append(
+            _resumed_task(matches[0], entry.identifier, entry.resume)
+            if entry.resume is not None
+            else matches[0]
+        )
+
+    return selected
+
+
+def _resumed_task(task: ResolvedTask, identifier: str, resume: str) -> PreviousTask:
+    from inspect_ai.log._file import log_file_info
+
+    fs = filesystem(resume)
+    if not fs.exists(resume):
+        raise PrerequisiteError(
+            f"[bold]ERROR[/bold]: The log '{resume}' selected for resuming task "
+            f"'{identifier}' does not exist."
+        )
+
+    log_info = log_file_info(fs.info(resume))
+    eval_log = read_eval_log_headers([log_info])[0]
+    log_identifier = task_identifier(eval_log, None)
+    if log_identifier != identifier:
+        raise PrerequisiteError(
+            f"[bold]ERROR[/bold]: The log '{resume}' selected for resuming task "
+            f"'{identifier}' belongs to a different task ('{log_identifier}')."
+        )
+
+    eval_log, log_info = _recover_crashed_log(eval_log, log_info)
+    return PreviousTask(
+        id=eval_log.eval.task_id,
+        task=task.task,
+        task_args=resolve_task_args(task.task),
+        model=task.model,
+        model_roles=task.model_roles,
+        log=eval_log,
+        log_info=log_info,
+    )
 
 
 # filters to determine when we are done

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -628,23 +628,30 @@ def eval_set(
             raise PrerequisiteError(
                 "Error: No inspect tasks were found at the specified paths."
             )
-        return _run_eval_set_selection(
-            selection_path,
-            selection_tasks,
-            EvalSetArgsInTaskIdentifier(
-                config=selection_config,
-                solver=solver,
-                message_limit=message_limit,
-                token_limit=token_limit,
-                turn_limit=turn_limit,
-                time_limit=time_limit,
-                working_limit=working_limit,
-                cost_limit=cost_limit,
-            ),
-            lambda worker_eval_set_id, worker_tasks: run_eval(
-                worker_eval_set_id, worker_tasks, selection_mode=True
-            ),
-        )
+        # same run-boundary cleanup the eval-set path does in its own `finally`
+        # below: the inner eval() runs with eval_set_id set, so it leaves both
+        # the keep-alive park and the registry reset to its caller.
+        try:
+            return _run_eval_set_selection(
+                selection_path,
+                selection_tasks,
+                EvalSetArgsInTaskIdentifier(
+                    config=selection_config,
+                    solver=solver,
+                    message_limit=message_limit,
+                    token_limit=token_limit,
+                    turn_limit=turn_limit,
+                    time_limit=time_limit,
+                    working_limit=working_limit,
+                    cost_limit=cost_limit,
+                ),
+                lambda worker_eval_set_id, worker_tasks: run_eval(
+                    worker_eval_set_id, worker_tasks, selection_mode=True
+                ),
+                log_dir,
+            )
+        finally:
+            reset_run_registries()
 
     # get eval set id (set display name from user-provided value before resolution)
     set_eval_set_id_display(eval_set_id)
@@ -1239,6 +1246,7 @@ def _run_eval_set_selection(
     resolved_tasks: list[ResolvedTask],
     eval_set_args: EvalSetArgsInTaskIdentifier,
     run_eval: Callable[[str, list[ResolvedTask | PreviousTask]], list[EvalLog]],
+    log_dir: str,
 ) -> tuple[bool, list[EvalLog]]:
     """Run a worker's share of an eval set.
 
@@ -1252,6 +1260,7 @@ def _run_eval_set_selection(
         resolved_tasks: All tasks resolved by this eval set (tasks × models).
         eval_set_args: Eval-set level args that participate in task identity.
         run_eval: Runs the selected tasks under an eval set id, returning their logs.
+        log_dir: Log directory (for the keep-alive park's launch handoff).
 
     Returns:
         Whether every selected task succeeded, and the logs they produced.
@@ -1263,6 +1272,14 @@ def _run_eval_set_selection(
     selected = _selected_eval_set_tasks(resolved_tasks, selection, eval_set_args)
     set_eval_set_id_display(selection.eval_set_id)
     logs = run_eval(selection.eval_set_id, selected)
+
+    # keep-alive: park exactly as the eval-set path does — after the run, with
+    # the task display closed. A worker binds its own (pid-keyed) socket, so
+    # concurrent workers parking under the shared eval set id don't collide;
+    # `inspect ctl` disambiguates them by pid as it does during the run.
+    if keep_alive_intent():
+        run_coroutine(_keep_alive_park(selection.eval_set_id, log_dir))
+
     return all_evals_succeeded(logs), logs
 
 

--- a/tests/test_eval_set_selection.py
+++ b/tests/test_eval_set_selection.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from inspect_ai import Task, TaskSource, eval_set, task
+from inspect_ai._control.eval_state import get_eval_states
 from inspect_ai._eval.eval_set_manifest import (
     INSPECT_EVAL_SET_CAPTURE,
     EvalSetCapture,
@@ -592,6 +593,16 @@ def test_eval_set_selection_resume_log_missing(
             "schema version 99",
         ),
         (json.dumps({"version": 1, "eval_set_id": "x", "tasks": []}), "names no tasks"),
+        (
+            json.dumps(
+                {
+                    "version": 1,
+                    "eval_set_id": "x",
+                    "tasks": [{"identifier": "y"}, {"identifier": "y"}],
+                }
+            ),
+            "names the same task more than once: y",
+        ),
     ],
 )
 def test_eval_set_selection_invalid(
@@ -648,6 +659,59 @@ def test_eval_set_selection_scanner_error(
             tmp_path / "logs",
             scanner=[],
         )
+
+
+def test_eval_set_selection_parks_for_keep_alive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`ctl_server="keep"` parks a worker, exactly as it does an eval set.
+
+    Selection mode returns before the eval-set park; the inner `eval()` runs
+    with an eval_set_id so it doesn't park either. Without a park of its own a
+    worker would silently exit instead of keeping its control surface up. A spy
+    stands in for the (blocking) park.
+    """
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    captured: dict[str, object] = {}
+
+    async def spy(eval_set_id: str, log_dir: str) -> None:
+        captured["eval_set_id"] = eval_set_id
+        captured["states"] = [s.task for s in get_eval_states()]
+
+    monkeypatch.setattr("inspect_ai._eval.evalset._keep_alive_park", spy)
+
+    success, _ = run_selection(
+        monkeypatch,
+        tmp_path,
+        selection_for(capture.tasks[0].identifier, eval_set_id="parked-set"),
+        tmp_path / "logs",
+        ctl_server="keep",
+    )
+
+    assert success
+    assert captured.get("eval_set_id") == "parked-set", "keep-alive park not entered"
+    # the run's eval states are still registered at park time (they're what
+    # `inspect ctl task list` shows through the lingering window)
+    assert captured["states"] == ["selection_task_one"]
+
+
+def test_eval_set_selection_clears_run_registries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A worker clears the process-scoped registries at its run boundary.
+
+    The inner `eval()` leaves this to its caller when an eval_set_id is set, so
+    a worker that returned without cleaning up would leak EvalStates (and
+    config / limit overrides) into whatever the process does next.
+    """
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    run_selection(
+        monkeypatch,
+        tmp_path,
+        selection_for(capture.tasks[0].identifier),
+        tmp_path / "logs",
+    )
+    assert get_eval_states() == []
 
 
 def test_eval_set_capture_and_selection_are_exclusive(

--- a/tests/test_eval_set_selection.py
+++ b/tests/test_eval_set_selection.py
@@ -603,6 +603,41 @@ def test_eval_set_selection_resume_log_missing(
             ),
             "names the same task more than once: y",
         ),
+        # a misspelled optional field must fail rather than be dropped: read as
+        # `resume=None`, this selection would silently rerun completed samples
+        (
+            json.dumps(
+                {
+                    "version": 1,
+                    "eval_set_id": "x",
+                    "tasks": [{"identifier": "y", "resuem": "prior.eval"}],
+                }
+            ),
+            "resuem",
+        ),
+        (
+            json.dumps(
+                {
+                    "version": 1,
+                    "eval_set_id": "x",
+                    "runner_notes": "unknown",
+                    "tasks": [{"identifier": "y"}],
+                }
+            ),
+            "runner_notes",
+        ),
+        # a version this inspect doesn't understand is reported as a version
+        # mismatch even when the newer schema's fields are what fail validation
+        (
+            json.dumps(
+                {
+                    "version": 99,
+                    "eval_set_id": "x",
+                    "tasks": [{"identifier": "y", "field_from_v99": True}],
+                }
+            ),
+            "schema version 99",
+        ),
     ],
 )
 def test_eval_set_selection_invalid(
@@ -744,3 +779,7 @@ def test_eval_set_selection_schema_stability() -> None:
     expected = _EXPECTED_SELECTION_FIELDS[EVAL_SET_SELECTION_VERSION]
     assert set(EvalSetSelection.model_fields.keys()) == expected["selection"]
     assert set(EvalSetSelectionTask.model_fields.keys()) == expected["task"]
+    # the field set above is the whole format: loosening this would let a
+    # runner's typo through as a silently dropped field
+    assert EvalSetSelection.model_config.get("extra") == "forbid"
+    assert EvalSetSelectionTask.model_config.get("extra") == "forbid"

--- a/tests/test_eval_set_selection.py
+++ b/tests/test_eval_set_selection.py
@@ -1,0 +1,682 @@
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inspect_ai import Task, TaskSource, eval_set, task
+from inspect_ai._eval.eval_set_manifest import (
+    INSPECT_EVAL_SET_CAPTURE,
+    EvalSetCapture,
+)
+from inspect_ai._eval.eval_set_selection import (
+    EVAL_SET_SELECTION_VERSION,
+    INSPECT_EVAL_SET_SELECTION,
+    EvalSetSelection,
+    EvalSetSelectionTask,
+)
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.dataset import Sample
+from inspect_ai.log import EvalLog, list_eval_logs, read_eval_log
+from inspect_ai.scorer import Score, Scorer, Target, exact, scorer
+from inspect_ai.scorer._metrics import accuracy
+from inspect_ai.solver import Generate, Solver, TaskState, generate, solver
+
+MODELS = ["mockllm/model", "mockllm/model2"]
+
+
+@task
+def selection_task_one() -> Task:
+    return Task(
+        dataset=[Sample(input="1+1", target="2"), Sample(input="2+2", target="4")],
+        solver=[generate()],
+        scorer=exact(),
+    )
+
+
+@task
+def selection_task_two() -> Task:
+    return Task(
+        dataset=[Sample(input="hello", target="hello")],
+        solver=[generate()],
+        scorer=exact(),
+    )
+
+
+def enumerate_eval_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **kwargs: Any
+) -> EvalSetCapture:
+    """Enumerate the eval set under capture mode (how a runner learns identifiers)."""
+    manifest_path = tmp_path / "manifest.json"
+    monkeypatch.setenv(INSPECT_EVAL_SET_CAPTURE, str(manifest_path))
+    try:
+        with pytest.raises(SystemExit):
+            eval_set(
+                tasks=[selection_task_one(), selection_task_two()],
+                model=MODELS,
+                log_dir=str(tmp_path / "capture-logs"),
+                display="plain",
+                **kwargs,
+            )
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_CAPTURE)
+    return EvalSetCapture.model_validate_json(manifest_path.read_bytes())
+
+
+def run_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    selection: EvalSetSelection,
+    log_dir: Path,
+    *,
+    tasks: list[Task] | TaskSource | None = None,
+    name: str = "selection",
+    **kwargs: Any,
+) -> tuple[bool, list[EvalLog]]:
+    """Run a worker over `selection` (how a runner executes one task)."""
+    selection_path = tmp_path / f"{name}.json"
+    selection_path.write_text(selection.model_dump_json())
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(selection_path))
+    try:
+        return eval_set(
+            tasks=[selection_task_one(), selection_task_two()]
+            if tasks is None
+            else tasks,
+            model=MODELS,
+            log_dir=str(log_dir),
+            display="plain",
+            **kwargs,
+        )
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_SELECTION)
+
+
+def selection_for(
+    identifier: str, eval_set_id: str = "worker-test"
+) -> EvalSetSelection:
+    return EvalSetSelection(
+        version=EVAL_SET_SELECTION_VERSION,
+        eval_set_id=eval_set_id,
+        tasks=[EvalSetSelectionTask(identifier=identifier)],
+    )
+
+
+def test_eval_set_selection_runs_only_selected_task(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    assert len(capture.tasks) == 4
+    selected = next(
+        t
+        for t in capture.tasks
+        if t.name == "selection_task_two" and t.model == "mockllm/model2"
+    )
+
+    log_dir = tmp_path / "logs"
+    success, logs = run_selection(
+        monkeypatch, tmp_path, selection_for(selected.identifier), log_dir
+    )
+
+    assert success
+    assert len(logs) == 1
+    assert logs[0].eval.task == "selection_task_two"
+    assert logs[0].eval.model == "mockllm/model2"
+    # the eval set has four tasks; the worker ran exactly one
+    assert len(list_eval_logs(str(log_dir))) == 1
+
+
+def test_eval_set_selection_stamps_eval_set_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    log_dir = tmp_path / "logs"
+    _, logs = run_selection(
+        monkeypatch,
+        tmp_path,
+        selection_for(capture.tasks[0].identifier, eval_set_id="runner-assigned-id"),
+        log_dir,
+    )
+    assert logs[0].eval.eval_set_id == "runner-assigned-id"
+
+
+def test_eval_set_selection_writes_no_eval_set_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A worker touches nothing in the log directory but its own log.
+
+    This is what lets many workers share one flat directory: the runner is the
+    sole writer of the eval-set metadata, and no worker prunes or rewrites
+    another's log.
+    """
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # a sibling worker's log, already in place
+    sibling = log_dir / "2024-01-01T00-00-00+00-00_sibling_abcdefghijklmnop.eval"
+    sibling.write_bytes(b"not a real log, but it must survive untouched")
+
+    run_selection(
+        monkeypatch, tmp_path, selection_for(capture.tasks[0].identifier), log_dir
+    )
+
+    assert sibling.read_bytes() == b"not a real log, but it must survive untouched"
+    for metadata in (".eval-set-id", "eval-set.json", "logs.json"):
+        assert not (log_dir / metadata).exists(), metadata
+    # exactly one new file (this worker's log)
+    assert len(list(log_dir.iterdir())) == 2
+
+
+def test_eval_set_selection_concurrent_workers(tmp_path: Path) -> None:
+    """Two workers selecting different tasks into one flat directory both succeed.
+
+    This is the concurrency property the whole selection protocol exists for,
+    so it runs real processes rather than in-process eval sets.
+    """
+    definition = tmp_path / "definition.py"
+    definition.write_text(
+        textwrap.dedent(
+            """
+            from inspect_ai import Task, eval_set, task
+            from inspect_ai.dataset import Sample
+            from inspect_ai.scorer import exact
+            from inspect_ai.solver import generate
+
+
+            @task
+            def alpha() -> Task:
+                return Task(
+                    dataset=[Sample(input="1+1", target="2")],
+                    solver=[generate()],
+                    scorer=exact(),
+                )
+
+
+            @task
+            def beta() -> Task:
+                return Task(
+                    dataset=[Sample(input="hello", target="hello")],
+                    solver=[generate()],
+                    scorer=exact(),
+                )
+
+
+            eval_set(
+                tasks=[alpha(), beta()],
+                model="mockllm/model",
+                log_dir="logs",
+            )
+            """
+        )
+    )
+
+    # enumerate, exactly as a runner would
+    manifest_path = tmp_path / "manifest.json"
+    capture_result = subprocess.run(
+        [sys.executable, str(definition)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={
+            **os.environ,
+            INSPECT_EVAL_SET_CAPTURE: str(manifest_path),
+            "INSPECT_DISPLAY": "plain",
+        },
+    )
+    assert capture_result.returncode == 0, capture_result.stderr
+    capture = EvalSetCapture.model_validate_json(manifest_path.read_bytes())
+    assert {t.name for t in capture.tasks} == {"alpha", "beta"}
+
+    # launch one worker per task, both writing into the same flat directory
+    # (the definition's own log_dir, relative to the working directory)
+    log_dir = tmp_path / "logs"
+    workers: list[subprocess.Popen[str]] = []
+    for capture_task in capture.tasks:
+        selection_path = tmp_path / f"selection-{capture_task.name}.json"
+        selection_path.write_text(
+            selection_for(
+                capture_task.identifier, eval_set_id="concurrent"
+            ).model_dump_json()
+        )
+        workers.append(
+            subprocess.Popen(
+                [sys.executable, str(definition)],
+                cwd=tmp_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={
+                    **os.environ,
+                    INSPECT_EVAL_SET_SELECTION: str(selection_path),
+                    "INSPECT_DISPLAY": "plain",
+                },
+            )
+        )
+
+    for worker in workers:
+        _, stderr = worker.communicate(timeout=300)
+        assert worker.returncode == 0, stderr
+
+    logs = list_eval_logs(str(log_dir))
+    assert len(logs) == 2
+    headers = [read_eval_log(log.name, header_only=True) for log in logs]
+    assert {header.eval.task for header in headers} == {"alpha", "beta"}
+    assert all(header.status == "success" for header in headers)
+    assert all(header.eval.eval_set_id == "concurrent" for header in headers)
+    # neither worker wrote eval-set metadata
+    assert {path.name for path in log_dir.iterdir()} == {
+        log.name.split("/")[-1] for log in logs
+    }
+
+
+def test_eval_set_selection_resume_reuses_completed_samples(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Resuming a failed log reuses its completed samples instead of re-running them."""
+    solved: list[str] = []
+
+    @solver
+    def fail_second_sample_first_attempt() -> Solver:
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            solved.append(str(state.sample_id))
+            if state.sample_id == "two" and solved.count("two") == 1:
+                raise ValueError("first attempt fails")
+            return state
+
+        return solve
+
+    @scorer(metrics=[accuracy()])
+    def always_correct() -> Scorer:
+        async def score(state: TaskState, target: Target) -> Score:
+            return Score(value="C")
+
+        return score
+
+    def resumable_tasks() -> list[Task]:
+        return [
+            Task(
+                dataset=[Sample(id="one", input="one"), Sample(id="two", input="two")],
+                solver=fail_second_sample_first_attempt(),
+                scorer=always_correct(),
+                name="resumable",
+            )
+        ]
+
+    manifest_path = tmp_path / "manifest.json"
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv(INSPECT_EVAL_SET_CAPTURE, str(manifest_path))
+    try:
+        with pytest.raises(SystemExit):
+            eval_set(
+                tasks=resumable_tasks(),
+                model="mockllm/model",
+                log_dir=str(log_dir),
+                display="plain",
+            )
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_CAPTURE)
+    capture = EvalSetCapture.model_validate_json(manifest_path.read_bytes())
+    identifier = capture.tasks[0].identifier
+
+    def run(selection: EvalSetSelection, name: str) -> tuple[bool, list[EvalLog]]:
+        selection_path = tmp_path / f"{name}.json"
+        selection_path.write_text(selection.model_dump_json())
+        monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(selection_path))
+        try:
+            return eval_set(
+                tasks=resumable_tasks(),
+                model="mockllm/model",
+                log_dir=str(log_dir),
+                display="plain",
+                max_samples=1,
+            )
+        finally:
+            monkeypatch.delenv(INSPECT_EVAL_SET_SELECTION)
+
+    # first worker: sample "two" errors. the task still completes (worker mode
+    # forces fail_on_error=False) and performs no task-level retry of its own --
+    # both are the runner's decisions to make from the log.
+    success, logs = run(selection_for(identifier), "first")
+    assert success
+    assert logs[0].status == "success"
+    assert solved.count("one") == 1
+    assert solved.count("two") == 1
+    # the residue the runner adjudicates: completed < total
+    assert logs[0].results is not None
+    assert logs[0].results.total_samples == 2
+    assert logs[0].results.completed_samples == 1
+    prior_location = logs[0].location
+
+    # second worker resumes that log: sample "one" is reused (its solver is not
+    # called again) and only the errored sample "two" runs
+    success, logs = run(
+        EvalSetSelection(
+            version=EVAL_SET_SELECTION_VERSION,
+            eval_set_id="worker-test",
+            tasks=[EvalSetSelectionTask(identifier=identifier, resume=prior_location)],
+        ),
+        "second",
+    )
+    assert success
+    assert solved.count("one") == 1
+    assert solved.count("two") == 2
+    assert logs[0].results is not None
+    assert logs[0].results.completed_samples == 2
+
+
+def test_eval_set_selection_forces_fail_on_error_off(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A definition demanding fail-fast still completes: completion is the runner's call.
+
+    `fail_on_error=True` (the default) would mark the log `error` on the first
+    sample error. Worker mode overrides it so the errored sample becomes an
+    entry in the runner's adjudication queue rather than a failed task.
+    """
+
+    @solver
+    def fail_one_sample() -> Solver:
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            if state.sample_id == "bad":
+                raise ValueError("this sample always errors")
+            return state
+
+        return solve
+
+    @scorer(metrics=[accuracy()])
+    def always_correct() -> Scorer:
+        async def score(state: TaskState, target: Target) -> Score:
+            return Score(value="C")
+
+        return score
+
+    def tasks() -> list[Task]:
+        return [
+            Task(
+                dataset=[Sample(id="ok", input="ok"), Sample(id="bad", input="bad")],
+                solver=fail_one_sample(),
+                scorer=always_correct(),
+                name="fail_fast",
+            )
+        ]
+
+    manifest_path = tmp_path / "manifest.json"
+    log_dir = tmp_path / "logs"
+    kwargs: dict[str, Any] = dict(
+        model="mockllm/model",
+        log_dir=str(log_dir),
+        display="plain",
+        fail_on_error=True,
+        continue_on_fail=False,
+    )
+
+    monkeypatch.setenv(INSPECT_EVAL_SET_CAPTURE, str(manifest_path))
+    try:
+        with pytest.raises(SystemExit):
+            eval_set(tasks=tasks(), **kwargs)
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_CAPTURE)
+    capture = EvalSetCapture.model_validate_json(manifest_path.read_bytes())
+
+    # the manifest records what the definition asked for, so a runner can see
+    # what is being honoured and what is being overridden
+    assert capture.options["fail_on_error"] is True
+    assert capture.options["continue_on_fail"] is False
+    assert capture.options["retry_on_error"] is None
+    assert capture.options["scanners"] is False
+
+    selection_path = tmp_path / "selection.json"
+    selection_path.write_text(
+        selection_for(capture.tasks[0].identifier).model_dump_json()
+    )
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(selection_path))
+    try:
+        success, logs = eval_set(tasks=tasks(), **kwargs)
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_SELECTION)
+
+    assert success
+    assert logs[0].status == "success"
+    assert logs[0].results is not None
+    assert logs[0].results.total_samples == 2
+    assert logs[0].results.completed_samples == 1
+
+
+def test_eval_set_selection_honors_retry_on_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`retry_on_error` stays under the definition author's control."""
+    attempts: list[str] = []
+
+    @solver
+    def fail_twice() -> Solver:
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            attempts.append(str(state.sample_id))
+            if len(attempts) <= 2:
+                raise ValueError("transient")
+            return state
+
+        return solve
+
+    @scorer(metrics=[accuracy()])
+    def always_correct() -> Scorer:
+        async def score(state: TaskState, target: Target) -> Score:
+            return Score(value="C")
+
+        return score
+
+    def tasks() -> list[Task]:
+        return [
+            Task(
+                dataset=[Sample(id="one", input="one")],
+                solver=fail_twice(),
+                scorer=always_correct(),
+                name="retrying",
+            )
+        ]
+
+    manifest_path = tmp_path / "manifest.json"
+    kwargs: dict[str, Any] = dict(
+        model="mockllm/model",
+        log_dir=str(tmp_path / "logs"),
+        display="plain",
+        retry_on_error=3,
+    )
+
+    monkeypatch.setenv(INSPECT_EVAL_SET_CAPTURE, str(manifest_path))
+    try:
+        with pytest.raises(SystemExit):
+            eval_set(tasks=tasks(), **kwargs)
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_CAPTURE)
+    capture = EvalSetCapture.model_validate_json(manifest_path.read_bytes())
+    assert capture.options["retry_on_error"] == 3
+
+    selection_path = tmp_path / "selection.json"
+    selection_path.write_text(
+        selection_for(capture.tasks[0].identifier).model_dump_json()
+    )
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(selection_path))
+    try:
+        success, logs = eval_set(tasks=tasks(), **kwargs)
+    finally:
+        monkeypatch.delenv(INSPECT_EVAL_SET_SELECTION)
+
+    # two failures then a success: the definition's three sample attempts ran
+    assert success
+    assert len(attempts) == 3
+    assert logs[0].results is not None
+    assert logs[0].results.completed_samples == 1
+
+
+def test_eval_set_selection_unknown_identifier(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(PrerequisiteError, match="does not match any of the 4 tasks"):
+        run_selection(
+            monkeypatch,
+            tmp_path,
+            selection_for("nope@nope#nope/nope/nope"),
+            tmp_path / "logs",
+        )
+
+
+def test_eval_set_selection_resume_log_mismatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A resume log belonging to a different task is rejected rather than reused."""
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    log_dir = tmp_path / "logs"
+    identifiers = {t.name: t.identifier for t in capture.tasks if t.model == MODELS[0]}
+
+    _, logs = run_selection(
+        monkeypatch, tmp_path, selection_for(identifiers["selection_task_one"]), log_dir
+    )
+    assert logs[0].location
+
+    with pytest.raises(PrerequisiteError, match="belongs to a different task"):
+        run_selection(
+            monkeypatch,
+            tmp_path,
+            EvalSetSelection(
+                version=EVAL_SET_SELECTION_VERSION,
+                eval_set_id="worker-test",
+                tasks=[
+                    EvalSetSelectionTask(
+                        identifier=identifiers["selection_task_two"],
+                        resume=logs[0].location,
+                    )
+                ],
+            ),
+            log_dir,
+            name="mismatch",
+        )
+
+
+def test_eval_set_selection_resume_log_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    capture = enumerate_eval_set(monkeypatch, tmp_path)
+    with pytest.raises(PrerequisiteError, match="does not exist"):
+        run_selection(
+            monkeypatch,
+            tmp_path,
+            EvalSetSelection(
+                version=EVAL_SET_SELECTION_VERSION,
+                eval_set_id="worker-test",
+                tasks=[
+                    EvalSetSelectionTask(
+                        identifier=capture.tasks[0].identifier,
+                        resume=str(tmp_path / "absent.eval"),
+                    )
+                ],
+            ),
+            tmp_path / "logs",
+        )
+
+
+@pytest.mark.parametrize(
+    "content,error_match",
+    [
+        ("{not json", "Unable to read the eval set selection"),
+        (json.dumps({"version": 1}), "Unable to read the eval set selection"),
+        (
+            json.dumps(
+                {"version": 99, "eval_set_id": "x", "tasks": [{"identifier": "y"}]}
+            ),
+            "schema version 99",
+        ),
+        (json.dumps({"version": 1, "eval_set_id": "x", "tasks": []}), "names no tasks"),
+    ],
+)
+def test_eval_set_selection_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, content: str, error_match: str
+) -> None:
+    selection_path = tmp_path / "selection.json"
+    selection_path.write_text(content)
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(selection_path))
+    with pytest.raises(PrerequisiteError, match=error_match):
+        eval_set(
+            tasks=[selection_task_one()],
+            model="mockllm/model",
+            log_dir=str(tmp_path / "logs"),
+            display="plain",
+        )
+
+
+def test_eval_set_selection_missing_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(tmp_path / "absent.json"))
+    with pytest.raises(
+        PrerequisiteError, match="Unable to read the eval set selection"
+    ):
+        eval_set(
+            tasks=[selection_task_one()],
+            model="mockllm/model",
+            log_dir=str(tmp_path / "logs"),
+            display="plain",
+        )
+
+
+def test_eval_set_selection_task_source_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(PrerequisiteError, match="TaskSource"):
+        run_selection(
+            monkeypatch,
+            tmp_path,
+            selection_for("anything"),
+            tmp_path / "logs",
+            tasks=TaskSource(),
+        )
+
+
+def test_eval_set_selection_scanner_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(PrerequisiteError, match="Scanners are not supported"):
+        run_selection(
+            monkeypatch,
+            tmp_path,
+            selection_for("anything"),
+            tmp_path / "logs",
+            scanner=[],
+        )
+
+
+def test_eval_set_capture_and_selection_are_exclusive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(INSPECT_EVAL_SET_CAPTURE, str(tmp_path / "manifest.json"))
+    monkeypatch.setenv(INSPECT_EVAL_SET_SELECTION, str(tmp_path / "selection.json"))
+    with pytest.raises(PrerequisiteError, match="cannot both be set"):
+        eval_set(
+            tasks=[selection_task_one()],
+            model="mockllm/model",
+            log_dir=str(tmp_path / "logs"),
+            display="plain",
+        )
+
+
+# Golden values for the selection schema. These must NOT be changed for an
+# existing version -- an external runner writes these files. If the schema
+# changes, bump EVAL_SET_SELECTION_VERSION and update accordingly.
+_EXPECTED_SELECTION_FIELDS: dict[int, dict[str, set[str]]] = {
+    1: {
+        "selection": {"version", "eval_set_id", "tasks"},
+        "task": {"identifier", "resume"},
+    }
+}
+
+
+def test_eval_set_selection_schema_stability() -> None:
+    assert EVAL_SET_SELECTION_VERSION in _EXPECTED_SELECTION_FIELDS
+    expected = _EXPECTED_SELECTION_FIELDS[EVAL_SET_SELECTION_VERSION]
+    assert set(EvalSetSelection.model_fields.keys()) == expected["selection"]
+    assert set(EvalSetSelectionTask.model_fields.keys()) == expected["task"]


### PR DESCRIPTION
Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself. Selected tasks run through the ordinary `eval()` path with no eval-set orchestration; because the runner owns completion decisions, workers neither fail a task on sample errors nor retry a task in-process.