### PR TITLE
fix(model): compute default token usage for callable custom_outputs in MockLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- MockLLM: Compute default token usage for callable custom_outputs. (#5091)
 - Eval logs: Users can chain conditional S3 writes using the ETag returned by `write_eval_log()` and `write_eval_log_async()`.
 - Breaking (tests only) Sandboxes: `inspect_ai.util._sandbox.self_check` is now a collection of plain pytest tests. See docstring for migration instructions.
 - Eval Set: A worker running a selection now skips the tasks it was not selected to run, so a large eval set need not cost every worker its full startup memory.

--- a/src/inspect_ai/model/_providers/mockllm.py
+++ b/src/inspect_ai/model/_providers/mockllm.py
@@ -91,13 +91,11 @@ class MockLLM(ModelAPI):
             output = self.outputs(input, tools, tool_choice, config)
             if _inspect.isawaitable(output):
                 output = await output
-            model_call = ModelCall.create(request, {"content": output.completion})
-            return output, model_call
-
-        try:
-            output = next(self.outputs)
-        except StopIteration:
-            raise ValueError("custom_outputs ran out of values")
+        else:
+            try:
+                output = next(self.outputs)
+            except StopIteration:
+                raise ValueError("custom_outputs ran out of values")
 
         if not isinstance(output, ModelOutput):
             raise ValueError(

--- a/tests/model/test_mock_model_llm.py
+++ b/tests/model/test_mock_model_llm.py
@@ -100,6 +100,35 @@ async def test_mock_generate_custom_callable() -> None:
 
     response = await model.generate(input="unused input")
     assert response.completion == "response from callable"
+    assert response.usage is not None
+    assert response.usage.output_tokens == len("response from callable")
+    assert (
+        response.usage.total_tokens
+        == response.usage.input_tokens + response.usage.output_tokens
+    )
+
+
+@skip_if_trio
+async def test_mock_generate_custom_callable_explicit_usage() -> None:
+    from inspect_ai.model import ModelUsage
+
+    explicit_usage = ModelUsage(input_tokens=10, output_tokens=20, total_tokens=30)
+
+    def custom_output_generator(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        out = ModelOutput.from_content(
+            model="mockllm", content="response with explicit usage"
+        )
+        out.usage = explicit_usage
+        return out
+
+    model = get_model("mockllm/model", custom_outputs=custom_output_generator)
+    response = await model.generate(input="test")
+    assert response.usage == explicit_usage
 
 
 @skip_if_trio


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5091

In `MockLLM.generate()`, when `self.outputs` was a `Callable`, the method returned early without running the `if output.usage is None:` block. This caused callable `custom_outputs` to return `output.usage = None` unless the user explicitly constructed and attached a `ModelUsage` object in the custom function (unlike iterable/generator custom outputs and default outputs which compute input, output, and total token usage automatically).

### What is the new behavior?

`MockLLM.generate()` unifies output retrieval across callable and iterable paths so that callable custom outputs also receive default token usage calculation when `output.usage is None` (while preserving any explicit `ModelUsage` supplied by the callable).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via fresh reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified callable usage calculation and preservation of explicit ModelUsage; all checks passed)