### PR TITLE
Fix conflict between legacy hooks and modern hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Hooks: Startup now loads all installed Inspect extensions before collecting and validating hooks, even when another hook was registered earlier.
 - Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself.
 - Eval Log: Samples halted by a limit now record why it fired (`EvalSampleLimit.reason`, `limit_reason` on sample summaries and `samples_df()`), so operator-terminated samples can be told apart without reading transcript events.
 - Sandbox: Sandbox-tools binaries downloaded from S3 are now verified against SHA256 digests pinned in the package; failures warn by default, or fail when `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Hooks: Startup now loads all installed Inspect extensions before collecting and validating hooks, even when another hook was registered earlier.
+- Hooks: Fixes an issue in hooks startup where legacy hooks (e.g., Inspect Telemetry) would prevent modern hooks from being registered automatically through entrypoints.
 - Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself.
 - Eval Log: Samples halted by a limit now record why it fired (`EvalSampleLimit.reason`, `limit_reason` on sample summaries and `samples_df()`), so operator-terminated samples can be told apart without reading transcript events.
 - Sandbox: Sandbox-tools binaries downloaded from S3 are now verified against SHA256 digests pinned in the package; failures warn by default, or fail when `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` is set.

--- a/src/inspect_ai/hooks/_startup.py
+++ b/src/inspect_ai/hooks/_startup.py
@@ -40,10 +40,12 @@ def _load_registry_hooks() -> list[Hooks]:
     if _registry_hooks_loaded:
         return []
 
+    from inspect_ai._util.entrypoints import ensure_entry_points
     from inspect_ai.hooks._hooks import get_all_hooks
 
     # Note that hooks loaded by virtue of load_file_tasks() -> load_module() (e.g.
     # if the user defines an @hook alongside their task) won't be loaded by now.
+    ensure_entry_points()
     hooks = get_all_hooks()
     _registry_hooks_loaded = True
     _verify_all_required_hooks(hooks)

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -6,6 +6,7 @@ import pytest
 import inspect_ai.hooks._startup as hooks_startup_module
 from inspect_ai import eval
 from inspect_ai._eval.task.task import Task
+from inspect_ai._util import entrypoints as entrypoints_module
 from inspect_ai._util.environ import environ_var
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.registry import _registry, registry_info, registry_lookup
@@ -573,6 +574,31 @@ def test_init_hooks_can_be_called_multiple_times(mock_hooks: MockHooks) -> None:
     eval(Task(dataset=[Sample("sample_1")]), model="mockllm/model")
 
     assert len(mock_hooks.run_start_events) == 1
+
+
+def test_init_hooks_loads_entry_points_with_preexisting_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The decorator registers immediately, modeling a hook imported as a side effect
+    # of legacy hook initialization before entry points are loaded.
+    @hooks(name="startup_preexisting", description="test")
+    class PreexistingHooks(Hooks):
+        pass
+
+    def ensure_entry_points() -> None:
+        @hooks(name="startup_extension", description="test")
+        class ExtensionHooks(Hooks):
+            pass
+
+    monkeypatch.setattr(entrypoints_module, "ensure_entry_points", ensure_entry_points)
+
+    try:
+        init_hooks()
+        assert registry_lookup("hooks", "startup_preexisting") is not None
+        assert registry_lookup("hooks", "startup_extension") is not None
+    finally:
+        _registry.pop("hooks:startup_preexisting", None)
+        _registry.pop("hooks:startup_extension", None)
 
 
 def test_hooks_name_and_description(mock_hooks: MockHooks) -> None:

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -579,6 +579,7 @@ def test_init_hooks_can_be_called_multiple_times(mock_hooks: MockHooks) -> None:
 def test_init_hooks_loads_entry_points_with_preexisting_hook(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+
     # The decorator registers immediately, modeling a hook imported as a side effect
     # of legacy hook initialization before entry points are loaded.
     @hooks(name="startup_preexisting", description="test")
@@ -593,12 +594,19 @@ def test_init_hooks_loads_entry_points_with_preexisting_hook(
     monkeypatch.setattr(entrypoints_module, "ensure_entry_points", ensure_entry_points)
 
     try:
+        preexisting_key = "hooks:startup_preexisting"
+        extension_key = "hooks:startup_extension"
+
+        assert preexisting_key in _registry
+        assert extension_key not in _registry
+
         init_hooks()
-        assert registry_lookup("hooks", "startup_preexisting") is not None
-        assert registry_lookup("hooks", "startup_extension") is not None
+
+        assert preexisting_key in _registry
+        assert extension_key in _registry
     finally:
-        _registry.pop("hooks:startup_preexisting", None)
-        _registry.pop("hooks:startup_extension", None)
+        _registry.pop(preexisting_key, None)
+        _registry.pop(extension_key, None)
 
 
 def test_hooks_name_and_description(mock_hooks: MockHooks) -> None:

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -579,12 +579,8 @@ def test_init_hooks_can_be_called_multiple_times(mock_hooks: MockHooks) -> None:
 def test_init_hooks_loads_entry_points_with_preexisting_hook(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-
-    # The decorator registers immediately, modeling a hook imported as a side effect
-    # of legacy hook initialization before entry points are loaded.
-    @hooks(name="startup_preexisting", description="test")
-    class PreexistingHooks(Hooks):
-        pass
+    preexisting_key = "hooks:startup_preexisting"
+    extension_key = "hooks:startup_extension"
 
     def ensure_entry_points() -> None:
         @hooks(name="startup_extension", description="test")
@@ -594,8 +590,11 @@ def test_init_hooks_loads_entry_points_with_preexisting_hook(
     monkeypatch.setattr(entrypoints_module, "ensure_entry_points", ensure_entry_points)
 
     try:
-        preexisting_key = "hooks:startup_preexisting"
-        extension_key = "hooks:startup_extension"
+        # The decorator registers immediately, modeling a hook imported as a side
+        # effect of legacy hook initialization before entry points are loaded.
+        @hooks(name="startup_preexisting", description="test")
+        class PreexistingHooks(Hooks):
+            pass
 
         assert preexisting_key in _registry
         assert extension_key not in _registry


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
There's a bug in hook loading when a legacy hook (e.g., inspect telemetry) is used together with a hook registered through Inspect entrypoints. The legacy hook is loaded first into registry, and subsequent calls to `get_all_hooks` would see the legacy hook and avoid loading additional hooks through entrypoints (see src/inspect_ai/_util/registry.py#L323).

### What is the new behavior?
This change forces entrypoint loading when hooks are initialised to prevent this failure mode.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, but it's a bug fix instead of an unintended change.

### Other information:
I considered the alternative of removing the legacy hook system. But it's too big of a change for me to suggest.