### PR TITLE
fix(solver): allow empty user message text in TaskState.input_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Solver: Allow empty user message text in TaskState.input_text. (#5046)
 - Eval Log: Reading a sample from a `.json` log now reports the requested uuid when the sample is missing, and raises a clear error when neither id nor uuid is provided.
 - vLLM: The server's `max_model_len` is now registered as the model's context window, so compaction and context-length handling reflect the served configuration (including LoRA adapters via their parent model). (#4215)
 - Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself.

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -228,7 +228,7 @@ class TaskState:
                 ),
                 None,
             )
-            if input:
+            if input is not None:
                 return input
             else:
                 raise ValueError(

--- a/tests/solver/test_solver.py
+++ b/tests/solver/test_solver.py
@@ -101,3 +101,33 @@ def test_valid_solvers_succeed():
 
     for f in [is_async, IsAsyncCallable]:
         solver(name=f.__name__)(f)()
+
+
+def test_task_state_input_text_empty_user_message():
+    from inspect_ai.model import ChatMessageAssistant
+
+    state_empty_str = TaskState(
+        model="mockllm/model", sample_id=1, epoch=1, input="", messages=[]
+    )
+    assert state_empty_str.input_text == ""
+
+    state_empty_msg = TaskState(
+        model="mockllm/model",
+        sample_id=1,
+        epoch=1,
+        input=[ChatMessageUser(content="")],
+        messages=[],
+    )
+    assert state_empty_msg.input_text == ""
+
+    state_no_user = TaskState(
+        model="mockllm/model",
+        sample_id=1,
+        epoch=1,
+        input=[ChatMessageAssistant(content="hi")],
+        messages=[],
+    )
+    with pytest.raises(
+        ValueError, match="input_text requested from TaskState but none available"
+    ):
+        _ = state_no_user.input_text


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5046

`TaskState.input_text` checked `if input:` rather than `if input is not None:`. When a `Sample` had its input provided as a list of `ChatMessage` objects where the last user message contained empty text `""` (e.g. `[ChatMessageUser(content="")]`), `if input:` evaluated to `False` and erroneously raised `ValueError: input_text requested from TaskState but none available`.

In contrast, when `TaskState.input` was a plain empty string `""`, `input_text` returned `""`.

### What is the new behavior?

`TaskState.input_text` checks `if input is not None:`, correctly returning `""` when the user message text is empty.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via fresh reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified input_text on empty string input, empty user message input, and missing user message error; all checks passed)