### PR TITLE
Fix mypy errors with openai 3.5.0 (optional FunctionCallOutput.call_id) and trio flake in suspended-hook requeue test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
+- OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.
 - Scoring: Skip Score.unscored() / NaN-at-root sentinels in aggregate() metric. (#5008)
 - Scoring: Return inf on OverflowError in perplexity_per_token() and perplexity_per_seq() metrics. (#5028)
 - Analysis: Ensure ColumnError.path is a string rather than a JSONPath object on record import errors. (#5006)

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -1027,10 +1027,11 @@ def messages_from_responses_input(
             else:
                 messages.append(ChatMessageSystem(content=content))
         elif is_function_call_output(item):
+            call_id = item.get("call_id")
             messages.append(
                 ChatMessageTool(
-                    tool_call_id=item["call_id"],
-                    function=function_calls_by_id.get(item["call_id"]),
+                    tool_call_id=call_id,
+                    function=function_calls_by_id.get(call_id) if call_id else None,
                     content=_tool_content_from_openai_tool_output(item["output"]),
                 )
             )

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -2531,7 +2531,7 @@ def pad_tool_messages_for_token_counting(
     for i, msg in enumerate(messages):
         # Forward scan: Check for function_call_output without preceding function_call
         if is_function_call_output(msg):
-            call_id = msg.get("call_id", "")
+            call_id = msg.get("call_id") or ""
             has_matching_call = (
                 result
                 and is_response_function_tool_call(result[-1])

--- a/tests/_control/test_requeue.py
+++ b/tests/_control/test_requeue.py
@@ -1731,11 +1731,22 @@ class _SuspendingEarlyStopping:
 
 @solver
 def _boom_then_ok():
-    """Errors the "boom" sample terminally; everything else succeeds."""
+    """Errors the "boom" sample terminally; everything else succeeds.
+
+    Non-boom samples park until "boom" has been terminal-counted. The
+    fanout starts one task per plan entry (`SampleScheduler.run`),
+    and trio randomizes the order runnable tasks are stepped, so which
+    sample reaches its solver first is not deterministic — the ordering
+    the finished-gate assertions rely on has to be explicit rather than
+    inherited from dataset order.
+    """
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         if state.sample_id == "boom":
             raise RuntimeError("terminal boom")
+        with anyio.fail_after(60):
+            while not any(s.errored for s in get_eval_states()):
+                await anyio.sleep(0.01)
         return state
 
     return solve
@@ -1780,7 +1791,9 @@ async def test_requeue_and_cancel_rejected_during_suspended_hook() -> None:
                     model="mockllm/model",
                     fail_on_error=False,
                     ctl_server=False,
-                    max_samples=1,  # boom goes terminal before last completes
+                    # both samples resident: "last" parks in its solver
+                    # until boom is terminal-counted (see _boom_then_ok)
+                    max_samples=2,
                 )
             )
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#340

Two independent scheduled-CI failures (run [33031037578](https://github.com/meridianlabs-ai/actions/actions/runs/33031037578)):

1. **static-analysis**: openai 3.5.0 widened `FunctionCallOutput.call_id` from `Required[str]` to `Optional[str]` (while `ResponseFunctionToolCallParam.call_id` remains `Required[str]`), producing 2 mypy errors — `_openai_responses.py:2545` (`str | None` assigned to a `Required[str]` TypedDict item) and `responses_impl.py:1033` (`str | None` passed to `dict.get` expecting `str`). At runtime, a payload omitting `call_id` (now permitted) would also raise `KeyError` in the bridge.
2. **slow-tests (trio)**: `test_requeue_and_cancel_rejected_during_suspended_hook` flaked ~50% of trio runs. `SampleScheduler.run` starts one task per plan entry and the test relied on the asyncio FIFO step order to have "boom" take the single `max_samples=1` slot first; trio deliberately randomizes runnable-task order, so half the time "last" ran first and the precondition assertion read `(completed, errored) == (1, 0)`.

### What is the new behavior?

1. Both call sites tolerate a missing/None `call_id`: the token-count padding helper coalesces with `or ""`, and the bridge passes `None` through to `ChatMessageTool.tool_call_id` (already `str | None`) instead of raising `KeyError`. Behavior for well-formed payloads is unchanged; mypy is clean on openai 3.5.0. The `openai` pin is intentionally not capped — the field is legitimately optional now.
2. The test's ordering is explicit instead of inherited from dataset order: non-boom samples park in the solver until an errored sample is terminal-counted, with `max_samples=2` so both samples are resident (a single slot would deadlock a last-first schedule). Product behavior under test is unchanged — this was a test-only ordering assumption.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Diagnosis, root-cause analysis, and the proposed fix are from issue meridianlabs-ai/inspect_ai#340 (triage of the scheduled run); this PR implements it as proposed.

**Verification** (local, openai 3.5.0 installed):
- `mypy src/inspect_ai/model/_openai_responses.py src/inspect_ai/agent/_bridge/responses_impl.py tests/_control/test_requeue.py` — clean (previously the 2 CI errors)
- `ruff check` / `ruff format --check` on changed files — clean
- `test_requeue_and_cancel_rejected_during_suspended_hook`: 9/9 consecutive trio runs pass (previously ~50% failure); asyncio passes
- Full `tests/_control/test_requeue.py`: 46 passed (asyncio), 44 passed (trio)
- Related coverage: `tests/model/providers/test_openai_responses.py`, `tests/model/test_token_counting_integration.py`, `tests/agent/test_bridge_{tool_search,agent_message,additional_tools}.py` — 107 passed

Agent involvement: implemented by Claude Code (Fable 5) from the triaged issue.

### Agent review
- Reviewer: Claude Fable 5 via general-purpose subagent (fresh context, same model as author), 1 pass; the reviewer independently re-ran mypy and both test backends
- Findings: 2 — 0 fixed, 2 dismissed (test's park loop polls the process-wide eval-state registry, safe because states are cleared per eval and the pattern matches the rest of the file; `or ""` coalescing lets a malformed None call_id match an empty-string call in the padding helper, a degenerate edge the helper's overcount-tolerant contract already covers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)