### PR TITLE
Retry transient mid-stream errors on OpenAI chat-completions streaming instead of failing the sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
 - Grok: Requests now carry xAI's conversation id header, which improves prompt cache hit rates for multi-turn samples.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.
+- OpenAI: Transient server errors and rate limits delivered mid-stream on chat-completions streaming are now retried instead of failing the sample.
 - Scoring: Skip Score.unscored() / NaN-at-root sentinels in aggregate() metric. (#5008)
 - Scoring: Return inf on OverflowError in perplexity_per_token() and perplexity_per_seq() metrics. (#5028)
 - Analysis: Ensure ColumnError.path is a string rather than a JSONPath object on record import errors. (#5006)

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from openai import (
     APIConnectionError,
+    APIError,
     APIStatusError,
     APITimeoutError,
     AsyncStream,
@@ -1280,6 +1281,16 @@ def openai_classify_retry(ex: BaseException) -> "RetryDecision | None":
         return None
     if isinstance(ex, APIConnectionError | APITimeoutError):
         return RetryDecision.transient()
+    if isinstance(ex, APIError):
+        # A failure delivered mid-stream (after HTTP 200) is raised by the SDK
+        # as a bare APIError with no status code, carrying only the error
+        # body's `code`/`type`. Classify from those the same way the
+        # OpenAIResponseError branch above does; anything else re-raises.
+        if "rate_limit_exceeded" in (ex.code, ex.type):
+            return RetryDecision.rate_limit()
+        if "server_error" in (ex.code, ex.type):
+            return RetryDecision.transient()
+        return None
     return None
 
 

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -168,6 +168,87 @@ def test_openai_classify_rate_limit_error_subclass() -> None:
     assert decision.retry_after == 5.0
 
 
+def test_openai_classify_mid_stream_server_error_as_transient() -> None:
+    """A transient failure delivered mid-stream (after HTTP 200) is a bare APIError.
+
+    The chat-completions stream iterator raises openai.APIError (no status
+    code) built from the SSE error body — it must classify from code/type
+    like the equivalent non-streaming 5xx does.
+    """
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIError(
+        message="The server had an error while processing your request.",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={
+            "message": "The server had an error while processing your request.",
+            "type": "server_error",
+            "code": None,
+        },
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+    # some backends signal via `code` rather than `type`
+    ex2 = APIError(
+        message="server error",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={"message": "server error", "type": "error", "code": "server_error"},
+    )
+    decision2 = openai_classify_retry(ex2)
+    assert decision2 is not None
+    assert decision2.kind == "transient"
+
+
+def test_openai_classify_mid_stream_rate_limit_as_rate_limit() -> None:
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIError(
+        message="rate limited",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={
+            "message": "rate limited",
+            "type": "requests",
+            "code": "rate_limit_exceeded",
+        },
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "rate_limit"
+
+
+def test_openai_classify_mid_stream_permanent_error_does_not_retry() -> None:
+    """A permanent bare APIError (non-transient code/type) must re-raise, not retry."""
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIError(
+        message="invalid request",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={
+            "message": "invalid request",
+            "type": "invalid_request_error",
+            "code": "invalid_api_key",
+        },
+    )
+    assert openai_classify_retry(ex) is None
+
+    # non-dict body leaves code/type as None — also not retryable
+    ex_no_body = APIError(
+        message="opaque failure",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body=None,
+    )
+    assert openai_classify_retry(ex_no_body) is None
+
+
 def test_openai_provider_quota_exceeded_does_not_retry() -> None:
     """OpenAI's monthly-quota error (RateLimitError with specific message) shouldn't retry."""
     from openai import RateLimitError


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#365.

On OpenAI chat-completions (and openai_compatible) streaming, a transient backend failure (e.g. `server_error` / overloaded) delivered mid-stream fails the sample instead of retrying — and under fail-on-error can cancel sibling samples. The same failure on the non-streaming path is retried: it arrives as an `APIStatusError` with a 5xx and `openai_classify_retry` classifies it transient via `is_retryable_http_status`. Mid-stream, HTTP 200 has already been returned, so the openai SDK raises a bare `openai.APIError` with no status code from the stream iterator (`openai/_streaming.py` raises `APIError(message=..., request=..., body=data["error"])` when an SSE payload carries an `error` key). That exception matched none of the classifier's branches, so it fell through to `return None` and the request was not retried. Streaming is auto-enabled whenever a caller passes `on_stream`, so a display-only progress consumer could turn a normally-retried condition into a hard sample failure. (The Responses API path was not affected: its mid-stream errors surface as `OpenAIResponseError`, already classified.)

### What is the new behavior?

`openai_classify_retry` gains a bare-`APIError` branch (checked last, after all the `APIError` subclasses it previously handled) that classifies from the error body's `code`/`type` — verified populated by `openai.APIError.__init__` from the SSE error body: `rate_limit_exceeded` → rate-limit retry, `server_error` → transient retry, anything else still returns `None` (re-raises), so genuinely permanent bare errors (e.g. `invalid_request_error`/`invalid_api_key`) are not blanket-retried. This mirrors the existing `OpenAIResponseError` branch for the Responses API.

Synthetic tests added to `tests/model/test_should_retry_classification.py` (no live API needed): mid-stream `server_error` signaled via `type` or via `code` → transient; `rate_limit_exceeded` → rate_limit; permanent bare `APIError` and non-dict body → not retried. Exception construction matches the SDK's mid-stream raise site exactly (openai 3.5.0).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verification: `pytest tests/model/test_should_retry_classification.py` — 43 passed; `ruff format` / `ruff check` clean; `mypy` clean on both changed files.

### Agent review
- Reviewer: Claude Fable 5 subagent (fresh context, same model as author), 1 pass over the diff
- Findings: 0 — the pass verified exception-hierarchy ordering (all retryable `APIError` subclasses are matched before the new bare branch), that `.code`/`.type` are unconditionally assigned by `APIError.__init__` in openai 3.5.0, that no permanent-error path becomes retryable, and that the tests construct exceptions exactly as `openai/_streaming.py` raises them mid-stream

Generated with [Claude Code](https://claude.ai/code)