### PR TITLE
Fix choice scorer aborting scoring runs on samples without choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Scorers: `match(numeric=True)` now parses numbers with attached sentence or enclosing punctuation (e.g. "42!", "(42)"); operator prefixes (`<42`, `~42`) still do not match, and `location="exact"` remains strict. (#4742)
-- Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices still score incorrect rather than raising). (#4590)
+- Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices always score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)
 - Eval logs: An Azure storage authentication failure while listing a remote log directory now raises `AzureAuthError` with remediation guidance instead of being downgraded to a warning and an empty listing, matching how S3 surfaces auth failures. (#4914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 - Scorers: `match(numeric=True)` now parses numbers with attached sentence or enclosing punctuation (e.g. "42!", "(42)"); operator prefixes (`<42`, `~42`) still do not match, and `location="exact"` remains strict. (#4742)
-- Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices. (#4590)
+- Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices still score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)
 - Eval logs: An Azure storage authentication failure while listing a remote log directory now raises `AzureAuthError` with remediation guidance instead of being downgraded to a warning and an empty listing, matching how S3 surfaces auth failures. (#4914)

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -28,21 +28,17 @@ def _score_target(target: Target, choices: Choices) -> tuple[list[int], list[str
 
     # a target that references a position beyond the task's choices is a
     # dataset error (e.g. a "10" target in a 30-option task resolves to
-    # index 35): raise loudly rather than silently scoring incorrect forever.
-    # a sample with no choices isn't a multiple choice sample at all (e.g.
-    # re-scoring a non-multiple-choice log), so there is nothing to validate
-    # against -- score it incorrect as before
-    if len(choices) > 0:
-        out_of_range = [
-            answer
-            for answer, position in zip(target_answers, target_positions)
-            if position >= len(choices)
-        ]
-        if out_of_range:
-            raise ValueError(
-                f"Choice scorer target references answer(s) beyond the task's "
-                f"{len(choices)} choices: {', '.join(out_of_range)}"
-            )
+    # index 35): raise loudly rather than silently scoring incorrect forever
+    out_of_range = [
+        answer
+        for answer, position in zip(target_answers, target_positions)
+        if position >= len(choices)
+    ]
+    if out_of_range:
+        raise ValueError(
+            f"Choice scorer target references answer(s) beyond the task's "
+            f"{len(choices)} choices: {', '.join(out_of_range)}"
+        )
 
     choice_positions = [i for i, choice in enumerate(choices) if choice.correct is True]
 
@@ -82,6 +78,14 @@ def choice() -> Scorer:
 
     async def score(state: TaskState, target: Target) -> Score:
         choices = state.choices
+
+        # a sample with no choices isn't a multiple choice sample at all (e.g.
+        # re-scoring a non-multiple-choice log): score it incorrect without
+        # parsing the target, which is likely free text rather than answer labels
+        if not choices:
+            return Score(
+                value=INCORRECT, answer="", explanation=state.output.completion
+            )
 
         if _choices_are_shuffled(choices):
             explanation = _shuffled_explanation(choices)

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -28,17 +28,21 @@ def _score_target(target: Target, choices: Choices) -> tuple[list[int], list[str
 
     # a target that references a position beyond the task's choices is a
     # dataset error (e.g. a "10" target in a 30-option task resolves to
-    # index 35): raise loudly rather than silently scoring incorrect forever
-    out_of_range = [
-        answer
-        for answer, position in zip(target_answers, target_positions)
-        if position >= len(choices)
-    ]
-    if out_of_range:
-        raise ValueError(
-            f"Choice scorer target references answer(s) beyond the task's "
-            f"{len(choices)} choices: {', '.join(out_of_range)}"
-        )
+    # index 35): raise loudly rather than silently scoring incorrect forever.
+    # a sample with no choices isn't a multiple choice sample at all (e.g.
+    # re-scoring a non-multiple-choice log), so there is nothing to validate
+    # against -- score it incorrect as before
+    if len(choices) > 0:
+        out_of_range = [
+            answer
+            for answer, position in zip(target_answers, target_positions)
+            if position >= len(choices)
+        ]
+        if out_of_range:
+            raise ValueError(
+                f"Choice scorer target references answer(s) beyond the task's "
+                f"{len(choices)} choices: {', '.join(out_of_range)}"
+            )
 
     choice_positions = [i for i, choice in enumerate(choices) if choice.correct is True]
 

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -122,16 +122,27 @@ async def test_score_target_beyond_choices_raises():
 
 
 @pytest.mark.anyio
-async def test_score_no_choices_does_not_raise():
+@pytest.mark.parametrize(
+    "target",
+    [
+        "No",  # alphanumeric, parseable as answer labels
+        "The answer is 42.",  # free text, unparseable as answer labels
+        "",  # empty
+    ],
+)
+async def test_score_no_choices_does_not_raise(target: str):
     # the choice scorer applied to a sample with no choices (e.g. re-scoring a
-    # non-multiple-choice log) should score incorrect, not abort the run
+    # non-multiple-choice log) should score incorrect, not abort the run --
+    # whatever the target looks like
     scorer = choice()
     state = simple_task_state(model_output="No", choices=[])
 
-    result = await scorer(state, Target("No"))
+    result = await scorer(state, Target(target))
 
+    assert result is not None
     assert result.text == INCORRECT
     assert result.answer == ""
+    assert result.explanation == "No"
 
 
 def test_answer_index_rejects_separators():

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -121,6 +121,19 @@ async def test_score_target_beyond_choices_raises():
         await scorer(state, Target("10"))
 
 
+@pytest.mark.anyio
+async def test_score_no_choices_does_not_raise():
+    # the choice scorer applied to a sample with no choices (e.g. re-scoring a
+    # non-multiple-choice log) should score incorrect, not abort the run
+    scorer = choice()
+    state = simple_task_state(model_output="No", choices=[])
+
+    result = await scorer(state, Target("No"))
+
+    assert result.text == INCORRECT
+    assert result.answer == ""
+
+
 def test_answer_index_rejects_separators():
     # answer_index() should never silently return garbage indices for
     # separator characters -- it should raise so callers know to filter.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#372

Applying the `choice` scorer to a sample with no choices (e.g. `inspect score --scorer choice` against a non-multiple-choice log, or a task where only some samples set choices) raises `ValueError` and aborts the entire scoring run. The bounds check added in 6de08de (#4591) is unconditional on `len(choices)`, so with zero choices every non-empty target is "out of range". This broke `tests/_eval/test_score.py::test_score[multiple-scorers]`, which re-scores a non-multiple-choice log with `[f1, choice]`.

### What is the new behavior?

The out-of-range guard only applies when the sample actually has choices. A sample with zero choices isn't a multiple-choice sample, so there is nothing to validate the target against — it scores `INCORRECT` with an empty answer, as it did before 6de08de. Real multiple-choice tasks keep the new guard (a `"10"` target in a 30-option task still raises).

Added a regression test (`test_score_no_choices_does_not_raise`) and amended the existing unreleased CHANGELOG entry for #4590 to note the scoping.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verification:
- `pytest tests/scorer/test_choice.py` — 17 passed (asyncio), 16 passed with `--runtrio` (trio variants)
- `tests/_eval/test_score.py::test_score[multiple-scorers]` skips locally (requires `OPENAI_API_KEY`); the new unit test exercises the same failing path (0 choices, non-empty target)
- `ruff check`, `ruff format --check`, and `mypy` clean on changed files

### Agent review
- Reviewer: none — no separate review pass was run; the change is the two-line scoping of an existing guard proposed and pre-verified in the linked issue's triage analysis
- Agent involvement: implemented by Claude Fable 5 (Claude Code) from the issue's proposed fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)