### PR TITLE
fix(solver): preserve original_position across repeated shuffles

### DIFF
--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -114,13 +114,12 @@ class Choices(Sequence[Choice]):
         shuffled_positions = list(range(len(self._choices)))
         rand.shuffle(shuffled_positions)
 
-        shuffled_choices = [Choice("notachoice", None, -1)] * len(self._choices)
-
-        for i, shuffled_position in enumerate(shuffled_positions):
-            shuffled_choices[i] = self._choices[shuffled_position]
-            shuffled_choices[i].original_position = shuffled_position
-
-        self._choices = shuffled_choices
+        # Reorder the existing Choice objects without clobbering their
+        # `original_position` (which refers to the choice's position in the
+        # sample's original list, not its position before this shuffle).
+        # Repeating a shuffle must not corrupt the mapping back to the
+        # original order.
+        self._choices = [self._choices[p] for p in shuffled_positions]
 
     def prompt(self, question: str, template: str) -> str:
         """Format a prompt for these choices.

--- a/tests/solver/test_multiple_choice.py
+++ b/tests/solver/test_multiple_choice.py
@@ -12,7 +12,7 @@ from inspect_ai.scorer._choice import choice
 from inspect_ai.scorer._metric import CORRECT
 from inspect_ai.scorer._target import Target
 from inspect_ai.solver import MultipleChoiceTemplate, TaskState, multiple_choice
-from inspect_ai.solver._task_state import Choice
+from inspect_ai.solver._task_state import Choice, Choices
 
 
 async def generate(state: TaskState, **kwargs: Any) -> TaskState:
@@ -103,6 +103,45 @@ def test_more_than_26_choices():
     assert log.status == "success"
     assert log.results
     assert log.results.scores[0].metrics["accuracy"].value == 1.0
+
+
+def test_shuffle_preserves_original_position_after_repeated_shuffles():
+    choices = Choices(["Choice0", "Choice1", "Choice2"])
+
+    # Initial: each choice keeps its position in the sample's original list
+    assert [c.original_position for c in choices] == [0, 1, 2]
+
+    choices.shuffle(Random(42))
+    # Each choice's original position is preserved, though the list order
+    # (and therefore the order in which positions appear) changes
+    assert sorted(c.original_position for c in choices) == [0, 1, 2]
+
+    # A second shuffle must not corrupt the mapping back to the original order
+    choices.shuffle(Random(123))
+    assert sorted(c.original_position for c in choices) == [0, 1, 2]
+
+    # The values are re-ordered but the original positions are preserved
+    assert sorted(c.value for c in choices) == ["Choice0", "Choice1", "Choice2"]
+
+    # Even after repeated shuffles, choices can be mapped back to their
+    # original order using `original_position`
+    from inspect_ai.solver._multiple_choice import unshuffle_choices
+
+    unshuffled = unshuffle_choices(choices)
+    assert [c.value for c in unshuffled] == ["Choice0", "Choice1", "Choice2"]
+    assert [c.original_position for c in unshuffled] == [0, 1, 2]
+
+
+def test_shuffle_preserves_original_position_when_constructed_from_choices():
+    choices = Choices(
+        [
+            Choice(value="a", correct=None, original_position=10),
+            Choice(value="b", correct=None, original_position=20),
+            Choice(value="c", correct=None, original_position=30),
+        ]
+    )
+    choices.shuffle(Random(7))
+    assert sorted(c.original_position for c in choices) == [10, 20, 30]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

`Choices.shuffle()` in `src/inspect_ai/solver/_task_state.py` previously rebuilt the choice list and overwrote each choice's `original_position` with its *pre-shuffle list position*:

```python
for i, shuffled_position in enumerate(shuffled_positions):
    shuffled_choices[i] = self._choices[shuffled_position]
    shuffled_choices[i].original_position = shuffled_position
```

On a second shuffle this corrupted the mapping back to the sample's original choice order, because the values were already shuffled — `original_position` then pointed at the intermediate (already-shuffled) order rather than the sample's original order.

This changes the implementation to reorder the existing `Choice` objects directly:

```python
self._choices = [self._choices[p] for p in shuffled_positions]
```

preserving each choice's `original_position` as documented ("the original position in the sample's list of choices"). The random sequence is unchanged, so shuffle outcomes for existing evals are identical.

Fixes #5010

## Testing

- Added `test_shuffle_preserves_original_position_after_repeated_shuffles` — asserts `original_position` survives two successive shuffles and that `unshuffle_choices()` still maps choices back to the exact original order and positions.
- Added `test_shuffle_preserves_original_position_when_constructed_from_choices` — covers `Choices` constructed from existing `Choice` objects with arbitrary `original_position` values.
- Full `tests/solver/` + `tests/scorer/` suites: **632 passed, 0 failed** (198 skipped: vllm/trio-dependent).
- `ruff check` and `ruff format --check` clean on both changed files and the whole repo.
- Pre-existing unrelated failure: `tests/dataset/test_content_document.py` fails on Windows (MIME detection differences, `libmagic`), confirmed failing on the clean tree before this change.

## AI assistance disclosure

This contribution was implemented with assistance from Claude Code (Anthropic). I understand and can defend every line. The change was reviewed in multiple passes — including an independent re-review of the fix against the documented `original_position` semantics and a check that the failing test was a pre-existing Windows platform issue rather than a regression.