### PR TITLE
fix(scorer): match(numeric=True) with trailing/enclosing punctuation

### DIFF
--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -120,13 +120,45 @@ def _is_number(s: str) -> bool:
     return _parse_number(s) is not None
 
 
+# Sentence/enclosing punctuation that commonly attaches to a number token
+# in model output (e.g. "42!", "(42)", "[42]"). These are stripped from the
+# token edges before numeric recognition; a token with punctuation *inside*
+# the digits (e.g. "42abc") is still rejected. `%` is intentionally excluded:
+# "60%" is a percentage and must not collapse to the number 60.
+_TOKEN_PUNCTUATION = "!?:;()[]{}'\"`~<=>@#^&|"
+
+
+def _number_token(s: str) -> str:
+    """Return the numeric form of a token, tolerating edge punctuation.
+
+    If `s` (possibly with sentence/enclosing punctuation attached to its
+    edges, e.g. ``"42!"`` or ``"(42)"``) parses as a number, return the
+    token stripped of that punctuation (so it can be normalized); otherwise
+    return the token unchanged.
+    """
+    stripped = s.strip(_TOKEN_PUNCTUATION)
+    return stripped if stripped != s and _is_number(stripped) else s
+
+
+def _is_number_token(s: str) -> bool:
+    """Recognise a whitespace-delimited token as a number.
+
+    Unlike `_is_number`, tolerates sentence/enclosing punctuation attached
+    to the token edges (e.g. ``"42!"``, ``"(42)"``), which `match(numeric=True)`
+    previously rejected.
+    """
+    return _is_number(s) or _is_number(s.strip(_TOKEN_PUNCTUATION))
+
+
 def first_number_normalized(words: list[str]) -> str:
-    number = next((word for word in words if _is_number(word)), None)
-    return normalize_number(number) if number is not None else ""
+    number = next((word for word in words if _is_number_token(word)), None)
+    if number is None:
+        return ""
+    return normalize_number(_number_token(number))
 
 
 def all_numbers_normalized(words: list[str]) -> list[str]:
-    return [normalize_number(word) for word in words if _is_number(word)]
+    return [normalize_number(_number_token(word)) for word in words if _is_number_token(word)]
 
 
 def normalize_number(number: str, precision: int = 5) -> str:

--- a/tests/scorer/test_match.py
+++ b/tests/scorer/test_match.py
@@ -304,6 +304,51 @@ async def test_numeric_unicode_minus_with_leading_text():
     assert result.text == CORRECT
 
 
+# --- trailing / enclosing punctuation on number tokens ----------------------
+# match(numeric=True) must recognise numbers with sentence or enclosing
+# punctuation attached (e.g. "42!", "(42)"), without weakening the strict
+# rejection of tokens with non-numeric characters inside the digits.
+
+
+@pytest.mark.anyio
+async def test_numeric_match_with_trailing_punctuation():
+    scorer = match(numeric=True)
+    for output in ["The answer is 42!", "The answer is 42?", "The answer is 42:"]:
+        state = simple_task_state(model_output=output)
+        result = await scorer(state, Target(["42"]))
+        assert result.text == CORRECT
+
+
+@pytest.mark.anyio
+async def test_numeric_match_with_enclosing_punctuation():
+    scorer = match(numeric=True)
+    for output in ["The answer is (42).", "The answer is (42)", "The answer is [42]"]:
+        state = simple_task_state(model_output=output)
+        result = await scorer(state, Target(["42"]))
+        assert result.text == CORRECT
+
+
+@pytest.mark.anyio
+async def test_numeric_any_with_punctuation():
+    scorer = match(numeric=True, location="any")
+    state = simple_task_state(model_output="first (7) then 25! then done")
+    result = await scorer(state, Target(["25"]))
+
+    assert result.text == CORRECT
+    assert result.answer == "25"
+
+
+@pytest.mark.anyio
+async def test_numeric_exact_still_rejects_punct_inside_digits():
+    # a token with non-numeric characters *inside* the digits must still be
+    # rejected — only edge punctuation is tolerated
+    scorer = match(numeric=True)
+    state = simple_task_state(model_output="The answer is 42abc")
+    result = await scorer(state, Target(["42"]))
+
+    assert result.text == INCORRECT
+
+
 # --- any unmatched returns raw output ---------------------------------------
 # Counterpoint to test_numeric_any_answer_is_matched_number: when no number
 # matches, fall back to the raw model output rather than an extracted form.


### PR DESCRIPTION
## Summary

`match(numeric=True)` splits the model output into whitespace-delimited tokens and recognizes numbers via `_is_number()`. Tokens with sentence or enclosing punctuation attached (e.g. `"42!"`, `"(42)"`, `"[42]"`, `"42?"`, `"42:"`) failed to parse as numbers, so `first_number_normalized` / `all_numbers_normalized` silently dropped them and the score was `INCORRECT`.

This adds `_number_token()` / `_is_number_token()` in `src/inspect_ai/scorer/_common.py` which tolerate punctuation attached to the token *edges* during numeric recognition and normalization.

Notes:
- `%` is intentionally excluded from the stripped characters: `"60%"` is a percentage and must not collapse to the number `60` (existing tests `test_non_numeric_match*` rely on this).
- Tokens with non-numeric characters *inside* the digits (e.g. `"42abc"`) are still rejected — the `location="exact"` strictness tests continue to pass.

Fixes #4742

## Testing

- Added 4 regression tests in `tests/scorer/test_match.py` covering trailing punctuation (`42!`/`42?`/`42:`), enclosing punctuation (`(42).`/`(42)`/`[42]`), `location="any"` with mixed punctuation, and the strictness guard (`42abc` still `INCORRECT`).
- Full `tests/scorer/` suite: **539 passed, 0 failed** (174 skipped: vllm/trio-dependent).
- `ruff check` and `ruff format --check` clean on both changed files.

## AI assistance disclosure

This contribution was implemented with assistance from Claude Code (Anthropic). I understand and can defend every line. I ran multiple review passes: an initial implementation, a regression check against the existing `test_non_numeric_match_plain` (which caught that `%` must not be stripped), and a final full-suite verification.