### PR TITLE
Fix nested truncation of subagent results when a submitted answer exceeds max_tool_output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices. (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)
+- Agents: A react agent's submitted answer is no longer subject to tool output truncation, so long subagent results (e.g. from deepagent or `as_tool`) no longer show nested truncation messages.
 - Eval logs: An Azure storage authentication failure while listing a remote log directory now raises `AzureAuthError` with remediation guidance instead of being downgraded to a warning and an empty listing, matching how S3 surfaces auth failures. (#4914)
 - Human Agent: End-of-input (e.g. Ctrl+D) at the `task submit`/`task quit` confirmation prompt now declines cleanly instead of raising an `EOFError` traceback.
 - Model streaming: stream-event handling — including live partial-output snapshots in inspect view — now runs only when `on_stream` is passed, so it can no longer fail model calls that stream without a callback.

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -195,11 +195,11 @@ def react(
         if result is None:
             return None
 
-        # Prefer the answer from the tool call arguments: the result message
-        # has passed through max_tool_output truncation, which would replace
-        # a long answer with a truncation envelope (and produce a nested
-        # envelope when the completion is itself returned as a tool result,
-        # e.g. from a subagent).
+        # The result message above establishes that the submit succeeded, but
+        # its content has passed through max_tool_output truncation — so read
+        # the answer from the originating call's arguments instead (otherwise
+        # a long answer becomes a truncation envelope, nested once the
+        # completion is itself returned as a tool result, e.g. by a subagent).
         call = next(
             (c for c in (tool_calls or []) if c.id == result.tool_call_id), None
         )

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -24,6 +24,7 @@ from inspect_ai.model._trim import partition_messages, trim_messages
 from inspect_ai.scorer._score import score
 from inspect_ai.tool._mcp.connection import mcp_connection
 from inspect_ai.tool._tool import Tool, ToolResult, ToolSource, tool
+from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.tool._tool_info import parse_tool_info
 from inspect_ai.util._checkpoint import Checkpointer, checkpointer
@@ -177,10 +178,12 @@ def react(
     # resolve attempts
     attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
 
-    def submission(tool_results: list[ChatMessage]) -> str | None:
-        return next(
+    def submission(
+        tool_calls: list[ToolCall] | None, tool_results: list[ChatMessage]
+    ) -> str | None:
+        result = next(
             (
-                result.text
+                result
                 for result in tool_results
                 if isinstance(result, ChatMessageTool)
                 and result.function == submit_tool.name
@@ -189,6 +192,25 @@ def react(
             ),
             None,
         )
+        if result is None:
+            return None
+
+        # Prefer the answer from the tool call arguments: the result message
+        # has passed through max_tool_output truncation, which would replace
+        # a long answer with a truncation envelope (and produce a nested
+        # envelope when the completion is itself returned as a tool result,
+        # e.g. from a subagent).
+        call = next(
+            (c for c in (tool_calls or []) if c.id == result.tool_call_id), None
+        )
+        if call is not None:
+            answer = call.arguments.get("answer")
+            if isinstance(answer, str):
+                return answer
+
+        # Fall back to the result text (custom submit tools aren't required
+        # to take an `answer` argument).
+        return result.text
 
     async def execute(state: AgentState) -> AgentState:
         async with checkpointer() as cp:
@@ -274,7 +296,9 @@ def react(
                                     state.output = output
 
                                 # check for a submission
-                                answer = submission(messages)
+                                answer = submission(
+                                    state.output.message.tool_calls, messages
+                                )
                                 if answer is not None:
                                     # set the output to the answer for scoring
                                     if submit.answer_only:

--- a/tests/agent/deepagent/test_deepagent_e2e.py
+++ b/tests/agent/deepagent/test_deepagent_e2e.py
@@ -15,6 +15,7 @@ def _eval_deepagent(
     input: str = "Do the task",
     target: str = "n/a",
     message_limit: int = 20,
+    max_tool_output: int | None = None,
 ) -> dict:
     """Helper to run a deepagent eval and return results."""
     agent_kwargs.setdefault("submit", True)
@@ -26,7 +27,7 @@ def _eval_deepagent(
         message_limit=message_limit,
     )
     model = get_model("mockllm/model", custom_outputs=outputs)
-    log = eval(task, model=model)[0]
+    log = eval(task, model=model, max_tool_output=max_tool_output)[0]
     return {
         "log": log,
         "status": log.status,
@@ -277,6 +278,58 @@ class TestSubmitIntegration:
         assert any(marker in r for r in agent_results), (
             "parent did not receive the subagent's answer"
         )
+
+    def test_long_subagent_answer_truncated_once(self) -> None:
+        """A long subagent answer is truncated once, not wrapped twice.
+
+        The child's submit() result passes through max_tool_output truncation
+        like any other tool output. Previously the truncation envelope (rather
+        than the raw answer) became the subagent's completion, so the parent's
+        agent tool result nested a second envelope around the first.
+        """
+        marker = "LONG_ANSWER_MARKER_42"
+        answer = f"{marker} " + ("finding " * 1000)
+        result = _eval_deepagent(
+            agent_kwargs={"submit": True},
+            max_tool_output=1024,
+            outputs=[
+                # 1. Parent dispatches research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="agent",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Find the answer.",
+                    },
+                ),
+                # 2. Research subagent submits a very long answer
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": answer},
+                ),
+                # 3. Parent submits its own answer
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+        agent_results = [
+            str(e.result)
+            for e in result["events"]
+            if isinstance(e, ToolEvent) and e.function == "agent"
+        ]
+        assert len(agent_results) == 1
+        agent_result = agent_results[0]
+
+        # exactly one truncation envelope: the parent's own truncation of the
+        # (legitimately oversized) agent tool output
+        assert agent_result.count("was too long to be displayed") == 1
+        assert "call to agent" in agent_result
+        # the child's submit truncation envelope must not leak into the parent
+        assert "call to submit" not in agent_result
+        # the truncated content is the answer itself
+        assert marker in agent_result
 
 
 class TestCustomSubagents:

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -22,6 +22,7 @@ from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
     ChatMessageSystem,
+    ChatMessageTool,
 )
 from inspect_ai.scorer import Score, Target, accuracy, includes, scorer
 from inspect_ai.solver import Generate, Solver, TaskState, solver
@@ -264,6 +265,89 @@ def check_custom_submit(log: EvalLog, name: str, description: str) -> None:
     assert model_event
     assert model_event.tools[1].name == name
     assert model_event.tools[1].description == description
+
+
+def test_react_agent_long_submit_answer_not_truncated() -> None:
+    """A long submitted answer becomes the completion untruncated.
+
+    The submit tool's result message passes through max_tool_output
+    truncation like any other tool output; the answer used for the
+    completion must be the raw submitted answer, not the truncation
+    envelope.
+    """
+    answer = "ANSWER_MARKER_42 " + ("finding " * 1000)
+    task = Task(
+        dataset=[Sample(input="Do the task")],
+        solver=react(tools=[addition()], submit=AgentSubmit(answer_only=True)),
+    )
+    model = mockllm_model_with_submissions([answer])
+    log = eval(task, model=model, max_tool_output=1024)[0]
+    assert log.status == "success"
+    assert log.samples
+    assert log.samples[0].output.completion == answer
+    for message in log.samples[0].messages:
+        if isinstance(message, ChatMessageAssistant):
+            assert "was too long to be displayed" not in message.text
+
+
+def test_react_agent_as_tool_long_answer_truncated_once() -> None:
+    """A long agent-as-tool answer is truncated once, not wrapped twice.
+
+    The child react agent's submit() result passes through max_tool_output
+    truncation; the answer surfaced through the parent's tool result must be
+    the raw answer (truncated once by the parent), not a truncation envelope
+    nested inside another one.
+    """
+    from inspect_ai.agent._as_tool import as_tool
+
+    marker = "AS_TOOL_ANSWER_MARKER_42"
+    answer = f"{marker} " + ("finding " * 1000)
+
+    researcher = react(
+        name="researcher",
+        description="Researches things.",
+        tools=[addition()],
+    )
+    task = Task(
+        dataset=[Sample(input="Do the task")],
+        solver=react(tools=[as_tool(researcher)]),
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            # 1. Parent calls the researcher tool
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="researcher",
+                tool_arguments={"input": "Find the answer."},
+            ),
+            # 2. Child researcher submits a very long answer
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": answer},
+            ),
+            # 3. Parent submits its own answer
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "done"},
+            ),
+        ],
+    )
+    log = eval(task, model=model, max_tool_output=1024)[0]
+    assert log.status == "success"
+    assert log.samples
+    tool_messages = [
+        m
+        for m in log.samples[0].messages
+        if isinstance(m, ChatMessageTool) and m.function == "researcher"
+    ]
+    assert len(tool_messages) == 1
+    result = tool_messages[0].text
+    assert result.count("was too long to be displayed") == 1
+    assert "call to submit" not in result
+    assert marker in result
 
 
 def addition_dataset() -> list[Sample]:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When a react agent's submitted answer exceeds `max_tool_output`, the submit tool's result message is truncated and wrapped in a truncation envelope like any other tool output. `submission()` in `_react.py` extracted the answer from that already-truncated result text, so the envelope itself became `state.output.completion`.

When that completion is then returned as a *parent* tool result — a deepagent subagent dispatched via the `agent` tool, or a react agent wrapped with `as_tool()` — the parent's tool-execution layer truncates it again. In the log viewer the parent's tool result shows nested wrappers: "The output of your call to agent was too long… \<START_TOOL_OUTPUT\>" immediately followed by "The output of your call to submit was too long… \<START_TOOL_OUTPUT\>". The real answer is truncated twice and the inner envelope leaks into the parent conversation.

(Reported internally with a log-viewer screenshot of a deepagent run; no tracker issue.)

### What is the new behavior?

`submission()` now reads the answer from the submit tool *call arguments* on the assistant message (matched by `tool_call_id`), so the completion carries the raw submitted answer regardless of `max_tool_output`. It falls back to the result message text when there is no matching call or no string `answer` argument (custom submit tools aren't required to take an `answer` parameter).

This fixes react generally, not just deepagent: `answer_only`, `answer_delimiter`, and the `keep_in_messages=False` content-append path all consume the same extracted answer, so `as_tool()` (which reads `state.output.message.content`) is fixed transitively. `handoff()` filters message history rather than reading the completion, so it was not affected. The *outer* truncation — a parent agent tool result legitimately exceeding `max_tool_output` — still applies, exactly once, to the real answer text.

Tests (all written first and confirmed failing before the fix):
- `test_deepagent_e2e.py::test_long_subagent_answer_truncated_once` — deepagent child submits an answer longer than `max_tool_output`; asserts the parent's `agent` tool result contains exactly one truncation envelope, no leaked `call to submit` envelope, and the real answer text inside.
- `test_agent_react.py::test_react_agent_long_submit_answer_not_truncated` — a long submitted answer becomes the completion untruncated.
- `test_agent_react.py::test_react_agent_as_tool_long_answer_truncated_once` — same double-wrap regression through the `as_tool()` path.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. One nuance: a custom submit tool that *transforms* the answer before returning it (contrary to the documented `AgentSubmit.tool` contract, "The tool should return the `answer` provided to it") would previously surface its transformed return value in the completion; if it takes a string `answer` argument, the raw argument is now used instead.

### Other information:

Verification: `make check` (ruff + mypy) clean; `make test` passes (10,191 passed, 0 failed; standard `--runslow`/`--runtrio`/`--runapi` skips).

This change was implemented by an AI agent (Claude Code, Claude Fable 5) directed by @dragonstyle.

### Agent review
- Reviewer: Claude Fable 5 code-review subagent (fresh context, same model as author), 1 pass over the final diff plus all downstream consumers (`execute_tools`, deepagent `_extract_result`, `as_tool`, `handoff`).
- Findings: 0 issues. One below-threshold note — the custom-submit-tool transform nuance described under breaking changes — dismissed as applying only to tools that already violate the documented contract.
