### PR TITLE
Retry transient mid-stream errors on SageMaker, Anthropic, and OpenAI-compatible streaming instead of failing the sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
 - Grok: Requests now carry xAI's conversation id header, which improves prompt cache hit rates for multi-turn samples.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.
-- Model streaming: Transient errors delivered mid-stream (after HTTP 200) — SageMaker stream errors, Anthropic rate-limit/timeout error events, OpenAI-compatible server error vocabularies, and streams that end with no data — are now retried instead of failing the sample.
+- Model streaming: Transient errors delivered mid-stream after HTTP 200 (provider stream error events, and streams that end with no data) are now retried instead of failing the sample.
 - Scoring: Skip Score.unscored() / NaN-at-root sentinels in aggregate() metric. (#5008)
 - Scoring: Return inf on OverflowError in perplexity_per_token() and perplexity_per_seq() metrics. (#5028)
 - Analysis: Ensure ColumnError.path is a string rather than a JSONPath object on record import errors. (#5006)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Eval Set: A selection document's operational overrides gain a dataset `limit` and `max_sandboxes`.
 - Grok: Requests now carry xAI's conversation id header, which improves prompt cache hit rates for multi-turn samples.
 - OpenAI: Function call outputs without a `call_id` (optional as of openai 3.5.0) no longer error in the agent bridge or token-count padding.
+- Model streaming: Transient errors delivered mid-stream (after HTTP 200) — SageMaker stream errors, Anthropic rate-limit/timeout error events, OpenAI-compatible server error vocabularies, and streams that end with no data — are now retried instead of failing the sample.
 - Scoring: Skip Score.unscored() / NaN-at-root sentinels in aggregate() metric. (#5008)
 - Scoring: Return inf on OverflowError in perplexity_per_token() and perplexity_per_seq() metrics. (#5028)
 - Analysis: Ensure ColumnError.path is a string rather than a JSONPath object on record import errors. (#5006)

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -123,7 +123,12 @@ from ._generate_config import (
 from ._model_call import ModelCall, as_error_response
 from ._model_data.model_data import ModelCost
 from ._model_output import ModelFallback, ModelOutput, ModelUsage
-from ._stream import ModelStreamObserver, StreamHandler, model_stream_observer
+from ._stream import (
+    ModelStreamObserver,
+    NoStreamDataError,
+    StreamHandler,
+    model_stream_observer,
+)
 from ._throughput import record_generate, throughput_view
 from ._tokens import count_media_tokens, count_text_tokens, count_tokens
 
@@ -1727,6 +1732,13 @@ class Model:
             # count toward adaptive scale-up, but the controller doesn't
             # scale down for what's essentially infra noise.
             if isinstance(ex, AttemptTimeoutError):
+                report_http_retry(model=model)
+                return True
+
+            # a 200 stream that ended with zero chunks (see NoStreamDataError)
+            # is retried for any provider: there is no error payload to
+            # classify from, and a retry against a healthy server succeeds
+            if isinstance(ex, NoStreamDataError):
                 report_http_retry(model=model)
                 return True
 

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from openai import (
     APIConnectionError,
+    APIError,
     APIStatusError,
     APITimeoutError,
     AsyncStream,
@@ -104,6 +105,7 @@ from ._model_output import (
     collect_stop_details,
 )
 from ._stream import (
+    NoStreamDataError,
     StreamReasoningEvent,
     StreamTextEvent,
     StreamToolCallEvent,
@@ -975,8 +977,11 @@ async def openai_chat_completion_stream_final(
         await _report_chat_completion_chunk(chunk, tool_calls)
     if not saw_chunk:
         # get_final_completion() would fail on a bare assert; raise a
-        # descriptive error instead (misbehaving server: 200 with empty body)
-        raise RuntimeError("Streaming response ended without delivering any chunks.")
+        # descriptive, retryable error instead (misbehaving server: 200 with
+        # empty body)
+        raise NoStreamDataError(
+            "Streaming response ended without delivering any chunks."
+        )
     try:
         return state.get_final_completion()
     except LengthFinishReasonError as ex:
@@ -1280,6 +1285,49 @@ def openai_classify_retry(ex: BaseException) -> "RetryDecision | None":
         return None
     if isinstance(ex, APIConnectionError | APITimeoutError):
         return RetryDecision.transient()
+    if isinstance(ex, APIError):
+        # A failure delivered mid-stream (after HTTP 200) is raised by the
+        # SDK as a bare APIError with no status code, carrying only the
+        # error body's `code`/`type`. OpenAI itself signals with
+        # `server_error` / `rate_limit_exceeded`; OpenAI-compatible servers
+        # use their own vocabulary — often a numeric HTTP status in `code`
+        # (vLLM/SGLang: {"type": "InternalServerError", "code": 500},
+        # OpenRouter: {"code": 502}), which classifies through the standard
+        # status rules. Anything unrecognized stays unretried.
+        code_status = _http_status_from_error_code(ex.code)
+        if code_status is not None:
+            if code_status == 429:
+                return RetryDecision.rate_limit()
+            if is_retryable_http_status(code_status):
+                return RetryDecision.transient()
+            return None
+        # normalize code/type spellings (rate_limit_error/RateLimitError/...)
+        names = {
+            v.lower().replace("_", "") for v in (ex.code, ex.type) if isinstance(v, str)
+        }
+        if names & {"ratelimitexceeded", "ratelimiterror"}:
+            return RetryDecision.rate_limit()
+        if names & {"servererror", "internalservererror", "internalerror"}:
+            return RetryDecision.transient()
+        return None
+    return None
+
+
+def _http_status_from_error_code(code: object) -> int | None:
+    """Coerce an error body `code` to an HTTP status when it is one.
+
+    OpenAI-compatible servers often put a numeric HTTP status in `code`
+    (as an int or a digit string). The SDK annotates `APIError.code` as
+    `Optional[str]` but passes body values through unconverted, so an int
+    arrives as an int at runtime.
+    """
+    if isinstance(code, bool):
+        return None
+    if isinstance(code, int):
+        return code if 100 <= code <= 599 else None
+    if isinstance(code, str) and code.isdigit():
+        status = int(code)
+        return status if 100 <= status <= 599 else None
     return None
 
 

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -1321,11 +1321,7 @@ def _http_status_from_error_code(code: object) -> int | None:
     `Optional[str]` but passes body values through unconverted, so an int
     arrives as an int at runtime.
     """
-    if isinstance(code, bool):
-        return None
-    if isinstance(code, int):
-        return code if 100 <= code <= 599 else None
-    if isinstance(code, str) and code.isdigit():
+    if isinstance(code, int) or (isinstance(code, str) and code.isdecimal()):
         status = int(code)
         return status if 100 <= status <= 599 else None
     return None

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1407,15 +1407,20 @@ class AnthropicAPI(ModelAPI):
             # the SSE error body, not an HTTP status), so the status-based
             # checks below can't classify it — classify from the body's
             # error type: these are the in-band analogues of 429/529/500/408.
-            if isinstance(ex.body, dict):
+            # Scoped to status 200 so that a real HTTP error status (e.g. a
+            # proxy's 4xx wrapping an anthropic-format body) keeps failing
+            # fast via the status rules.
+            if ex.status_code == 200 and isinstance(ex.body, dict):
                 error_type = _error_type_from_body(ex.body)
                 if error_type == "rate_limit_error":
                     return RetryDecision.rate_limit(retry_after=retry_after)
                 if error_type in ("overloaded_error", "api_error", "timeout_error"):
                     return RetryDecision.transient(retry_after=retry_after)
-                body_str = str(ex.body).lower()
+            if isinstance(ex.body, dict | str):
                 # message-based fallback for error bodies without a
-                # recognized type
+                # recognized type (a mid-stream error event whose data fails
+                # JSON parsing attaches the raw SSE string as the body)
+                body_str = str(ex.body).lower()
                 if "overloaded" in body_str or "internal server error" in body_str:
                     return RetryDecision.transient(retry_after=retry_after)
                 # TCP interruptions can truncate large request bodies in transit,
@@ -4102,17 +4107,14 @@ def _warn_refusal_without_fallback(
 def _error_type_from_body(body: dict[str, Any]) -> str | None:
     """Extract the API error type from an error response body.
 
-    Handles both the full error envelope the SDK attaches as `ex.body`
-    ({"type": "error", "error": {"type": "rate_limit_error", ...}}) and a
-    bare inner error object ({"type": "overloaded_error", ...}).
+    The SDK attaches the full error envelope as `ex.body` — for both
+    mid-stream SSE error events and non-streaming HTTP errors —
+    ({"type": "error", "error": {"type": "rate_limit_error", ...}}).
     """
     error = body.get("error")
     if isinstance(error, dict):
         error_type = error.get("type")
         return error_type if isinstance(error_type, str) else None
-    error_type = body.get("type")
-    if isinstance(error_type, str) and error_type != "error":
-        return error_type
     return None
 
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1402,10 +1402,20 @@ class AnthropicAPI(ModelAPI):
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, APIStatusError):
             retry_after = parse_retry_after_from_exception(ex)
-            # when streaming, anthropic does not set status_code == 529
-            # for overloaded or internal server errors so we check for them explicitly
+            # An error event delivered mid-stream surfaces as an
+            # APIStatusError with status_code == 200 (the SDK builds it from
+            # the SSE error body, not an HTTP status), so the status-based
+            # checks below can't classify it — classify from the body's
+            # error type: these are the in-band analogues of 429/529/500/408.
             if isinstance(ex.body, dict):
+                error_type = _error_type_from_body(ex.body)
+                if error_type == "rate_limit_error":
+                    return RetryDecision.rate_limit(retry_after=retry_after)
+                if error_type in ("overloaded_error", "api_error", "timeout_error"):
+                    return RetryDecision.transient(retry_after=retry_after)
                 body_str = str(ex.body).lower()
+                # message-based fallback for error bodies without a
+                # recognized type
                 if "overloaded" in body_str or "internal server error" in body_str:
                     return RetryDecision.transient(retry_after=retry_after)
                 # TCP interruptions can truncate large request bodies in transit,
@@ -4087,6 +4097,23 @@ def _warn_refusal_without_fallback(
         "requests automatically. Learn more at "
         "https://inspect.aisi.org.uk/fallbacks.html.",
     )
+
+
+def _error_type_from_body(body: dict[str, Any]) -> str | None:
+    """Extract the API error type from an error response body.
+
+    Handles both the full error envelope the SDK attaches as `ex.body`
+    ({"type": "error", "error": {"type": "rate_limit_error", ...}}) and a
+    bare inner error object ({"type": "overloaded_error", ...}).
+    """
+    error = body.get("error")
+    if isinstance(error, dict):
+        error_type = error.get("type")
+        return error_type if isinstance(error_type, str) else None
+    error_type = body.get("type")
+    if isinstance(error_type, str) and error_type != "error":
+        return error_type
+    return None
 
 
 def _strip_reasoning(message: ChatMessageAssistant) -> ChatMessageAssistant:

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -120,6 +120,7 @@ from inspect_ai.model._reasoning import (
 )
 from inspect_ai.model._retry import batch_admin_retry_config
 from inspect_ai.model._stream import (
+    NoStreamDataError,
     StreamReasoningEvent,
     StreamTextEvent,
     StreamToolCallEvent,
@@ -647,7 +648,7 @@ class GoogleGenAIAPI(ModelAPI):
                                 await _report_stream_part_delta(part)
 
         if last_chunk is None:
-            raise RuntimeError(
+            raise NoStreamDataError(
                 f"No response chunks received from streaming API for model {model}"
             )
 

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -59,6 +59,7 @@ from inspect_ai.model._providers.util.util import (
 )
 from inspect_ai.model._retry import batch_admin_retry_config
 from inspect_ai.model._stream import (
+    NoStreamDataError,
     StreamReasoningEvent,
     StreamTextEvent,
     StreamToolCallEvent,
@@ -376,7 +377,7 @@ class GrokAPI(ModelAPI):
                         async for streamed_response, chunk in chat.stream():
                             await _report_grok_stream_chunk(chunk)
                         if streamed_response is None:
-                            raise RuntimeError(
+                            raise NoStreamDataError(
                                 "No response chunks received from streaming "
                                 f"API for model {self.service_model_name()}"
                             )

--- a/src/inspect_ai/model/_providers/sagemaker.py
+++ b/src/inspect_ai/model/_providers/sagemaker.py
@@ -68,12 +68,15 @@ SAGEMAKER_RETRY_ERROR_CODES = {
     # 507, # Insufficient storage
 }
 
-# ModelStreamError ErrorCodes documented as transient by AWS (the full
-# documented set — both are infrastructure/timeout conditions whose
-# non-streaming analogues are retried above; unknown codes don't retry).
+# In-band stream errors (delivered after HTTP 200). Both are transient:
+# InternalStreamFailure by definition (AWS: "unknown error ... Try your
+# request again") and ModelStreamError because its documented ErrorCodes —
+# ModelInvocationTimeExceeded and StreamBroken, the full documented set —
+# are infrastructure/timeout conditions whose non-streaming analogues
+# (container timeout, connection reset) are retried above.
 SAGEMAKER_RETRY_STREAM_ERROR_CODES = {
-    "ModelInvocationTimeExceeded",  # model didn't finish within the allowed time
-    "StreamBroken",  # TCP connection between client and model reset or closed
+    "ModelStreamError",
+    "InternalStreamFailure",
 }
 
 # botocore transport-layer exceptions raised before a response is received —
@@ -99,23 +102,16 @@ SAGEMAKER_RETRY_TRANSPORT_ERRORS = (
 
 
 class SageMakerStreamError(RuntimeError):
-    """In-band ModelStreamError event from a streaming response (after HTTP 200).
+    """In-band ModelStreamError/InternalStreamFailure from a response stream.
 
-    Preserves the event's structured `ErrorCode` so `should_retry` can
-    classify it (folding it into the message string would hide it from the
-    retry classifier and fail the sample on transient conditions).
-    """
-
-    def __init__(self, message: str, error_code: str | None = None) -> None:
-        super().__init__(message)
-        self.error_code = error_code
-
-
-class SageMakerInternalStreamFailure(RuntimeError):
-    """In-band InternalStreamFailure event from a streaming response.
-
-    AWS documents this as an unknown backend failure with explicit guidance
-    to "Try your request again", so `should_retry` treats it as transient.
+    Both event shapes are marked `exception` in the AWS service model, so
+    botocore normally surfaces them as `EventStreamError` (a `ClientError`
+    with the exception type as `Error.Code`) raised from the stream
+    iterator — `should_retry` classifies that path directly. This typed
+    exception backstops the defensive in-band checks in the stream loop so
+    that if either shape ever does arrive as a yielded event, it still
+    classifies as transient rather than failing the sample (see
+    `SAGEMAKER_RETRY_STREAM_ERROR_CODES` for why both are transient).
     """
 
 
@@ -209,21 +205,18 @@ class SagemakerAPI(ModelAPI):
                 and status_code in SAGEMAKER_RETRY_ERROR_CODES
             ):
                 return RetryDecision.transient()
+            # In-band stream errors (delivered after HTTP 200) surface as
+            # EventStreamError — a ClientError raised from the response
+            # stream iterator with the exception type as the code
+            if error_code in SAGEMAKER_RETRY_STREAM_ERROR_CODES:
+                return RetryDecision.transient()
         # Transport-layer failures (connection could not be established/was
         # dropped/timed out) are transient — the request never reached the
         # model, so a redial typically succeeds.
         elif isinstance(ex, SAGEMAKER_RETRY_TRANSPORT_ERRORS):
             return RetryDecision.transient()
-        # In-band stream errors (delivered after HTTP 200): an
-        # InternalStreamFailure is documented by AWS as transient; a
-        # ModelStreamError is classified by its ErrorCode (both documented
-        # codes are transient — see SAGEMAKER_RETRY_STREAM_ERROR_CODES).
-        elif isinstance(ex, SageMakerInternalStreamFailure):
-            return RetryDecision.transient()
-        elif (
-            isinstance(ex, SageMakerStreamError)
-            and ex.error_code in SAGEMAKER_RETRY_STREAM_ERROR_CODES
-        ):
+        # backstop for in-band stream error events (see the class docstring)
+        elif isinstance(ex, SageMakerStreamError):
             return RetryDecision.transient()
         return RetryDecision.no()
 
@@ -723,15 +716,18 @@ class SagemakerAPI(ModelAPI):
         report_model_stream_start()
 
         async for event in event_stream:
-            # Check for error events first
+            # Defensive checks for in-band error events. botocore normally
+            # raises these two shapes as EventStreamError from the iterator
+            # (classified in should_retry) rather than yielding them, but if
+            # one arrives as an event it must raise something the retry
+            # classifier recognizes.
             if "ModelStreamError" in event:
                 error_info = event["ModelStreamError"]
-                error_code = error_info.get("ErrorCode")
+                error_code = error_info.get("ErrorCode", "Unknown")
                 error_message = error_info.get("Message", "Model stream error occurred")
                 logger.error(f"ModelStreamError: {error_code} - {error_message}")
                 raise SageMakerStreamError(
-                    f"ModelStreamError [{error_code or 'Unknown'}]: {error_message}",
-                    error_code=error_code,
+                    f"ModelStreamError [{error_code}]: {error_message}"
                 )
 
             if "InternalStreamFailure" in event:
@@ -739,9 +735,7 @@ class SagemakerAPI(ModelAPI):
                     "Message", "Internal stream failure occurred"
                 )
                 logger.error(f"InternalStreamFailure: {error_message}")
-                raise SageMakerInternalStreamFailure(
-                    f"InternalStreamFailure: {error_message}"
-                )
+                raise SageMakerStreamError(f"InternalStreamFailure: {error_message}")
 
             # Process payload chunks
             if "PayloadPart" in event:

--- a/src/inspect_ai/model/_providers/sagemaker.py
+++ b/src/inspect_ai/model/_providers/sagemaker.py
@@ -37,6 +37,7 @@ from .._model_call import ModelCall
 from .._model_output import ModelOutput
 from .._reasoning import clamp_reasoning_effort_to_low_medium_high
 from .._stream import (
+    NoStreamDataError,
     StreamContentEvent,
     StreamReasoningEvent,
     StreamTextEvent,
@@ -67,6 +68,14 @@ SAGEMAKER_RETRY_ERROR_CODES = {
     # 507, # Insufficient storage
 }
 
+# ModelStreamError ErrorCodes documented as transient by AWS (the full
+# documented set — both are infrastructure/timeout conditions whose
+# non-streaming analogues are retried above; unknown codes don't retry).
+SAGEMAKER_RETRY_STREAM_ERROR_CODES = {
+    "ModelInvocationTimeExceeded",  # model didn't finish within the allowed time
+    "StreamBroken",  # TCP connection between client and model reset or closed
+}
+
 # botocore transport-layer exceptions raised before a response is received —
 # the connection could not be established, was dropped mid-flight, or timed
 # out. These are transient (a redialed request typically succeeds) and are not
@@ -87,6 +96,27 @@ SAGEMAKER_RETRY_TRANSPORT_ERRORS = (
 # container only exposes chat/completion inference fields. Users of
 # target_perplexity() must provide num_target_tokens in sample metadata
 # rather than relying on auto-tokenization.
+
+
+class SageMakerStreamError(RuntimeError):
+    """In-band ModelStreamError event from a streaming response (after HTTP 200).
+
+    Preserves the event's structured `ErrorCode` so `should_retry` can
+    classify it (folding it into the message string would hide it from the
+    retry classifier and fail the sample on transient conditions).
+    """
+
+    def __init__(self, message: str, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class SageMakerInternalStreamFailure(RuntimeError):
+    """In-band InternalStreamFailure event from a streaming response.
+
+    AWS documents this as an unknown backend failure with explicit guidance
+    to "Try your request again", so `should_retry` treats it as transient.
+    """
 
 
 class SagemakerAPI(ModelAPI):
@@ -183,6 +213,17 @@ class SagemakerAPI(ModelAPI):
         # dropped/timed out) are transient — the request never reached the
         # model, so a redial typically succeeds.
         elif isinstance(ex, SAGEMAKER_RETRY_TRANSPORT_ERRORS):
+            return RetryDecision.transient()
+        # In-band stream errors (delivered after HTTP 200): an
+        # InternalStreamFailure is documented by AWS as transient; a
+        # ModelStreamError is classified by its ErrorCode (both documented
+        # codes are transient — see SAGEMAKER_RETRY_STREAM_ERROR_CODES).
+        elif isinstance(ex, SageMakerInternalStreamFailure):
+            return RetryDecision.transient()
+        elif (
+            isinstance(ex, SageMakerStreamError)
+            and ex.error_code in SAGEMAKER_RETRY_STREAM_ERROR_CODES
+        ):
             return RetryDecision.transient()
         return RetryDecision.no()
 
@@ -685,17 +726,22 @@ class SagemakerAPI(ModelAPI):
             # Check for error events first
             if "ModelStreamError" in event:
                 error_info = event["ModelStreamError"]
-                error_code = error_info.get("ErrorCode", "Unknown")
+                error_code = error_info.get("ErrorCode")
                 error_message = error_info.get("Message", "Model stream error occurred")
                 logger.error(f"ModelStreamError: {error_code} - {error_message}")
-                raise RuntimeError(f"ModelStreamError [{error_code}]: {error_message}")
+                raise SageMakerStreamError(
+                    f"ModelStreamError [{error_code or 'Unknown'}]: {error_message}",
+                    error_code=error_code,
+                )
 
             if "InternalStreamFailure" in event:
                 error_message = event["InternalStreamFailure"].get(
                     "Message", "Internal stream failure occurred"
                 )
                 logger.error(f"InternalStreamFailure: {error_message}")
-                raise RuntimeError(f"InternalStreamFailure: {error_message}")
+                raise SageMakerInternalStreamFailure(
+                    f"InternalStreamFailure: {error_message}"
+                )
 
             # Process payload chunks
             if "PayloadPart" in event:
@@ -716,10 +762,9 @@ class SagemakerAPI(ModelAPI):
         )
 
         if n_chunks == 0:
-            # No data chunks at all — surface as an error so the request can be
-            # retried / counted as a failure rather than silently scored as an
-            # empty (wrong) completion.
-            raise RuntimeError(
+            # No data chunks at all — surface as a retryable error rather than
+            # silently scoring an empty (wrong) completion.
+            raise NoStreamDataError(
                 "No data chunks received from streaming SageMaker endpoint "
                 f"'{self.endpoint_name}'."
             )

--- a/src/inspect_ai/model/_stream.py
+++ b/src/inspect_ai/model/_stream.py
@@ -118,6 +118,19 @@ StreamContentEvent: TypeAlias = Union[
 """Content delta reported by a provider streaming loop (internal)."""
 
 
+class NoStreamDataError(RuntimeError):
+    """A streaming response completed (HTTP 200) without delivering any data.
+
+    Raised by provider streaming loops when a misbehaving server ends the
+    stream with zero chunks. Always retried by the model layer's retry
+    classifier (`Model.should_retry`) regardless of provider — an empty
+    stream carries no signal to classify from, and failing the sample would
+    score a server hiccup as an empty (wrong) completion. Subclass of
+    `RuntimeError` so pre-existing `except RuntimeError` handling still
+    applies.
+    """
+
+
 PARTIAL_OUTPUT_FLUSH_INTERVAL = 1.0
 """Minimum seconds between partial-output snapshot notifications.
 

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -712,9 +712,11 @@ async def test_chat_completion_stream_gated_without_on_stream(
 
 
 async def test_chat_completion_stream_empty_raises() -> None:
-    """A zero-chunk stream raises a descriptive error, not a bare assert."""
+    """A zero-chunk stream raises a descriptive, retryable error, not a bare assert."""
+    from inspect_ai.model._stream import NoStreamDataError
+
     fake_stream: Any = _FakeChunkStream([])
-    with pytest.raises(RuntimeError, match="without delivering any chunks"):
+    with pytest.raises(NoStreamDataError, match="without delivering any chunks"):
         await openai_chat_completion_stream_final(fake_stream)
 
 

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -504,6 +504,46 @@ def test_anthropic_mid_stream_permanent_error_does_not_retry() -> None:
     assert decision.retry is False
 
 
+def test_anthropic_transient_body_type_on_permanent_status_does_not_retry() -> None:
+    """Type-based classification is scoped to status 200 (the mid-stream case).
+
+    A real HTTP error status — e.g. a proxy's 4xx wrapping an
+    anthropic-format body with a transient inner type — must keep failing
+    fast via the status rules rather than retrying forever.
+    """
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="not found",
+        response=_httpx2_response(404),
+        body={"type": "error", "error": {"type": "api_error", "message": "no route"}},
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
+
+
+def test_anthropic_mid_stream_unparseable_string_body_falls_back_to_substring() -> None:
+    """An SSE error event whose data fails JSON parsing attaches the raw string body."""
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="overloaded",
+        response=_httpx2_response(200),
+        body='{"type": "error", "error": {"type": "overloaded_er',
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
 def test_anthropic_httpx2_transport_error_classifies_as_transient() -> None:
     """Anthropic >= 1 is built on httpx2 — raw httpx2 transport errors that escape the SDK unwrapped must still retry."""
     from inspect_ai.model._providers.anthropic import AnthropicAPI
@@ -890,23 +930,27 @@ def test_sagemaker_other_error_does_not_retry() -> None:
     assert decision.retry is False
 
 
-@pytest.mark.parametrize("error_code", ["ModelInvocationTimeExceeded", "StreamBroken"])
-def test_sagemaker_mid_stream_model_stream_error_classifies_as_transient(
-    error_code: str,
+@pytest.mark.parametrize("code", ["ModelStreamError", "InternalStreamFailure"])
+def test_sagemaker_mid_stream_event_stream_error_classifies_as_transient(
+    code: str,
 ) -> None:
-    """In-band ModelStreamError events (after HTTP 200) classify by ErrorCode.
+    """In-band stream errors (after HTTP 200) surface as EventStreamError.
 
-    Both AWS-documented codes are infrastructure transients whose
-    non-streaming analogues (container timeout / connection reset) retry.
+    Both event shapes are marked `exception` in the AWS service model, so
+    botocore raises them from the stream iterator as EventStreamError (a
+    ClientError) with the exception type as the code — and both are
+    infrastructure transients (AWS documents InternalStreamFailure as "Try
+    your request again"; ModelStreamError's documented ErrorCodes are a
+    model timeout and a TCP reset).
     """
-    from inspect_ai.model._providers.sagemaker import (
-        SagemakerAPI,
-        SageMakerStreamError,
-    )
+    from botocore.exceptions import EventStreamError
+
+    from inspect_ai.model._providers.sagemaker import SagemakerAPI
 
     api = SagemakerAPI.__new__(SagemakerAPI)
-    ex = SageMakerStreamError(
-        f"ModelStreamError [{error_code}]: stream failed", error_code=error_code
+    ex = EventStreamError(
+        {"Error": {"Code": code, "Message": "stream failed"}},
+        "InvokeEndpointWithResponseStream",
     )
     decision = api.should_retry(ex)
     assert isinstance(decision, RetryDecision)
@@ -914,29 +958,15 @@ def test_sagemaker_mid_stream_model_stream_error_classifies_as_transient(
     assert decision.kind == "transient"
 
 
-def test_sagemaker_mid_stream_unknown_error_code_does_not_retry() -> None:
+def test_sagemaker_in_band_stream_error_backstop_classifies_as_transient() -> None:
+    """The typed backstop for in-band error events also classifies as transient."""
     from inspect_ai.model._providers.sagemaker import (
         SagemakerAPI,
         SageMakerStreamError,
     )
 
     api = SagemakerAPI.__new__(SagemakerAPI)
-    for error_code in ("SomeFutureCode", None):
-        ex = SageMakerStreamError("ModelStreamError: stream failed", error_code)
-        decision = api.should_retry(ex)
-        assert isinstance(decision, RetryDecision)
-        assert decision.retry is False
-
-
-def test_sagemaker_internal_stream_failure_classifies_as_transient() -> None:
-    """InternalStreamFailure is documented by AWS as transient ("Try your request again")."""
-    from inspect_ai.model._providers.sagemaker import (
-        SagemakerAPI,
-        SageMakerInternalStreamFailure,
-    )
-
-    api = SagemakerAPI.__new__(SagemakerAPI)
-    ex = SageMakerInternalStreamFailure("InternalStreamFailure: unknown failure")
+    ex = SageMakerStreamError("ModelStreamError [StreamBroken]: tcp reset")
     decision = api.should_retry(ex)
     assert isinstance(decision, RetryDecision)
     assert decision.retry is True

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -73,6 +73,23 @@ def test_model_unrelated_attribute_error_does_not_retry() -> None:
     assert model.should_retry(ex) is False
 
 
+def test_model_empty_stream_classifies_as_retryable_for_any_provider() -> None:
+    """A 200 stream that ended with zero chunks retries regardless of provider.
+
+    Provider streaming loops raise NoStreamDataError when a misbehaving
+    server delivers nothing; there is no payload to classify from, so the
+    model layer retries it generically.
+    """
+    from inspect_ai.model._stream import NoStreamDataError
+
+    model = get_model("mockllm/model")
+    ex = NoStreamDataError("Streaming response ended without delivering any chunks.")
+    assert model.should_retry(ex) is True
+
+    # a plain RuntimeError with the same message must not retry
+    assert model.should_retry(RuntimeError(str(ex))) is False
+
+
 def test_model_call_soon_on_non_none_object_does_not_retry() -> None:
     """A deterministic bug mentioning call_soon (wrong-typed receiver) must not retry.
 
@@ -166,6 +183,156 @@ def test_openai_classify_rate_limit_error_subclass() -> None:
     assert decision is not None
     assert decision.kind == "rate_limit"
     assert decision.retry_after == 5.0
+
+
+def test_openai_classify_mid_stream_server_error_as_transient() -> None:
+    """A transient failure delivered mid-stream (after HTTP 200) is a bare APIError.
+
+    The chat-completions stream iterator raises openai.APIError (no status
+    code) built from the SSE error body — it must classify from code/type
+    like the equivalent non-streaming 5xx does.
+    """
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIError(
+        message="The server had an error while processing your request.",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={
+            "message": "The server had an error while processing your request.",
+            "type": "server_error",
+            "code": None,
+        },
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+    # some backends signal via `code` rather than `type`
+    ex2 = APIError(
+        message="server error",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={"message": "server error", "type": "error", "code": "server_error"},
+    )
+    decision2 = openai_classify_retry(ex2)
+    assert decision2 is not None
+    assert decision2.kind == "transient"
+
+
+def test_openai_classify_mid_stream_rate_limit_as_rate_limit() -> None:
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIError(
+        message="rate limited",
+        request=httpx2.Request("POST", "https://example.com/v1/chat/completions"),
+        body={
+            "message": "rate limited",
+            "type": "requests",
+            "code": "rate_limit_exceeded",
+        },
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "rate_limit"
+
+
+def test_openai_classify_mid_stream_vllm_numeric_code_as_transient() -> None:
+    """vLLM/SGLang deliver mid-stream errors as {"type": "InternalServerError", "code": 500}.
+
+    The numeric code (an int at runtime despite the SDK's Optional[str]
+    annotation) classifies through the standard HTTP status rules, and the
+    CamelCase type spelling is recognized on its own too.
+    """
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    request = httpx2.Request("POST", "https://example.com/v1/chat/completions")
+    ex = APIError(
+        message="internal error",
+        request=request,
+        body={"message": "internal error", "type": "InternalServerError", "code": 500},
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "transient"
+
+    # type-only spelling (no code at all)
+    ex2 = APIError(
+        message="internal error",
+        request=request,
+        body={"message": "internal error", "type": "InternalServerError"},
+    )
+    decision2 = openai_classify_retry(ex2)
+    assert decision2 is not None
+    assert decision2.kind == "transient"
+
+
+def test_openai_classify_mid_stream_openrouter_numeric_code() -> None:
+    """OpenRouter delivers mid-stream errors as {"error": {"code": 502, "message": ...}}."""
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    request = httpx2.Request("POST", "https://example.com/v1/chat/completions")
+    ex = APIError(
+        message="Provider returned error",
+        request=request,
+        body={"message": "Provider returned error", "code": 502},
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "transient"
+
+    # numeric 429 (as int or digit string) classifies as rate limit
+    for code in (429, "429"):
+        ex2 = APIError(
+            message="rate limited",
+            request=request,
+            body={"message": "rate limited", "code": code},
+        )
+        decision2 = openai_classify_retry(ex2)
+        assert decision2 is not None
+        assert decision2.kind == "rate_limit"
+
+
+def test_openai_classify_mid_stream_permanent_error_does_not_retry() -> None:
+    """A permanent bare APIError (non-transient code/type) must re-raise, not retry."""
+    from openai import APIError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    request = httpx2.Request("POST", "https://example.com/v1/chat/completions")
+    ex = APIError(
+        message="invalid request",
+        request=request,
+        body={
+            "message": "invalid request",
+            "type": "invalid_request_error",
+            "code": "invalid_api_key",
+        },
+    )
+    assert openai_classify_retry(ex) is None
+
+    # a numeric non-retryable status must not retry either
+    ex_400 = APIError(
+        message="bad request",
+        request=request,
+        body={"message": "bad request", "code": 400},
+    )
+    assert openai_classify_retry(ex_400) is None
+
+    # non-dict body leaves code/type as None — also not retryable
+    ex_no_body = APIError(
+        message="opaque failure",
+        request=request,
+        body=None,
+    )
+    assert openai_classify_retry(ex_no_body) is None
 
 
 def test_openai_provider_quota_exceeded_does_not_retry() -> None:
@@ -269,6 +436,72 @@ def test_anthropic_streaming_overloaded_body_classifies_as_transient() -> None:
     assert isinstance(decision, RetryDecision)
     assert decision.retry is True
     assert decision.kind == "transient"
+
+
+def test_anthropic_mid_stream_rate_limit_classifies_as_rate_limit() -> None:
+    """A mid-stream SSE error event surfaces as APIStatusError with status 200.
+
+    The SDK builds it from the error body (the HTTP response was 200), so
+    classification must come from the body's error type — a mid-stream
+    rate_limit_error is the same condition as a 429 on the non-streaming path.
+    """
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="rate limited",
+        response=_httpx2_response(200),
+        body={
+            "type": "error",
+            "error": {"type": "rate_limit_error", "message": "rate limited"},
+        },
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+@pytest.mark.parametrize(
+    "error_type", ["overloaded_error", "api_error", "timeout_error"]
+)
+def test_anthropic_mid_stream_transient_types_classify_as_transient(
+    error_type: str,
+) -> None:
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message=error_type,
+        response=_httpx2_response(200),
+        body={"type": "error", "error": {"type": error_type, "message": "boom"}},
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
+def test_anthropic_mid_stream_permanent_error_does_not_retry() -> None:
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="invalid request",
+        response=_httpx2_response(200),
+        body={
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": "bad input"},
+        },
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
 
 
 def test_anthropic_httpx2_transport_error_classifies_as_transient() -> None:
@@ -655,6 +888,59 @@ def test_sagemaker_other_error_does_not_retry() -> None:
     decision = api.should_retry(ex)
     assert isinstance(decision, RetryDecision)
     assert decision.retry is False
+
+
+@pytest.mark.parametrize("error_code", ["ModelInvocationTimeExceeded", "StreamBroken"])
+def test_sagemaker_mid_stream_model_stream_error_classifies_as_transient(
+    error_code: str,
+) -> None:
+    """In-band ModelStreamError events (after HTTP 200) classify by ErrorCode.
+
+    Both AWS-documented codes are infrastructure transients whose
+    non-streaming analogues (container timeout / connection reset) retry.
+    """
+    from inspect_ai.model._providers.sagemaker import (
+        SagemakerAPI,
+        SageMakerStreamError,
+    )
+
+    api = SagemakerAPI.__new__(SagemakerAPI)
+    ex = SageMakerStreamError(
+        f"ModelStreamError [{error_code}]: stream failed", error_code=error_code
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
+def test_sagemaker_mid_stream_unknown_error_code_does_not_retry() -> None:
+    from inspect_ai.model._providers.sagemaker import (
+        SagemakerAPI,
+        SageMakerStreamError,
+    )
+
+    api = SagemakerAPI.__new__(SagemakerAPI)
+    for error_code in ("SomeFutureCode", None):
+        ex = SageMakerStreamError("ModelStreamError: stream failed", error_code)
+        decision = api.should_retry(ex)
+        assert isinstance(decision, RetryDecision)
+        assert decision.retry is False
+
+
+def test_sagemaker_internal_stream_failure_classifies_as_transient() -> None:
+    """InternalStreamFailure is documented by AWS as transient ("Try your request again")."""
+    from inspect_ai.model._providers.sagemaker import (
+        SagemakerAPI,
+        SageMakerInternalStreamFailure,
+    )
+
+    api = SagemakerAPI.__new__(SagemakerAPI)
+    ex = SageMakerInternalStreamFailure("InternalStreamFailure: unknown failure")
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
 
 
 # ---------- Together (RetryError unwrapping) ----------


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#369 (follow-up to meridianlabs-ai/inspect_ai#365, whose OpenAI chat-completions instance was fixed in meridianlabs-ai/inspect_ai#366).

A transient error delivered **mid-stream — after HTTP 200 —** raises an exception shape the provider's retry classifier was never written against (each `should_retry` was written for the *non-streaming* call's status-coded exceptions), so it falls through to `RetryDecision.no()` and the sample fails instead of retrying. Users running streamed evals see samples fail on conditions the non-streaming path retries transparently:

1. **SageMaker**: in-band `ModelStreamError` / `InternalStreamFailure` stream errors were unclassified. (The issue described the stream loop's bare-`RuntimeError` conversion; review of this PR established the loop's error branches are actually dead code — both shapes are marked `exception` in the AWS service model, so botocore raises them from the stream iterator as `EventStreamError`, a `ClientError` whose `Error.Code` is the exception type. That path was equally unclassified: the `ClientError` arm of `should_retry` only recognizes `Code == "ModelError"`.)
2. **Anthropic**: a mid-stream SSE `error` event surfaces as `APIStatusError` with `status_code == 200`; only the `"overloaded"` / `"internal server error"` message substrings were retried. A mid-stream `rate_limit_error` (identical condition to a 429 on the non-streaming path) or `timeout_error` failed the sample.
3. **OpenAI-compatible family** (together, vllm, openrouter, moonshot, deepseek, fireworks, sglang, …): a mid-stream failure is a bare `openai.APIError` with no status code. Third-party servers emit vocabularies like vLLM/SGLang `{"type": "InternalServerError", "code": 500}` or OpenRouter `{"code": 502}` that nothing classified. (On this fork's `main` the bare-`APIError` case isn't classified at all — the #366 fix is not merged here yet; this PR subsumes it.)
4. **All streaming providers**: a 200 stream that ends with zero chunks raised a bare `RuntimeError` that no classifier recognizes — in `_openai.py`, `grok.py`, `sagemaker.py`, and (found during this PR's review) `google.py`. The SageMaker comment even stated the intent was "so the request can be retried", which never happened.

### What is the new behavior?

1. **SageMaker** classifies `EventStreamError`s with code `ModelStreamError` / `InternalStreamFailure` as transient — AWS documents `InternalStreamFailure` as "unknown error … Try your request again", and `ModelStreamError`'s documented `ErrorCode`s (`ModelInvocationTimeExceeded`, `StreamBroken`, the full set per the botocore service model) are a model timeout and a TCP reset, whose non-streaming analogues (container timeout / connection reset) already retry. The stream loop's in-band checks are kept as a defensive backstop raising a typed `SageMakerStreamError` (also classified transient) instead of a bare `RuntimeError`.
2. **Anthropic** classifies a status-200 `APIStatusError` from the body's `error.type`: `rate_limit_error` → rate_limit; `overloaded_error` / `api_error` / `timeout_error` → transient. Scoped to status 200 so a real HTTP error status (e.g. a proxy's 4xx wrapping an anthropic-format body) keeps failing fast via the status rules. The substring fallback is kept and now also covers string bodies (a mid-stream error event whose data fails JSON parsing attaches the raw SSE string as `ex.body`).
3. **OpenAI-compatible**: bare `APIError` is classified from the error body — a numeric `code` (int or decimal string; the SDK passes ints through despite its `Optional[str]` annotation, verified against the installed SDK) routes through the standard HTTP-status retry rules, and `code`/`type` spellings are normalized (`server_error`, `InternalServerError`, `internal_error`, `rate_limit_exceeded`, `RateLimitError`, …). This subsumes the #366 fix; if #366 lands upstream first, the overlap resolves to this broader branch.
4. **All providers**: the four zero-chunk sites (openai chat-completions shared helper, grok, sagemaker, google) raise a new `NoStreamDataError` (a `RuntimeError` subclass, so existing handling is unchanged), which `Model.should_retry` retries generically — an empty stream carries no payload to classify from, and any provider gaining streaming later (e.g. upstream UKGovernmentBEIS/inspect_ai#5097) inherits the behavior.

Out of scope (flagged "minor / arguably separate" in the issue): Grok's gRPC retry set omitting `INTERNAL`/`ABORTED`, and the google SDK `TypeError` edge on a code-less error chunk.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The new exception types subclass `RuntimeError` (matching what the raise sites threw before), so pre-existing `except RuntimeError` handling is unchanged; classification changes only convert sample failures into retries.

### Other information:

Verification: `pytest tests/model/test_should_retry_classification.py tests/model/providers/test_openai_compatible.py tests/model/providers/test_sagemaker.py tests/model/providers/test_anthropic.py tests/model/providers/test_google.py tests/model/providers/test_grok.py` — 414 passed (19 new/strengthened tests); `ruff check` and `mypy` clean on all changed files. SDK error shapes verified against the installed openai 3.5.0, anthropic 1.2.0, and botocore packages (including feeding synthetic event-stream wire messages through botocore's `EventStreamJSONParser` to confirm how SageMaker delivers stream errors).

### Agent review
- Reviewer: Claude Fable 5 via /code-review at high effort — 8 finder agents, each in a fresh context (same model family as the author), followed by author-side verification of each finding against the installed SDKs; 1 orchestrated pass.
- Findings: 13 — 7 fixed, 6 dismissed.
  - Fixed: SageMaker in-band error branches were dead code (real errors arrive as `EventStreamError`; verified empirically, classification moved to the `ClientError` arm); a fourth zero-chunk `RuntimeError` site in google.py; Anthropic type classification unscoped by status (would retry proxy-wrapped permanent errors); unparseable (string) mid-stream bodies skipping all Anthropic checks; `isdigit()` accepting non-decimal digits that crash `int()`; a logger regression (`None` instead of `Unknown`); assorted simplifications (dead bool guard, speculative body shape in the Anthropic helper, duplicated comment, over-long CHANGELOG entry).
  - Dismissed: retry_after sourced from the 200 response's `anthropic-ratelimit-*-reset` headers (best available signal; consistent with the pre-existing overloaded path); three refactor suggestions to consolidate status-classification helpers across `_openai.py`/`_util` (out of scope for a bug fix; noted for follow-up); vocabulary duplication with the `OpenAIResponseError` branch (different exception type, kept separate); contradictory-body edge `{"type": "server_error", "code": 200}` (no known producer; the numeric status is treated as authoritative).

Disclosure: implemented by Claude Fable 5 (Claude Code) triggered from issue #369.

Generated with [Claude Code](https://claude.ai/code)