### PR TITLE
Deflake test_config_send_delay_vs_tick_precision[trio]: raise 50ms wall-clock ceiling that stalls exceed on loaded CI runners

### DIFF
--- a/tests/model/providers/util/test_batch.py
+++ b/tests/model/providers/util/test_batch.py
@@ -1011,8 +1011,13 @@ class TestBatcher:
 
             assert len(results) == 3
 
-            # Should timeout properly despite close timing values
-            assert 0.005 < elapsed < 0.05  # Should be close to send_delay timing
+            # Should timeout properly despite close timing values. The lower
+            # bound is the real check (the batch is under `size`, so it can only
+            # be sent once `send_delay` elapses); the upper bound is deliberately
+            # generous because the nominal path is ~31ms under trio and a loaded
+            # CI runner can stretch each 9ms tick several-fold. It still catches
+            # a regression to the 15s DEFAULT_SEND_DELAY/DEFAULT_BATCH_TICK.
+            assert 0.005 < elapsed < 1.0
 
         await self._run_with_task_group(test_logic)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#355

`TestBatcher::test_config_send_delay_vs_tick_precision[trio]` flakes on loaded CI runners: it asserts a 50ms wall-clock ceiling on a path whose nominal cost under the trio backend is ~31ms (only ~1.6x headroom). A scheduling stall on an xdist runner stretched the four `anyio.sleep(0.009)` ticks and produced `AssertionError: assert 0.1257... < 0.05`. The captured stdout in the failing run shows the batcher performed exactly the expected 4 worker iterations — this is scheduler stall, not a product bug.

### What is the new behavior?

Test-only change: the upper bound is raised from 0.05s to 1.0s, with a comment explaining the rationale. The deterministic lower bound (`0.005 < elapsed`) is kept unchanged — it is the half of the assertion that actually verifies `send_delay` is honoured (the batch is below the minimum `size`, so it can only be sent once `send_delay` elapses). The 1.0s ceiling is ~32x the measured nominal, beyond any plausible runner stall, while remaining 15x below a single `DEFAULT_BATCH_TICK`/`DEFAULT_SEND_DELAY` (15s), so a regression to the defaults or a hang still fails the test. This follows the precedent of fe6556462, which deflaked another test in this file the same way.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Test-only change, so no CHANGELOG entry.

Verification run locally:
- `pytest tests/model/providers/util/test_batch.py::TestBatcher::test_config_send_delay_vs_tick_precision -v --runtrio` — trio variant passed
- same test without `--runtrio` — asyncio variant passed
- `ruff check`, `ruff format --check`, and `mypy` on the changed file — all clean

### Agent review
- Reviewer: none — no separate review pass was run. The change is a single test assertion bound raise implementing the fix already specified verbatim in the triage issue (meridianlabs-ai/inspect_ai#355), which contains the timing analysis and standalone reproduction.
- Agent involvement: this PR was authored by Claude Fable 5 (Claude Code) triggered by the `auto` label on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)