### PR TITLE
fix(scorer): choice scorer misparses multi-digit labels (36+ choices)

### DIFF
--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -1,3 +1,5 @@
+import re
+
 from inspect_ai._util.answer import answer_character, answer_index
 from inspect_ai.solver._multiple_choice import (
     answer_options,
@@ -18,17 +20,30 @@ def _choices_are_shuffled(choices: Choices) -> bool:
 def _score_target(target: Target, choices: Choices) -> tuple[list[int], list[str]]:
     # Filter out separator characters (e.g. "A,B" or "A, B") so that only
     # actual answer letters/digits are mapped to choice indices.
-    target_positions = [
-        answer_index(target_character)
-        for target_character in target.text
-        if target_character not in (",", " ")
-    ]
+    #
+    # Group target text into runs of letters and runs of digits: letters map
+    # one-to-one to choice indices (e.g. "AB" -> [0, 1]), while a digit run
+    # is a single multi-digit label (e.g. "10" -> [35]) rather than being
+    # split into individual characters.
+    target_positions = _answer_positions(target.text)
 
     choice_positions = [i for i, choice in enumerate(choices) if choice.correct is True]
 
     answers = [answer_character(choice) for choice in choice_positions]
 
     return target_positions, answers
+
+
+def _answer_positions(target_text: str) -> list[int]:
+    positions: list[int] = []
+    for label in re.findall(r"[A-Za-z]+|\d+", target_text):
+        if label.isalpha():
+            # a run of letters is a sequence of single-letter answers
+            positions.extend(answer_index(char) for char in label)
+        else:
+            # a run of digits is a single multi-digit answer label
+            positions.append(answer_index(label))
+    return positions
 
 
 def _shuffled_explanation(choices: Choices) -> str:

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -164,3 +164,53 @@ async def test_correct_multiple_answers_all_incorrect():
     assert result.text == CORRECT
     assert result.answer == ""
     assert result.explanation == "ANSWERS: "
+
+
+@pytest.mark.anyio
+async def test_score_multi_digit_choice_label():
+    # 36 choices -> labels are "A".."Z" then "1", "2", ..., "10", "11", ...
+    scorer = choice()
+    state = simple_task_state(
+        model_output="ANSWER: 10",
+        choices=[f"choice {i}" for i in range(36)],
+    )
+    for index in range(36):
+        state.choices.mark_choice(index, index == 35)
+
+    result = await scorer(state, Target("10"))
+
+    assert result.text == CORRECT
+    assert result.answer == "10"
+
+
+@pytest.mark.anyio
+async def test_score_multi_digit_choice_label_separated():
+    scorer = choice()
+    state = simple_task_state(
+        model_output="ANSWER: 11",
+        choices=[f"choice {i}" for i in range(37)],
+    )
+    for index in range(37):
+        state.choices.mark_choice(index, index == 36)
+
+    result = await scorer(state, Target("11"))
+
+    assert result.text == CORRECT
+    assert result.answer == "11"
+
+
+@pytest.mark.anyio
+async def test_score_mixed_letter_and_multi_digit_labels():
+    # "A,10" -> choices A and the 36th choice (label "10")
+    scorer = choice()
+    state = simple_task_state(
+        model_output="ANSWER: A, 10",
+        choices=[f"choice {i}" for i in range(36)],
+    )
+    for index in range(36):
+        state.choices.mark_choice(index, index in (0, 35))
+
+    result = await scorer(state, Target("A,10"))
+
+    assert result.text == CORRECT
+    assert result.answer == "A, 10"


### PR DESCRIPTION
## Summary

The choice scorer maps the target to choice indices by iterating over `target.text` one character at a time. That is correct for letter forms such as `"AB"`, but it splits a multi-digit label such as `"10"` (the 36th choice — labels are `"A".."Z"` then `"1"`, `"2"`, ...) into `"1"` and `"0"`, producing positions 26 and 25 instead of position 35.

This changes `_score_target` in `src/inspect_ai/scorer/_choice.py` to group the target text into runs of letters and runs of digits: letters map one-to-one to choice indices (e.g. `"AB"` → `[0, 1]`), while a digit run is a single multi-digit label (e.g. `"10"` → `[35]`). `answer_index` already handles multi-digit labels correctly; only the per-character splitting was wrong.

Fixes #4590

## Testing

- Added 3 regression tests in `tests/scorer/test_choice.py`: the 36th-choice case from the issue (`Target("10")` with 36 choices), a 37-choice case (`"11"`), and a mixed `"A,10"` multi-select case.
- Verified round-trip stability `answer_character(i)` ↔ `answer_index(label)` for labels 26–139.
- Full `tests/scorer/` + `tests/solver/test_multiple_choice.py`: **568 passed, 0 failed** (200 skipped: vllm/trio-dependent).
- `ruff check` and `ruff format --check` clean on both changed files.

## AI assistance disclosure

This contribution was implemented with assistance from Claude Code (Anthropic). I understand and can defend every line. I ran multiple review passes: an initial per-character approach, a correctness check against `answer_index` semantics for multi-digit labels, and a final full-suite verification including boundary round-trips.