### PR TITLE
Fix raw S3/GCS authentication errors when listing remote eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Control Channel: Task-selecting `inspect ctl` commands now take a `--model` disambiguator, so one task run against several models can be selected by name (e.g. `inspect ctl task cancel my_task --model gpt-5`).
 - Model roles can now be bound to a list of models (e.g. `model_roles={"grader": [...]}`), with model-graded scorers grading by majority vote across the list.
 - Checkpointing: Sandbox snapshots now support selectable strategies (per sandbox, settable at the sample, task, or eval layer) — incremental restic (default) or self-contained per-checkpoint archives captured with in-image tools only.
+- Eval Log: Listing remote log directories now degrades S3 and GCS authentication failures to a warning and an empty result, matching the existing Azure behavior.
 
 ## 0.3.260 (21 August 2026)
 

--- a/src/inspect_ai/_util/remote.py
+++ b/src/inspect_ai/_util/remote.py
@@ -1,0 +1,87 @@
+"""Helpers for treating remote-filesystem auth failures as degraded listings."""
+
+from urllib.parse import urlparse
+
+from botocore.exceptions import ClientError, NoCredentialsError
+
+from inspect_ai._util.azure import (
+    AZURE_SCHEMES,
+    azure_warning_hint,
+    should_suppress_azure_error,
+)
+
+S3_SCHEME = "s3"
+GCS_SCHEMES = {"gs", "gcs"}
+
+
+def _is_s3_auth_error(error: Exception) -> bool:
+    """Return True if ``error`` is an S3 credential/auth failure."""
+    if isinstance(error, NoCredentialsError):
+        return True
+    if isinstance(error, ClientError):
+        code = getattr(error, "response", {}).get("Error", {}).get("Code")
+        if code in {
+            "NoCredentialsError",
+            "CredentialRetrievalError",
+            "InvalidAccessKeyId",
+            "SignatureDoesNotMatch",
+            "AccessDenied",
+        }:
+            return True
+    msg = str(error).lower()
+    return "credential" in msg or "access key" in msg or "signature" in msg
+
+
+def _is_gcs_auth_error(error: Exception) -> bool:
+    """Return True if ``error`` is a Google Cloud Storage auth failure."""
+    msg = str(error).lower()
+    return any(
+        phrase in msg
+        for phrase in (
+            "credential",
+            "authentication",
+            "unauthenticated",
+            "invalid credentials",
+            "anonymous caller",
+            "login required",
+        )
+    )
+
+
+def should_suppress_remote_auth_error(path: str, error: Exception) -> bool:
+    """Return True if a remote filesystem auth issue should be downgraded.
+
+    Auth failures for Azure, S3, and GCS are treated leniently so that log
+    listings degrade to an empty/warning result rather than surfacing a raw
+    provider exception to the user.
+    """
+    scheme = urlparse(path).scheme.lower()
+    if scheme in AZURE_SCHEMES:
+        return should_suppress_azure_error(path, error)
+    if scheme == S3_SCHEME:
+        return _is_s3_auth_error(error)
+    if scheme in GCS_SCHEMES:
+        return _is_gcs_auth_error(error)
+    return False
+
+
+def remote_auth_warning_hint(path: str, error: Exception) -> str:
+    """Diagnostic guidance for remote listing/authentication issues."""
+    scheme = urlparse(path).scheme.lower()
+    if scheme in AZURE_SCHEMES:
+        return azure_warning_hint(path, error)
+    if scheme == S3_SCHEME:
+        return (
+            "S3 authentication failed while probing "
+            f"'{path}'. Suppressed stack trace. Guidance: ensure AWS credentials are "
+            "configured (e.g. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, SSO, or an "
+            f"IAM role) and the bucket is accessible. Original error: {error}"
+        )
+    if scheme in GCS_SCHEMES:
+        return (
+            "Google Cloud Storage authentication failed while probing "
+            f"'{path}'. Suppressed stack trace. Guidance: ensure Application Default "
+            "Credentials are configured (e.g. `gcloud auth application-default login`). "
+            f"Original error: {error}"
+        )
+    return f"Authentication failed while probing '{path}': {error}"

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -11,7 +11,7 @@ from typing import IO, Any, AsyncIterator, Callable, Generator, Literal, cast
 
 import anyio.to_thread
 import fsspec  # type: ignore
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 from fsspec.asyn import AsyncFileSystem  # type: ignore
 from fsspec.core import split_protocol  # type: ignore
 from pydantic import (
@@ -22,7 +22,6 @@ from pydantic import (
 from inspect_ai._util._async import current_async_backend, run_coroutine, tg_collect
 from inspect_ai._util.async_zip import AsyncZipReader
 from inspect_ai._util.asyncfiles import AsyncFilesystem, get_async_filesystem
-from inspect_ai._util.azure import azure_warning_hint, should_suppress_azure_error
 from inspect_ai._util.constants import ALL_LOG_FORMATS, EVAL_LOG_FORMAT
 from inspect_ai._util.dateutil import UtcDatetimeStr
 from inspect_ai._util.error import EvalError
@@ -33,6 +32,10 @@ from inspect_ai._util.file import (
     filesystem,
 )
 from inspect_ai._util.json import to_json_safe
+from inspect_ai._util.remote import (
+    remote_auth_warning_hint,
+    should_suppress_remote_auth_error,
+)
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._resolve import rebind_sample_timelines, resolve_sample_events_data
@@ -234,14 +237,18 @@ async def _list_eval_logs_async(
                         log_dir, recursive=recursive, detail=True
                     )
                 ]
-        except ClientError as ex:
+        except (ClientError, NoCredentialsError) as ex:
+            code = getattr(ex, "response", {}).get("Error", {}).get("Code")
             # a missing bucket is an empty listing (as with the existence
             # precheck the other branches perform), not an error
-            if ex.response.get("Error", {}).get("Code") in (
+            if code in (
                 "NoSuchBucket",
                 "404",
                 "NotFound",
             ):
+                return []
+            if should_suppress_remote_auth_error(log_dir, ex):
+                logger.warning(remote_auth_warning_hint(log_dir, ex))
                 return []
             raise
         # resolve to eval logs (async fan-out so header reads on
@@ -256,8 +263,8 @@ async def _list_eval_logs_async(
         try:
             exists = fs.exists(log_dir)
         except Exception as ex:  # noqa: BLE001
-            if should_suppress_azure_error(log_dir, ex):
-                logger.warning(azure_warning_hint(log_dir, ex))
+            if should_suppress_remote_auth_error(log_dir, ex):
+                logger.warning(remote_auth_warning_hint(log_dir, ex))
                 exists = True
             else:
                 raise
@@ -267,16 +274,14 @@ async def _list_eval_logs_async(
         return await log_files_from_ls_async(logs, formats, descending)
     elif fs.is_async():
         async with async_filesystem(log_dir, fs_options=fs_options) as async_fs:
-            # Attempt existence check with robust handling for Azure-style auth issues.
+            # Attempt existence check with robust handling for remote auth issues.
             try:
                 exists = await async_fs._exists(log_dir)
             except Exception as ex:  # noqa: BLE001
-                if should_suppress_azure_error(log_dir, ex):
-                    logger.warning(azure_warning_hint(log_dir, ex))
+                if should_suppress_remote_auth_error(log_dir, ex):
+                    logger.warning(remote_auth_warning_hint(log_dir, ex))
                     exists = True
                 else:
-                    # TODO: Add S3 login error catching, as well as any other remote file system of interest
-                    # Re-raise non-auth related issues
                     raise
 
             if exists:

--- a/tests/log/test_list_logs.py
+++ b/tests/log/test_list_logs.py
@@ -1,11 +1,14 @@
+import contextlib
 from os.path import dirname, join
 from pathlib import Path
 from typing import Any, cast
 
 import anyio
 import pytest
+from botocore.exceptions import ClientError
+from test_helpers.utils import skip_if_trio
 
-from inspect_ai._util.file import filesystem
+from inspect_ai._util.file import FileInfo, filesystem
 from inspect_ai.log import list_eval_logs, list_eval_logs_async
 from inspect_ai.log._file import (
     EvalLogInfo,
@@ -184,3 +187,185 @@ def test_list_logs_async_remote_fs_trio(monkeypatch: pytest.MonkeyPatch):
         assert len(logs) == 3
 
     anyio.run(check, backend="trio")
+
+
+@skip_if_trio
+async def test_list_logs_async_s3_auth_error_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from inspect_ai.log import _file as log_file
+
+    class FakeFileSystem:
+        def is_s3(self) -> bool:
+            return True
+
+        def is_async(self) -> bool:
+            return True
+
+        def _file_info(self, info: dict[str, Any]) -> FileInfo:
+            return FileInfo(
+                name=info["name"],
+                type=info["type"],
+                size=info.get("size", 0),
+                mtime=info.get("mtime"),
+                etag=None,
+            )
+
+    class FakeAsyncFileSystem:
+        async def _exists(self, log_dir: str) -> bool:
+            raise ClientError(
+                {"Error": {"Code": "InvalidAccessKeyId", "Message": "bad key"}},
+                "HeadBucket",
+            )
+
+        async def _ls(self, log_dir: str, detail: bool = True) -> list[dict[str, Any]]:
+            return []
+
+        def invalidate_cache(self, log_dir: str) -> None:
+            pass
+
+    @contextlib.asynccontextmanager
+    async def fake_async_filesystem(
+        location: str, fs_options: dict[str, Any] = {}
+    ) -> Any:
+        yield FakeAsyncFileSystem()
+
+    monkeypatch.setattr(
+        log_file, "filesystem", lambda path, fs_options={}: FakeFileSystem()
+    )
+    monkeypatch.setattr(log_file, "async_filesystem", fake_async_filesystem)
+
+    with caplog.at_level("WARNING"):
+        logs = await list_eval_logs_async(
+            "s3://bucket/logs", recursive=False, fs_options={"anon": False}
+        )
+
+    assert logs == []
+    assert "S3 authentication failed while probing" in caplog.text
+
+
+@skip_if_trio
+async def test_list_logs_async_s3_non_auth_error_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_ai.log import _file as log_file
+
+    class FakeFileSystem:
+        def is_s3(self) -> bool:
+            return True
+
+        def is_async(self) -> bool:
+            return True
+
+    class FakeAsyncFileSystem:
+        async def _exists(self, log_dir: str) -> bool:
+            raise ClientError(
+                {"Error": {"Code": "InternalError", "Message": "boom"}},
+                "HeadBucket",
+            )
+
+        async def _ls(self, log_dir: str, detail: bool = True) -> list[dict[str, Any]]:
+            return []
+
+    @contextlib.asynccontextmanager
+    async def fake_async_filesystem(
+        location: str, fs_options: dict[str, Any] = {}
+    ) -> Any:
+        yield FakeAsyncFileSystem()
+
+    monkeypatch.setattr(
+        log_file, "filesystem", lambda path, fs_options={}: FakeFileSystem()
+    )
+    monkeypatch.setattr(log_file, "async_filesystem", fake_async_filesystem)
+
+    with pytest.raises(ClientError, match="InternalError"):
+        await list_eval_logs_async(
+            "s3://bucket/logs", recursive=False, fs_options={"anon": False}
+        )
+
+
+@skip_if_trio
+async def test_list_logs_async_gcs_auth_error_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from inspect_ai.log import _file as log_file
+
+    class FakeFileSystem:
+        def is_s3(self) -> bool:
+            return False
+
+        def is_async(self) -> bool:
+            return True
+
+    class FakeAsyncFileSystem:
+        async def _exists(self, log_dir: str) -> bool:
+            raise OSError("Invalid credentials: anonymous caller does not have access")
+
+        async def _ls(self, log_dir: str, detail: bool = True) -> list[dict[str, Any]]:
+            return []
+
+        def invalidate_cache(self, log_dir: str) -> None:
+            pass
+
+    @contextlib.asynccontextmanager
+    async def fake_async_filesystem(
+        location: str, fs_options: dict[str, Any] = {}
+    ) -> Any:
+        yield FakeAsyncFileSystem()
+
+    monkeypatch.setattr(
+        log_file, "filesystem", lambda path, fs_options={}: FakeFileSystem()
+    )
+    monkeypatch.setattr(log_file, "async_filesystem", fake_async_filesystem)
+
+    with caplog.at_level("WARNING"):
+        logs = await list_eval_logs_async("gs://bucket/logs", recursive=False)
+
+    assert logs == []
+    assert "Google Cloud Storage authentication failed while probing" in caplog.text
+
+
+@skip_if_trio
+async def test_list_logs_async_s3_fast_path_auth_error_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from inspect_ai.log import _file as log_file
+
+    class FakeFileSystem:
+        def is_s3(self) -> bool:
+            return True
+
+        def is_async(self) -> bool:
+            return True
+
+    class FakeAsyncFilesystem:
+        async def __aenter__(self) -> "FakeAsyncFilesystem":
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool:
+            return False
+
+        async def iter_files(
+            self, path: str, *, recursive: bool = False, detail: bool = True
+        ) -> Any:
+            # Force this method to be an async generator (required by the caller)
+            if False:
+                yield None
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "ListObjectsV2",
+            )
+
+    monkeypatch.setattr(
+        log_file, "filesystem", lambda path, fs_options={}: FakeFileSystem()
+    )
+    monkeypatch.setattr(log_file, "AsyncFilesystem", FakeAsyncFilesystem)
+
+    with caplog.at_level("WARNING"):
+        logs = await list_eval_logs_async("s3://bucket/logs", recursive=False)
+
+    assert logs == []
+    assert "S3 authentication failed while probing" in caplog.text


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`list_eval_logs_async` only suppressed Azure authentication errors when probing a remote log directory. S3 and GCS credential/login failures were re-raised raw, so users with expired or missing credentials saw provider-specific stack traces instead of a clear warning.

Fixes #4914.

### What is the new behavior?

S3 and GCS authentication failures during remote log-directory probing are now downgraded to a warning and an empty listing, matching the existing Azure behavior. The change covers all three remote listing paths: the S3 fast path, the async fsspec branch, and the sync-under-trio fallback.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. A previously crashing call now returns `[]` and logs a warning, which is a safer degradation.

### Other information:

- New shared helpers live in `src/inspect_ai/_util/remote.py` so future remote filesystems can be added in one place.
- Added unit tests for S3 auth suppression, S3 non-auth error propagation, GCS auth suppression, and S3 fast-path auth suppression.
- `make check` passes `ruff`; `mypy` reports one pre-existing unrelated error in `src/inspect_ai/tool/_mcp/sampling.py` (`Module "mcp.types" has no attribute "SamplingMessageContentBlock"`). The files touched by this PR are clean.

### Agent review
- No independent agent review pass was run.
- This PR was authored with the assistance of an AI coding agent (OpenCode / Kimi-K2.7-Code).
