### PR TITLE
Document that the grep tool's patterns are basic regex (BRE), where unescaped | matches literally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Tools: The `grep` tool's docstring now documents that patterns use basic regex (BRE), where unescaped `|`, `+`, `?`, and `()` match literally.
 - Eval Log: Reading a sample from a `.json` log now reports the requested uuid when the sample is missing, and raises a clear error when neither id nor uuid is provided.
 - vLLM: The server's `max_model_len` is now registered as the model's context window, so compaction and context-length handling reflect the served configuration (including LoRA adapters via their parent model). (#4215)
 - Eval Set: Protocol for running a selection of an eval set's tasks (`INSPECT_EVAL_SET_SELECTION`), so an external runner can execute one task per process into a shared log directory while owning the eval-set metadata itself.

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -723,7 +723,7 @@ grep()
 grep(timeout=60)
 ```
 
-The model can specify a `pattern`, `path`, optional `glob` filter (e.g. `"*.py"`), `fixed_strings` flag for literal matching, and `output_mode` (`"content"`, `"files_with_matches"`, or `"count"`). Results include file paths and line numbers by default.
+The model can specify a `pattern`, `path`, optional `glob` filter (e.g. `"*.py"`), `fixed_strings` flag for literal matching, and `output_mode` (`"content"`, `"files_with_matches"`, or `"count"`). Patterns use grep's basic regex (BRE), so `|`, `+`, `?`, and `()` match literally unless backslash-escaped. Results include file paths and line numbers by default.
 
 ### Task Setup
 

--- a/src/inspect_ai/tool/_tools/_grep.py
+++ b/src/inspect_ai/tool/_tools/_grep.py
@@ -35,7 +35,9 @@ def grep(
 
         Args:
             pattern: Regular expression pattern to search for
-                (or literal string if fixed_strings is True).
+                (or literal string if fixed_strings is True). Uses
+                grep's basic regex (BRE): `|`, `+`, `?`, and `()`
+                match literally unless backslash-escaped.
             path: File or directory to search (defaults to working
                 directory).
             glob: Glob pattern to filter which files to search

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -90,6 +90,17 @@ def test_grep_fixed_strings() -> None:
 
 @skip_if_no_docker
 @pytest.mark.slow
+def test_grep_uses_basic_regex() -> None:
+    """Patterns are BRE: unescaped alternation is literal, escaped works."""
+    content = _run_grep({"pattern": "hello|goodbye", "path": "/tmp/testdir"})
+    assert "no matches" in content.lower()
+    content = _run_grep({"pattern": r"hello\|goodbye", "path": "/tmp/testdir"})
+    assert "hello.py" in content
+    assert "goodbye.txt" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
 def test_grep_no_matches() -> None:
     content = _run_grep({"pattern": "zzz_nonexistent_zzz", "path": "/tmp/testdir"})
     assert "no matches" in content.lower()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The sandbox `grep` tool shells out to plain `grep -rn`, which uses basic regular expressions (BRE). Its docstring says only "Regular expression pattern", so models routinely write ERE-style patterns like `crystal|biharmonic|Abrate` — in BRE the `|` is a literal character, grep exits 1, and the tool returns "No matches found.". That looks like a valid answer, so the model (e.g. a deepagent research subagent, where this tool is a default) proceeds on false information with no signal anywhere that the pattern syntax was the problem. Hit in practice: a research subagent's alternation search over a corpus returned empty results that were known to be wrong.

### What is the new behavior?

The tool docstring and the `tools-standard.qmd` grep section now state that patterns use grep's basic regex (BRE) and that `|`, `+`, `?`, and `()` match literally unless backslash-escaped, so models write valid BRE patterns. A new test (`test_grep_uses_basic_regex`) pins the BRE semantics: unescaped `|` alternation matches nothing, escaped `\|` alternation matches.

Switching the tool to `grep -E` was considered and deliberately not done here — that would change matching semantics for existing evals; documenting current behavior is the non-breaking fix. If maintainers would rather move the tool to ERE, happy to do that in a follow-up instead.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Checks: `ruff check`, `ruff format --check`, and `mypy` pass on the changed files. `pytest tests/tools/test_grep.py --runslow` (docker): 8 passed, including the new test. The full `make test` suite was not run (docstring/docs/test-only change).

Agent involvement: authored by Claude Code (Fable 5), directed and reviewed by @tadamcz.

### Agent review
- Reviewer: Claude Fable 5 via /code-review (8 finder angles + per-finding verifiers, each in a fresh subagent context; same model family as author), 1 pass
- Findings: 4 confirmed — 3 fixed (docstring wrongly attributed GNU escape extensions to POSIX; `tools-standard.qmd` grep section lacked the dialect note; CHANGELOG entry carried a rationale clause), 1 dismissed (suggested fixing the root cause with `grep -E` instead of documenting BRE — deliberate author decision to avoid a behavior change, noted above)
