### PR TITLE
fix(tool): exclude *args and **kwargs from tool schema and parameter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Tools: Exclude *args and **kwargs from JSON schema and required parameters in parse_tool_info(). (#5080)
 - Breaking (tests only) Sandboxes: `inspect_ai.util._sandbox.self_check` is now a collection of plain pytest tests. See docstring for migration instructions.
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -998,6 +998,12 @@ def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, An
     # build params
     params: dict[str, Any] = {}
     for param_name, param in signature.parameters.items():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+
         # Parse docstring
         docstring_info = parse_docstring(docstring, param_name)
 

--- a/src/inspect_ai/tool/_tool_info.py
+++ b/src/inspect_ai/tool/_tool_info.py
@@ -137,6 +137,12 @@ def _parse_tool_info_shared(func: Callable[..., Any]) -> ToolInfo:
     info = ToolInfo(name=func_name, description="")
 
     for param_name, param in signature.parameters.items():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+
         tool_param = ToolParam()
 
         # Look up docstring info from pre-built dict

--- a/tests/tools/test_call_tools.py
+++ b/tests/tools/test_call_tools.py
@@ -483,3 +483,39 @@ async def test_tool_event_message_id_for_multiple_calls():
     # ensure each event has a distinct message_id (regression: previously
     # every event pointed at the first ChatMessageTool)
     assert len({e.message_id for e in tool_events}) == 3
+
+
+async def test_tool_with_varargs_and_kwargs():
+    from inspect_ai.tool._tool_info import parse_tool_info
+
+    @tool
+    def varargs_tool():
+        async def execute(x: int, y: str = "default", *args: Any, **kwargs: Any) -> str:
+            """Tool with varargs and kwargs.
+
+            Args:
+                x (int): An integer.
+                y (str): A string.
+                *args (Any): Variable arguments.
+                **kwargs (Any): Variable keyword arguments.
+            """
+            return f"{x}_{y}"
+
+        return execute
+
+    tool_fn = varargs_tool()
+    info = parse_tool_info(tool_fn)
+    assert "args" not in info.parameters.properties
+    assert "kwargs" not in info.parameters.properties
+    assert info.parameters.required == ["x"]
+    assert "x" in info.parameters.properties
+    assert "y" in info.parameters.properties
+
+    tool_def = ToolDef(tool_fn)
+    call = make_call("varargs_tool", {"x": 42})
+    messages, _ = await execute_tools(
+        [ChatMessageAssistant(content=[], tool_calls=[call])], [tool_def]
+    )
+    assert isinstance(messages[-1], ChatMessageTool)
+    assert messages[-1].error is None
+    assert messages[-1].content == "42_default"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5080

When a tool function accepted variable arguments (`*args`) or keyword arguments (`**kwargs`), `parse_tool_info()` included `"args"` and `"kwargs"` in `info.parameters.properties` and marked them in `info.parameters.required` (because `param.default` was `param.empty`). Furthermore, `tool_params()` in `_call_tools.py` attempted to resolve type annotations for `args` and `kwargs`, raising `ValueError: No type annotation available for parameter args`.

### What is the new behavior?

`_parse_tool_info_shared()` and `tool_params()` skip parameters with kind `inspect.Parameter.VAR_POSITIONAL` and `inspect.Parameter.VAR_KEYWORD`. Functions with `*args` and `**kwargs` now produce clean tool JSON schemas containing only standard parameters and execute without parameter validation errors.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via fresh reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified schema properties and required fields with *args/**kwargs, verified execute_tools execution; all checks passed)