### PR TITLE
fix(util): format None values for top-level placeholders in format_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Util: Substitute placeholders with None value as 'None' in format_template(). (#5078)
 - Breaking (tests only) Sandboxes: `inspect_ai.util._sandbox.self_check` is now a collection of plain pytest tests. See docstring for migration instructions.
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.

--- a/src/inspect_ai/_util/format.py
+++ b/src/inspect_ai/_util/format.py
@@ -78,7 +78,11 @@ def format_template(
                     return "{" + field_name + "}", field_name
 
                 obj = params.get(first)
-                if obj is None and skip_unknown:
+                if (
+                    obj is None
+                    and (rest is not None or "[" in field_name)
+                    and skip_unknown
+                ):
                     return "{" + field_name + "}", field_name
 
                 return super().get_field(field_name, args, kwargs)

--- a/tests/util/test_format_template.py
+++ b/tests/util/test_format_template.py
@@ -93,6 +93,19 @@ def test_invalid_nested_attributes() -> None:
         assert result == case.expected
 
 
+def test_none_value_substitution() -> None:
+    """Test that placeholders with None value are formatted as 'None'."""
+    assert (
+        format_template("Hello {name}!", {"name": None}, skip_unknown=True)
+        == "Hello None!"
+    )
+    assert (
+        format_template("Hello {name}!", {"name": None}, skip_unknown=False)
+        == "Hello None!"
+    )
+    assert format_template("{a} and {b}", {"a": None, "b": "test"}) == "None and test"
+
+
 def test_format_specifications() -> None:
     """Test handling of format specifications."""
     test_cases: list[FormatterCase] = [


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5078

When `params` contained a key with value `None` (e.g. `{"name": None}`) and `skip_unknown=True` (the default), `format_template()` checked `if obj is None and skip_unknown:` unconditionally and returned `"{name}"` instead of formatting `None` as `"None"`.

### What is the new behavior?

`format_template()` only preserves placeholders when `obj is None` if nested attribute or indexing access was requested (e.g. `{obj.attribute}` or `{obj[0]}`). Top-level placeholders with `None` values format as `"None"` (matching Python `str.format()` behavior).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via fresh reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified format_template with None values, nested None attributes/indices, unknown keys, and custom format specs; all checks passed)