### PR TITLE
Grok evals now hit xAI's prompt cache across turns of a sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Breaking (tests only) Sandboxes: `inspect_ai.util._sandbox.self_check` is now a collection of plain pytest tests. See docstring for migration instructions.
 - Eval Set: A worker running a selection now skips the tasks it was not selected to run, so a large eval set need not cost every worker its full startup memory.
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
+- Grok: Requests now carry xAI's conversation id header, which improves prompt cache hit rates for multi-turn samples.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.
 - Scoring: Skip Score.unscored() / NaN-at-root sentinels in aggregate() metric. (#5008)
 - Scoring: Return inf on OverflowError in perplexity_per_token() and perplexity_per_seq() metrics. (#5028)

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -587,6 +587,14 @@ Note that `service_tier` applies to standard requests only — [batch](models-ba
 
 Additional custom model args (`-M`) are forwarded to the constructor of the `AsynClient` class.
 
+### Prompt Caching
+
+xAI caches prompt prefixes automatically, but its cache is per-server and requests are otherwise load balanced across servers, so a turn can land on a server that has never seen its prefix. Inspect therefore sends xAI's [`x-grok-conv-id`](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits) header, set to the running sample's unique id, which pins all of that sample's requests to a single server. Multi-turn agents benefit the most: each turn re-sends the whole conversation so far, and that prefix is already cached on the server the previous turn landed on.
+
+Cached tokens are billed at a lower rate and are reported in the eval log as `input_tokens_cache_read`.
+
+This requires no configuration. Note that the header is not sent for [batch](models-batch.qmd) requests (which share a single long-lived client and are not multi-turn), or when the model is used outside of a running sample (where there is no conversation to pin).
+
 ## AWS Bedrock {#aws-bedrock}
 
 To use the [AWS Bedrock](https://aws.amazon.com/bedrock/) provider, install the `aioboto3` package, set your credentials, and specify a model using the `--model` option:

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+from collections.abc import Mapping
 from copy import copy
 from typing import Any, Literal, cast
 
@@ -40,7 +41,7 @@ from inspect_ai._util.content import (
 )
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.images import inline_media_data_uri
-from inspect_ai.log._samples import set_active_model_event_call
+from inspect_ai.log._samples import sample_active, set_active_model_event_call
 from inspect_ai.model._call_tools import parse_tool_call
 from inspect_ai.model._chat_message import (
     ChatMessage,
@@ -90,6 +91,12 @@ XAI_BASE_URL = "XAI_BASE_URL"
 GROK_API_KEY = "GROK_API_KEY"
 GROK_BASE_URL = "GROK_BASE_URL"
 
+# xAI's prompt cache is per-server, and requests are otherwise load balanced
+# across servers. This header pins a conversation to one server so its turns
+# hit the cache the earlier turns populated.
+# https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+GROK_CONV_ID_HEADER = "x-grok-conv-id"
+
 # xAI model-name tokens for non-generative models (image/video generation,
 # embeddings) that must never be treated as a "latest" frontier chat model
 # by is_latest().
@@ -99,6 +106,33 @@ _NON_GENERATIVE_TOKENS = (
     "embedding",
     "tts",
 )
+
+
+def _client_metadata(metadata: Any) -> tuple[tuple[str, str], ...]:
+    """Normalize a caller-supplied `metadata` model arg to the SDK's shape.
+
+    `-M metadata=...` arrives as JSON, so it may be a mapping, or pairs may be
+    lists rather than the tuples `AsyncClient` expects. A mapping must be
+    handled explicitly: iterating one yields bare keys, which would unpack into
+    silently wrong header pairs.
+    """
+    if metadata is None:
+        return ()
+    if isinstance(metadata, Mapping):
+        metadata = metadata.items()
+    return tuple((str(key), str(value)) for key, value in metadata)
+
+
+def _grok_conv_id() -> str | None:
+    """Conversation id for xAI's cache server-affinity header.
+
+    A sample is Inspect's unit of conversation: every turn of its agent loop
+    shares a growing prefix, so pinning them to one server is what makes the
+    cache hit. Outside a sample there is no conversation to key on, so the
+    header is omitted and requests are load balanced as before.
+    """
+    active = sample_active()
+    return active.sample_uuid if active is not None else None
 
 
 def _sdk_supports_xhigh_effort() -> bool:
@@ -175,6 +209,9 @@ class GrokAPI(ModelAPI):
                 ("grpc.enable_retries", 0),
                 ("grpc.service_config", "{}"),
             ]
+        # held apart from model_args so model_client() can extend rather than
+        # collide with it when adding the conversation id header
+        self.client_metadata = _client_metadata(model_args.pop("metadata", None))
         self.model_args = model_args
 
         # initialize batcher
@@ -232,11 +269,15 @@ class GrokAPI(ModelAPI):
         # is_at_least_grok_4() and the DB-miss branch of input_tokens_name()
         return "grok" not in name
 
-    def model_client(self) -> AsyncClient:
+    def model_client(self, conv_id: str | None = None) -> AsyncClient:
+        metadata = self.client_metadata
+        if conv_id is not None:
+            metadata += ((GROK_CONV_ID_HEADER, conv_id),)
         return AsyncClient(
             api_key=self.api_key,
             api_host=self.base_url,
             timeout=3600,
+            metadata=metadata or None,
             **self.model_args,
         )
 
@@ -283,6 +324,12 @@ class GrokAPI(ModelAPI):
             else grok_tool_choice,
             **grok_params,
         )
+        # batch requests share one long-lived client, so they can't carry a
+        # per-conversation header (and aren't multi-turn conversations anyway)
+        conv_id = None if self._batcher else _grok_conv_id()
+        if conv_id is not None:
+            request["metadata"] = {GROK_CONV_ID_HEADER: conv_id}
+
         if self._batcher and config.response_schema is not None:
             schema_model = json_schema_to_base_model(config.response_schema.json_schema)
             # Batch queue payloads are dict-shaped; encode full schema here so the
@@ -305,7 +352,7 @@ class GrokAPI(ModelAPI):
                 # used in the direct path below.
                 chat_response = await self._batcher.generate_for_request(request)
             else:
-                async with self.model_client() as client:
+                async with self.model_client(conv_id) as client:
                     # chat call
                     chat = client.chat.create(
                         model=self.service_model_name(),

--- a/tests/model/providers/test_grok.py
+++ b/tests/model/providers/test_grok.py
@@ -1,9 +1,10 @@
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import grpc
 import pytest
-from test_helpers.utils import skip_if_no_grok
+from test_helpers.utils import skip_if_no_grok, skip_if_trio
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
@@ -465,3 +466,233 @@ async def test_grok_stream_chunk_gated_without_on_stream(
 
     # the usage progress channel still ran
     assert observer._tokens_current == 7
+
+
+# -- Prompt cache server affinity (x-grok-conv-id) -----------------------------
+
+
+def _fake_grok_response() -> Any:
+    """A minimal successful completion the provider can map to ModelOutput."""
+    from xai_sdk.chat import Response, chat_pb2
+
+    proto = chat_pb2.GetChatCompletionResponse(
+        outputs=[
+            chat_pb2.CompletionOutput(
+                index=0,
+                finish_reason="REASON_STOP",
+                message=chat_pb2.CompletionMessage(
+                    role=chat_pb2.MessageRole.ROLE_ASSISTANT, content="hello"
+                ),
+            )
+        ]
+    )
+    proto.usage.prompt_tokens = 100
+    proto.usage.cached_prompt_text_tokens = 80
+    proto.usage.completion_tokens = 5
+    proto.usage.total_tokens = 105
+    return Response(proto, 0)
+
+
+class _StubAsyncClient:
+    """Stands in for xai_sdk.AsyncClient, recording its constructor kwargs."""
+
+    instances: list["_StubAsyncClient"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.chat = MagicMock()
+        self.chat.create.return_value = SimpleNamespace(
+            sample=AsyncMock(return_value=_fake_grok_response())
+        )
+        _StubAsyncClient.instances.append(self)
+
+    async def __aenter__(self) -> "_StubAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+def _stub_grok_client(monkeypatch: pytest.MonkeyPatch) -> list[_StubAsyncClient]:
+    import inspect_ai.model._providers.grok as grok_module
+
+    _StubAsyncClient.instances = []
+    monkeypatch.setattr(grok_module, "AsyncClient", _StubAsyncClient)
+    return _StubAsyncClient.instances
+
+
+def _stub_active_sample(
+    monkeypatch: pytest.MonkeyPatch, sample_uuid: str | None
+) -> None:
+    import inspect_ai.model._providers.grok as grok_module
+
+    active = SimpleNamespace(sample_uuid=sample_uuid) if sample_uuid else None
+    monkeypatch.setattr(grok_module, "sample_active", lambda: active)
+
+
+async def _generate_once(api: Any, config: GenerateConfig | None = None) -> Any:
+    return await api.generate(
+        input=[ChatMessageUser(content="hello")],
+        tools=[],
+        tool_choice="none",
+        config=config or GenerateConfig(),
+    )
+
+
+@skip_if_trio
+async def test_grok_conv_id_sent_for_active_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sample's uuid pins its turns to one xAI server so the cache hits."""
+    from inspect_ai.model._providers.grok import GROK_CONV_ID_HEADER, GrokAPI
+
+    clients = _stub_grok_client(monkeypatch)
+    _stub_active_sample(monkeypatch, "sample-uuid-1")
+
+    api = GrokAPI(model_name="grok-4.6", api_key="test-key")
+    _output, model_call = await _generate_once(api)
+
+    assert clients[0].kwargs["metadata"] == ((GROK_CONV_ID_HEADER, "sample-uuid-1"),)
+    # and it is visible in the logged request for debugging cache behavior
+    assert model_call.request["metadata"] == {GROK_CONV_ID_HEADER: "sample-uuid-1"}
+
+
+@skip_if_trio
+async def test_grok_conv_id_omitted_without_active_sample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside a sample there is no conversation to key on, so no header."""
+    from inspect_ai.model._providers.grok import GrokAPI
+
+    clients = _stub_grok_client(monkeypatch)
+    _stub_active_sample(monkeypatch, None)
+
+    api = GrokAPI(model_name="grok-4.6", api_key="test-key")
+    _output, model_call = await _generate_once(api)
+
+    assert clients[0].kwargs["metadata"] is None
+    assert "metadata" not in model_call.request
+
+
+@skip_if_trio
+async def test_grok_conv_id_appends_to_caller_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-supplied metadata model arg is extended, not clobbered.
+
+    -M metadata=... arrives as JSON, so pairs are lists rather than tuples.
+    """
+    from inspect_ai.model._providers.grok import GROK_CONV_ID_HEADER, GrokAPI
+
+    clients = _stub_grok_client(monkeypatch)
+    _stub_active_sample(monkeypatch, "sample-uuid-1")
+
+    api = GrokAPI(
+        model_name="grok-4.6", api_key="test-key", metadata=[["x-team", "alpha"]]
+    )
+    await _generate_once(api)
+
+    assert clients[0].kwargs["metadata"] == (
+        ("x-team", "alpha"),
+        (GROK_CONV_ID_HEADER, "sample-uuid-1"),
+    )
+
+
+@skip_if_trio
+async def test_grok_metadata_model_arg_accepts_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mapping metadata model arg yields pairs, not unpacked bare keys."""
+    from inspect_ai.model._providers.grok import GROK_CONV_ID_HEADER, GrokAPI
+
+    clients = _stub_grok_client(monkeypatch)
+    _stub_active_sample(monkeypatch, "sample-uuid-1")
+
+    api = GrokAPI(
+        model_name="grok-4.6", api_key="test-key", metadata={"x-team": "alpha"}
+    )
+    await _generate_once(api)
+
+    assert clients[0].kwargs["metadata"] == (
+        ("x-team", "alpha"),
+        (GROK_CONV_ID_HEADER, "sample-uuid-1"),
+    )
+
+
+@skip_if_trio
+async def test_grok_conv_id_omitted_for_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batch shares one long-lived client, so no per-sample header.
+
+    The batcher expands the request dict into chat.create(**request), so an
+    unexpected metadata key there would raise.
+    """
+    from inspect_ai.model._providers.grok import GrokAPI
+
+    _stub_grok_client(monkeypatch)
+    _stub_active_sample(monkeypatch, "sample-uuid-1")
+
+    api = GrokAPI(model_name="grok-4.6", api_key="test-key")
+    batcher = MagicMock()
+    batcher.generate_for_request = AsyncMock(return_value=_fake_grok_response())
+    api._batcher = batcher
+
+    _output, model_call = await _generate_once(api)
+
+    assert "metadata" not in batcher.generate_for_request.await_args.args[0]
+    assert "metadata" not in model_call.request
+
+
+@skip_if_no_grok
+def test_grok_prompt_cache_across_turns_live() -> None:
+    """The conv id header is accepted and a second turn reads from the cache.
+
+    Guards two things against the real API: that attaching the header to the
+    gRPC call doesn't break requests, and that cache reads are reported. It
+    does not isolate the header's routing effect — xAI often keeps short
+    sequential conversations on one server anyway, so turn 2 tends to hit
+    either way. The header's measurable benefit shows up under concurrency.
+    """
+    from inspect_ai.event import ModelEvent
+    from inspect_ai.model._providers.grok import GROK_CONV_ID_HEADER
+    from inspect_ai.solver import Generate, TaskState, generate, solver, system_message
+
+    @solver
+    def second_turn():
+        async def solve(state: TaskState, _generate: Generate) -> TaskState:
+            state.messages.append(ChatMessageUser(content="Now reply with 'bye'."))
+            return await _generate(state)
+
+        return solve
+
+    padding = "The quick brown fox jumps over the lazy dog. " * 800
+    model = "grok/grok-4-1-fast-non-reasoning"
+    log = eval(
+        Task(
+            dataset=[Sample(input="Reply with 'hi'.")],
+            solver=[system_message(padding), generate(), second_turn()],
+        ),
+        model=model,
+        max_tokens=16,
+    )[0]
+
+    assert log.status == "success"
+    assert log.samples is not None
+    model_events = [e for e in log.samples[0].events if isinstance(e, ModelEvent)]
+    assert len(model_events) == 2
+
+    # both turns went out under the one sample's conv id
+    conv_ids = set()
+    for event in model_events:
+        assert event.call is not None
+        metadata = cast(dict[str, str], event.call.request["metadata"])
+        conv_ids.add(metadata[GROK_CONV_ID_HEADER])
+    assert len(conv_ids) == 1
+    assert conv_ids.pop() == log.samples[0].uuid
+
+    # the first turn's prompt is a prefix of the second turn's
+    second = model_events[1].output.usage
+    assert second is not None
+    assert second.input_tokens_cache_read is not None
+    assert second.input_tokens_cache_read > 0


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

xAI caches prompt prefixes automatically, but the cache is per-server and requests are otherwise load balanced across servers. A turn can therefore land on a server that has never seen its prefix, and pay full price for tokens it already paid for on the previous turn. xAI's documented remedy is the [`x-grok-conv-id`](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits) header, which pins requests carrying the same id to one server. Inspect was not sending it, so every Grok eval was leaving cache hits on the table — most visibly for multi-turn agents, where each turn re-sends the entire conversation so far.

### What is the new behavior?

Grok requests now carry `x-grok-conv-id`, set to the running sample's uuid, so all of a sample's turns pin to a single server. This needs no configuration and there is no new model arg.

Two cases deliberately do not send it:

- **Batch.** The batcher shares one long-lived client, so it cannot carry a per-sample header, and batch requests are not multi-turn conversations. Its request dict is also expanded into `chat.create(**request)`, where an unexpected `metadata` key would raise — so the id is kept out of the logged request in that path too.
- **Outside a sample.** A plain `get_model("grok/...")` script has no conversation for Inspect to key on. Inventing a process-wide id there would pin all traffic to one backend, so the header is simply omitted and requests are load balanced as before.

The resolved id is recorded in the logged model call, so cache behavior can be checked from the eval log. Cache reads were already surfaced as `input_tokens_cache_read`; this change is what makes them non-trivial.

One incidental fix: a caller-supplied `metadata` model arg previously went straight through to `AsyncClient`. It is now merged with the conv id rather than colliding with it, and the mapping form (`-M metadata='{"x-team":"alpha"}'`) is handled explicitly — iterating a mapping yields bare keys, which would have unpacked into silently wrong header pairs.

**Measured effect.** Three alternating pairs of runs, 40 samples x 8 turns, each sample given a unique ~5k-token prefix so a hit on turn 2+ can only come from that same sample's earlier turn (i.e. it isolates server affinity, not prefix sharing across samples):

| Arm | turns-2+ miss rate |
| --- | --- |
| without header | 6.86%, 7.22%, 5.48% (mean 6.52%) |
| with header | 4.75%, 4.07%, 3.01% (mean 3.94%) |

The arms do not overlap — roughly 40% fewer cache misses on turns 2+. At concurrency 1 there is no measurable difference: xAI already keeps a short sequential conversation on one server, so the header matters when the load balancer actually has a choice. The CHANGELOG entry is deliberately conservative about magnitude.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Behavior is additive and requires no user action.

### Other information:

The xAI SDK takes `metadata` at client construction rather than per request, so a per-conversation id needs a per-conversation client. That is already how the provider works — `model_client()` builds a fresh `AsyncClient` per generate call — so the id rides along at no extra cost.

Tests added to `tests/model/providers/test_grok.py`: header sent for an active sample, omitted without one, merged with a caller-supplied `metadata` (list-of-pairs and mapping forms), and omitted for batch. Plus one `--runapi` test that runs a real two-turn eval and asserts both turns carried the same conv id, that it equals the sample's uuid, and that turn 2 reports a cache read.

Note on that live test: its first version only asserted a cache read on turn 2, which would have passed with the feature removed (turn 2 caches anyway at concurrency 1). It was strengthened to assert the header actually reaches the wire. It still does not isolate the routing effect — that is what the A/B above is for.

Unrelated observation from those runs, not investigated and not addressed here: successful Grok evals produce a small number of extra `ModelEvent`s with `completed=None`, an empty completion, and no usage (roughly 16-24 per 320 calls). They appear in the no-header arm too, so they look pre-existing.

`make check` equivalent (`ruff format`, `ruff check`, `mypy --exclude tests/test_package src tests`) is clean. `pytest tests/model/providers/test_grok.py` — 20 passed, and 23 passed with `--runapi` (includes the three live Grok tests). Per repo convention I kept the test run scoped to the files touched rather than sweeping the suite.

### Agent review
- Reviewer: Claude Opus 5, 1 self-review pass **in the authoring context** — not a fresh context and not a different model. No independent review pass was run.
- Findings: 2 — both fixed. (1) A mapping-valued `metadata` model arg would unpack bare keys into wrong header pairs; added explicit `Mapping` handling plus a test. (2) The live API test did not actually exercise the feature; strengthened to assert the conv id reaches the request and matches the sample uuid.
- Given the limited review, an independent fresh-context pass before merge would be reasonable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
