### PR TITLE
return long subagent reports and submitted answers in full instead of truncating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Human Agent: End-of-input (e.g. Ctrl+D) at the `task submit`/`task quit` confirmation prompt now declines cleanly instead of raising an `EOFError` traceback.
 - Agents: Long subagent reports and submitted answers are no longer clipped at the maximum tool output size (they were previously truncated, subagent reports twice over).
 - Agents: An agent used as a tool via `as_tool()` returns its full response rather than one clipped at the maximum tool output size.
+- Deep Agent: `agent_list()` now reports one line per background agent instead of embedding every completed agent's full report.
 - Tools: Tools can declare their own output limit with `@tool(max_output=...)`, overriding `max_tool_output` (`0` disables truncation for that tool).
 - Model streaming: stream-event handling — including live partial-output snapshots in inspect view — now runs only when `on_stream` is passed, so it can no longer fail model calls that stream without a callback.
 - Eval logs: Users can chain conditional S3 writes using the ETag returned by `write_eval_log()` and `write_eval_log_async()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)
 - Eval logs: An Azure storage authentication failure while listing a remote log directory now raises `AzureAuthError` with remediation guidance instead of being downgraded to a warning and an empty listing, matching how S3 surfaces auth failures. (#4914)
 - Human Agent: End-of-input (e.g. Ctrl+D) at the `task submit`/`task quit` confirmation prompt now declines cleanly instead of raising an `EOFError` traceback.
+- Agents: Long subagent reports and submitted answers are no longer clipped at the maximum tool output size (they were previously truncated, subagent reports twice over).
+- Agents: An agent used as a tool via `as_tool()` returns its full response rather than one clipped at the maximum tool output size.
+- Tools: Tools can declare their own output limit with `@tool(max_output=...)`, overriding `max_tool_output` (`0` disables truncation for that tool).
 - Model streaming: stream-event handling — including live partial-output snapshots in inspect view — now runs only when `on_stream` is passed, so it can no longer fail model calls that stream without a callback.
 - Eval logs: Users can chain conditional S3 writes using the ETag returned by `write_eval_log()` and `write_eval_log_async()`.
 - Breaking (tests only) Sandboxes: `inspect_ai.util._sandbox.self_check` is now a collection of plain pytest tests. See docstring for migration instructions.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -71,6 +71,8 @@ The parent agent decides when to delegate vs. do work directly. The system promp
 
 Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean. All subagents inherit the parent's model by default — for cost-sensitive workloads, consider overriding `research()` with a cheaper model (e.g. `research(model="anthropic/claude-haiku-4-5")`), since read-only information gathering is the highest-volume subagent task. See [Subagents](#sec-customizing-builtins) below for how to customize or replace the defaults.
 
+A subagent's report is the whole point of the delegation, so it is exempt from the `max_tool_output` limit that applies to ordinary tool results — however long the report, the parent sees all of it. Use `limits` on a [customized subagent](#sec-customizing-builtins) (e.g. `token_limit()`) to bound how much work a subagent can do.
+
 ### Memory
 
 The `memory()` tool provides a scratchpad for the top-level agent for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -299,7 +299,7 @@ When enabled, the `agent()` tool gains a `background` argument. Calling `agent(s
 | `agent_status(agent_id)` | Non-blocking peek — status, and for a running agent a brief progress snapshot (elapsed time, message/tool-call counts, latest message); for a finished agent, its result. |
 | `agent_wait(agent_ids, mode, timeout)` | Block until the listed agents finish. `mode="all"` (default) waits for every agent; `mode="any"` returns on the first. On `timeout`, still-running agents are reported honestly. |
 | `agent_cancel(agent_id)` | Terminate a running agent. No-op on an already-finished agent. |
-| `agent_list(status_filter)` | Enumerate all dispatched agents (optionally filtered by status) — useful for recovering handles after a long stretch of work or context compaction. |
+| `agent_list(status_filter)` | Enumerate all dispatched agents (optionally filtered by status), one line each — useful for recovering handles after a long stretch of work or context compaction. Results are not included; `agent_status()` reads them. |
 
 : {tbl-colwidths=\[35,65\]}
 

--- a/docs/tools-custom.qmd
+++ b/docs/tools-custom.qmd
@@ -127,6 +127,26 @@ If one parallel call raises an unhandled exception, its in-flight siblings are c
 Only opt a tool in to parallel execution after auditing it for concurrent-safety. Stateful tools like `bash_session()` and `web_browser()` keep the default (`parallel=False`) and run serially.
 
 
+## Output Size {#sec-tool-output-size}
+
+Tool results are truncated at `max_tool_output` from the active generate config (16KB by default), with the model shown a notice that the output was too long. A tool can declare its own limit with `@tool(max_output=...)`, which takes precedence over the generate config:
+
+``` python
+@tool(max_output=0)
+def summarize():
+    async def summarize(text: str) -> str:
+        """Summarize a body of text.
+
+        Args:
+            text: The text to summarize.
+        """
+        ...
+    return summarize
+```
+
+`0` disables truncation for the tool, and a positive value caps it at that many bytes. Reserve `max_output=0` for tools whose result is a payload the caller depends on in full rather than incidental output the model reads and moves on from — for example the `submit()` tool of a [ReAct agent](react-agent.qmd) (whose result becomes the scored completion) and the `agent()` tool of a [Deep Agent](deepagent.qmd) (whose result is a subagent's report). Leave it unset for tools that read files, run commands, or fetch pages, where an unbounded result can flood the context window.
+
+
 ## Stateful Tools
 
 Some tools need to retain state across invocations (for example, the `bash_session()` and `web_browser()` tools both interact with a stateful remote process). You can create stateful tools by using the `store_as()` function to access discrete storage for your tool and/or specific instances of your tool.

--- a/docs/tools-custom.qmd
+++ b/docs/tools-custom.qmd
@@ -144,7 +144,11 @@ def summarize():
     return summarize
 ```
 
-`0` disables truncation for the tool, and a positive value caps it at that many bytes. Reserve `max_output=0` for tools whose result is a payload the caller depends on in full rather than incidental output the model reads and moves on from — for example the `submit()` tool of a [ReAct agent](react-agent.qmd) (whose result becomes the scored completion) and the `agent()` tool of a [Deep Agent](deepagent.qmd) (whose result is a subagent's report). Leave it unset for tools that read files, run commands, or fetch pages, where an unbounded result can flood the context window.
+`0` disables truncation for the tool, and a positive value caps it at that many bytes (a negative value is an error). Reserve `max_output=0` for tools whose result is a payload the caller depends on in full rather than incidental output the model reads and moves on from — for example the `submit()` tool of a [ReAct agent](react-agent.qmd) (whose result becomes the scored completion) and the `agent()` tool of a [Deep Agent](deepagent.qmd) (whose result is a subagent's report). Leave it unset for tools that read files, run commands, or fetch pages, where an unbounded result can flood the context window.
+
+Note that a single unbounded result is not the same risk as an unbounded *accumulation* of them. A tool that returns one agent's report is bounded by what that agent can generate; a tool that concatenates every result it has ever seen is not, and should stay capped (or summarise) no matter how important each individual payload is.
+
+`as_tool()` applies `max_output=0` by default, since an agent's response is the payload the caller asked for. Pass `as_tool(agent, max_output=...)` to cap it instead.
 
 
 ## Stateful Tools

--- a/src/inspect_ai/agent/_as_tool.py
+++ b/src/inspect_ai/agent/_as_tool.py
@@ -24,6 +24,7 @@ def as_tool(
     agent: Agent,
     description: str | None = None,
     limits: list[Limit] = [],
+    max_output: int | None = 0,
     **agent_kwargs: Any,
 ) -> Tool:
     """Convert an agent to a tool.
@@ -40,6 +41,11 @@ def as_tool(
        limits: List of limits to apply to the agent. Should a limit
           be exceeded, the tool call ends and returns an error
           explaining that a limit was exceeded.
+       max_output: Maximum size (in bytes) of the agent's response before
+          it is truncated. Defaults to `0` (no truncation) since the
+          response is the payload the caller asked for. Pass a positive
+          number of bytes to cap it, or `None` to defer to
+          `max_tool_output` in the active `GenerateConfig`.
        **agent_kwargs: Arguments to curry to Agent function (arguments
           provided here will not be presented to the model as part
           of the tool interface).
@@ -89,16 +95,16 @@ def as_tool(
     } | tool_info.parameters.properties
     tool_info.parameters.required.append("input")
 
-    # create tool (max_output=0 because the agent's report is the payload the
-    # caller asked for -- clipping it would substitute a truncation notice.
-    # It was also only ever clipped for agents whose final message content is
-    # a plain string; structured content already bypassed truncation.)
+    # create tool (max_output defaults to 0: the agent's report is the payload
+    # the caller asked for, and clipping it would substitute a truncation
+    # notice. It was also only ever clipped for agents whose final message
+    # content is a plain string; structured content already bypassed it.)
     tool_def = ToolDef(
         execute,
         name=tool_info.name,
         description=tool_info.description,
         parameters=tool_info.parameters,
-        max_output=0,
+        max_output=max_output,
     )
     return tool_def.as_tool()
 

--- a/src/inspect_ai/agent/_as_tool.py
+++ b/src/inspect_ai/agent/_as_tool.py
@@ -89,12 +89,16 @@ def as_tool(
     } | tool_info.parameters.properties
     tool_info.parameters.required.append("input")
 
-    # create tool
+    # create tool (max_output=0 because the agent's report is the payload the
+    # caller asked for -- clipping it would substitute a truncation notice.
+    # It was also only ever clipped for agents whose final message content is
+    # a plain string; structured content already bypassed truncation.)
     tool_def = ToolDef(
         execute,
         name=tool_info.name,
         description=tool_info.description,
         parameters=tool_info.parameters,
+        max_output=0,
     )
     return tool_def.as_tool()
 

--- a/src/inspect_ai/agent/_deepagent/agent_tool.py
+++ b/src/inspect_ai/agent/_deepagent/agent_tool.py
@@ -42,6 +42,15 @@ from .subagent import Subagent
 
 logger = getLogger(__name__)
 
+SUBAGENT_RESULT_MAX_OUTPUT = 0
+"""Output limit for tools that hand a subagent's result back to the parent.
+
+A subagent's report *is* the payload of the delegation, so clipping it at
+``max_tool_output`` (16KB by default) throws away the very thing the parent
+dispatched for. ``0`` disables truncation. Shared with the background
+lifecycle tools, which echo the same results.
+"""
+
 # ---------------------------------------------------------------------------
 # Background dispatch registry
 # ---------------------------------------------------------------------------
@@ -370,7 +379,11 @@ def agent_tool(
     if background_enabled and single_name is not None:
         only = single_name
 
-        @tool(parallel=can_parallel, viewer=_agent_viewer_for(single_name))
+        @tool(
+            parallel=can_parallel,
+            viewer=_agent_viewer_for(single_name),
+            max_output=SUBAGENT_RESULT_MAX_OUTPUT,
+        )
         def agent() -> Tool:
             """Delegate a task to a specialized subagent."""
 
@@ -388,7 +401,11 @@ def agent_tool(
 
     elif background_enabled:
 
-        @tool(parallel=can_parallel, viewer=_agent_viewer_for(single_name))
+        @tool(
+            parallel=can_parallel,
+            viewer=_agent_viewer_for(single_name),
+            max_output=SUBAGENT_RESULT_MAX_OUTPUT,
+        )
         def agent() -> Tool:  # type: ignore[no-redef]
             """Delegate a task to a specialized subagent."""
 
@@ -408,7 +425,11 @@ def agent_tool(
     elif single_name is not None:
         only = single_name
 
-        @tool(parallel=can_parallel, viewer=_agent_viewer_for(single_name))
+        @tool(
+            parallel=can_parallel,
+            viewer=_agent_viewer_for(single_name),
+            max_output=SUBAGENT_RESULT_MAX_OUTPUT,
+        )
         def agent() -> Tool:  # type: ignore[no-redef]
             """Delegate a task to a specialized subagent."""
 
@@ -425,7 +446,11 @@ def agent_tool(
 
     else:
 
-        @tool(parallel=can_parallel, viewer=_agent_viewer_for(single_name))
+        @tool(
+            parallel=can_parallel,
+            viewer=_agent_viewer_for(single_name),
+            max_output=SUBAGENT_RESULT_MAX_OUTPUT,
+        )
         def agent() -> Tool:  # type: ignore[no-redef]
             """Delegate a task to a specialized subagent."""
 

--- a/src/inspect_ai/agent/_deepagent/lifecycle_tools.py
+++ b/src/inspect_ai/agent/_deepagent/lifecycle_tools.py
@@ -30,6 +30,7 @@ from inspect_ai.tool._tool import Tool, tool
 from inspect_ai.tool._tool_call import ToolCall, ToolCallContent, ToolCallView
 
 from .agent_tool import (
+    SUBAGENT_RESULT_MAX_OUTPUT,
     AgentFuture,
     BackgroundRegistry,
     current_background_registry,
@@ -190,7 +191,7 @@ def _list_viewer(call: ToolCall) -> ToolCallView:
 # ---------------------------------------------------------------------------
 
 
-@tool(viewer=_status_viewer)
+@tool(viewer=_status_viewer, max_output=SUBAGENT_RESULT_MAX_OUTPUT)
 def agent_status() -> Tool:
     """Check the status of a background agent without blocking."""
 
@@ -220,7 +221,7 @@ def agent_status() -> Tool:
     return execute
 
 
-@tool(viewer=_wait_viewer)
+@tool(viewer=_wait_viewer, max_output=SUBAGENT_RESULT_MAX_OUTPUT)
 def agent_wait() -> Tool:
     """Wait for one or more background agents to complete."""
 
@@ -288,7 +289,7 @@ def agent_wait() -> Tool:
     return execute
 
 
-@tool(viewer=_cancel_viewer)
+@tool(viewer=_cancel_viewer, max_output=SUBAGENT_RESULT_MAX_OUTPUT)
 def agent_cancel() -> Tool:
     """Cancel a running background agent."""
 
@@ -329,7 +330,7 @@ def agent_cancel() -> Tool:
     return execute
 
 
-@tool(viewer=_list_viewer)
+@tool(viewer=_list_viewer, max_output=SUBAGENT_RESULT_MAX_OUTPUT)
 def agent_list() -> Tool:
     """List background agents and their statuses."""
 

--- a/src/inspect_ai/agent/_deepagent/lifecycle_tools.py
+++ b/src/inspect_ai/agent/_deepagent/lifecycle_tools.py
@@ -40,6 +40,9 @@ from .agent_tool import (
 # agent's status peek.
 _PEEK_MAX_BYTES = 2000
 
+# Maximum bytes of an errored agent's message included in a brief listing.
+_BRIEF_ERROR_MAX_BYTES = 200
+
 # Bounded wait (seconds) for an agent_cancel to settle. Cancellation is
 # cooperative, so a child stuck in a shielded or un-yielding call may not
 # stop promptly; rather than block the parent indefinitely we cap the wait
@@ -110,11 +113,50 @@ def _format_future_status(future: AgentFuture) -> str:
     return header
 
 
-def _format_many(futures: list[AgentFuture]) -> str:
-    """Join multiple agent status blocks with a separator."""
+def _format_brief(future: AgentFuture) -> str:
+    """Render one agent as a single line, without its result.
+
+    A completed agent's report can be arbitrarily large, and terminal futures
+    stay in the registry for the whole sample — so a listing that embedded
+    them would grow without bound as dispatches accumulate. That is exactly
+    backwards for the tool the model reaches for to re-orient after
+    compaction. The result is fetched one agent at a time via ``agent_status``
+    (the same split the eager completion push already uses: it announces the
+    finish and points at ``agent_status`` rather than carrying the result).
+    """
+    line = f"**{future.agent_id}** ({future.subagent_name}) — {future.status}"
+
+    if future.status == "running":
+        elapsed = max(0, int(anyio.current_time() - future.started_at))
+        message_count, tool_call_count, _ = _peek_messages(future)
+        return (
+            f"{line}; {elapsed}s, {message_count} messages "
+            f"({tool_call_count} tool calls)"
+        )
+
+    if future.status == "completed":
+        chars = len(future.result or "")
+        return (
+            f"{line}; {chars:,} chars — "
+            f"call agent_status('{future.agent_id}') to read it"
+        )
+
+    if future.status == "errored":
+        error = (future.error or "(no error detail)").splitlines()[0]
+        truncated = truncate_string_to_bytes(error, _BRIEF_ERROR_MAX_BYTES)
+        if truncated is not None:
+            error = truncated.output
+        return f"{line}; {error}"
+
+    # cancelled
+    return line
+
+
+def _format_listing(futures: list[AgentFuture]) -> str:
+    """Render a brief one-line-per-agent listing."""
     if not futures:
         return "No background agents."
-    return "\n\n---\n\n".join(_format_future_status(f) for f in futures)
+    return "\n".join(f"- {_format_brief(f)}" for f in futures)
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +372,10 @@ def agent_cancel() -> Tool:
     return execute
 
 
-@tool(viewer=_list_viewer, max_output=SUBAGENT_RESULT_MAX_OUTPUT)
+# No max_output exemption here, unlike the other three lifecycle tools: this
+# one lists *every* agent and deliberately omits their results, so it stays
+# small on its own and has no reason to opt out of the configured limit.
+@tool(viewer=_list_viewer)
 def agent_list() -> Tool:
     """List background agents and their statuses."""
 
@@ -341,9 +386,10 @@ def agent_list() -> Tool:
         """List background agents and their statuses.
 
         Returns all background agents you have dispatched (optionally
-        filtered by status), with a brief status for each. Useful for
-        recovering track of agents — for example after a long stretch of
-        work or after context compaction.
+        filtered by status), one line each. Useful for recovering track of
+        agents — for example after a long stretch of work or after context
+        compaction. Results are not included; call agent_status(agent_id)
+        to read a completed agent's output.
 
         Args:
             status_filter: Only include agents in this state. One of
@@ -357,7 +403,7 @@ def agent_list() -> Tool:
         if status_filter is not None:
             futures = [f for f in futures if f.status == status_filter]
         _note_seen_terminal(registry, futures)
-        return _format_many(futures)
+        return _format_listing(futures)
 
     return execute
 

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -170,11 +170,14 @@ def react(
         if not isinstance(submit.tool, ToolDef)
         else copy(submit.tool)
     )
-    # The submit result becomes the completion, so it must never be truncated —
-    # a truncation notice would be scored in place of the model's answer. Set
-    # here rather than on default_submit_tool so it also covers a caller-supplied
-    # submit tool; the ToolDef branch is copied above so we don't mutate theirs.
-    submit_tool.max_output = 0
+    # The submit result becomes the completion, so truncating it would score a
+    # truncation notice in place of the model's answer. Defaulted rather than
+    # forced: an explicit max_output on a caller's submit tool is their call.
+    # The copy above leaves their ToolDef alone, but note `as_tool()` writes
+    # tool attributes onto the shared underlying callable, so this (like the
+    # `name`/`description` above it) does reach a Tool they also use elsewhere.
+    if submit_tool.max_output is None:
+        submit_tool.max_output = 0
     tools.append(submit_tool)
 
     # resolve prompt / system message

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -1,3 +1,4 @@
+from copy import copy
 from logging import getLogger
 from typing import Literal, Sequence
 
@@ -167,8 +168,13 @@ def react(
             description=submit.description,
         )
         if not isinstance(submit.tool, ToolDef)
-        else submit.tool
+        else copy(submit.tool)
     )
+    # The submit result becomes the completion, so it must never be truncated —
+    # a truncation notice would be scored in place of the model's answer. Set
+    # here rather than on default_submit_tool so it also covers a caller-supplied
+    # submit tool; the ToolDef branch is copied above so we don't mutate theirs.
+    submit_tool.max_output = 0
     tools.append(submit_tool)
 
     # resolve prompt / system message

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -294,7 +294,9 @@ async def _execute_tools_impl(
 
                 # truncate if necessary
                 truncated_output = truncate_tool_output(
-                    call.function, content, max_output
+                    call.function,
+                    content,
+                    _tool_max_output(tdefs, call.function, max_output),
                 )
                 if truncated_output:
                     content = truncated_output.output
@@ -910,6 +912,7 @@ async def prepare_tools(
                 parallel=fields.parallel,
                 viewer=fields.viewer,
                 model_input=fields.model_input,
+                max_output=fields.max_output,
                 options=fields.options,
             )
             tdefs.append(tdef)
@@ -1131,6 +1134,29 @@ def validate_tool_input(input: dict[str, Any], parameters: ToolParams) -> str | 
         return message
     else:
         return None
+
+
+def _tool_max_output(
+    tdefs: list[ToolDef], tool_name: str, max_output: int | None
+) -> int | None:
+    """Resolve the output limit for a tool call.
+
+    A tool that declares its own `max_output` is making a claim about its
+    result (e.g. `submit()`, whose result becomes the agent's completion, and
+    the deep agent's `agent()`, whose result is a subagent's report), so that
+    declaration wins over the caller/generate config value.
+
+    Args:
+        tdefs: Tool definitions in scope for this execution.
+        tool_name: Name of the called tool (unresolved names fall back to
+            `max_output`).
+        max_output: Limit passed to `execute_tools()` (None defers to the
+            active `GenerateConfig`).
+    """
+    tdef = next((tdef for tdef in tdefs if tdef.name == tool_name), None)
+    if tdef is not None and tdef.max_output is not None:
+        return tdef.max_output
+    return max_output
 
 
 class TruncatedToolOutput(NamedTuple):

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -137,8 +137,9 @@ def basic_agent(
     # resolve score_value function
     score_value_fn = score_value or value_to_float()
 
-    # submission tool
-    @tool
+    # submission tool (max_output=0 because the submitted answer becomes the
+    # completion -- truncating it would score a truncation notice instead)
+    @tool(max_output=0)
     def submit() -> Tool:
         async def execute(answer: str) -> ToolResult:
             """Submit an answer for evaluation.

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -207,6 +207,8 @@ def tool(
             return execute
         ```
     """
+    validate_tool_max_output(max_output)
+
     if prompt:
         from inspect_ai._util.logger import warn_once
 
@@ -311,6 +313,20 @@ def tool_result_content(
             ):
                 result.append(c)
         return result
+
+
+def validate_tool_max_output(max_output: int | None) -> None:
+    """Reject a negative tool output limit.
+
+    `truncate_string_to_bytes` short-circuits on `max_bytes <= 0`, so a
+    negative value would silently disable truncation rather than cap it —
+    the opposite of what a typo'd or computed-negative value intends.
+    """
+    if max_output is not None and max_output < 0:
+        raise ValueError(
+            f"max_output must be 0 (no truncation) or a positive number of "
+            f"bytes (got {max_output})."
+        )
 
 
 TOOL_PROMPT = "prompt"

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -157,6 +157,7 @@ def tool(
     viewer: ToolCallViewer | None = None,
     model_input: ToolCallModelInput | None = None,
     parallel: bool | None = None,
+    max_output: int | None = None,
     prompt: str | None = None,
 ) -> Callable[[Callable[P, Tool]], Callable[P, Tool]]: ...
 
@@ -168,6 +169,7 @@ def tool(
     viewer: ToolCallViewer | None = None,
     model_input: ToolCallModelInput | None = None,
     parallel: bool | None = None,
+    max_output: int | None = None,
     prompt: str | None = None,
 ) -> Callable[P, Tool] | Callable[[Callable[P, Tool]], Callable[P, Tool]]:
     r"""Decorator for registering tools.
@@ -183,6 +185,11 @@ def tool(
             the same assistant message? Defaults to `False` (opt-in). Set
             `True` only after auditing the tool for concurrent-safety (no
             shared `Store`/sandbox mutations, no order-dependent side effects).
+        max_output: Maximum size (in bytes) of this tool's result before it is
+            truncated. `None` (the default) defers to `max_tool_output` in the
+            active `GenerateConfig` (16KB by default); `0` disables truncation
+            for this tool. A value specified here takes precedence over the
+            generate config.
         prompt: Deprecated (provide all descriptive information about
             the tool within the tool function's doc comment)
 
@@ -229,20 +236,21 @@ def tool(
             tool_parallel: bool = parallel is True
             tool_viewer = viewer
             tool_model_input = model_input
+            tool_max_output = max_output
             tool_options: dict[str, object] | None = None
             if is_registry_object(tool):
-                _, _, reg_parallel, reg_viewer, reg_model_input, options = (
-                    tool_registry_info(tool)
-                )
+                reg = tool_registry_info(tool)
                 # An unspecified outer (None) inherits the inner tool's
                 # declaration; an explicit outer value overrides.
                 if parallel is None:
-                    tool_parallel = reg_parallel
+                    tool_parallel = reg.parallel
                 else:
                     tool_parallel = parallel
-                tool_viewer = viewer or reg_viewer
-                tool_model_input = model_input or reg_model_input
-                tool_options = options
+                tool_viewer = viewer or reg.viewer
+                tool_model_input = model_input or reg.model_input
+                if max_output is None:
+                    tool_max_output = reg.max_output
+                tool_options = reg.options
 
             # tag the object
             registry_tag(
@@ -259,6 +267,7 @@ def tool(
                             tool_model_input
                             or getattr(tool, TOOL_INIT_MODEL_INPUT, None)
                         ),
+                        TOOL_MAX_OUTPUT: tool_max_output,
                         TOOL_OPTIONS: tool_options,
                     },
                 ),
@@ -308,6 +317,7 @@ TOOL_PROMPT = "prompt"
 TOOL_PARALLEL = "parallel"
 TOOL_VIEWER = "viewer"
 TOOL_MODEL_INPUT = "model_input"
+TOOL_MAX_OUTPUT = "max_output"
 TOOL_OPTIONS = "options"
 
 

--- a/src/inspect_ai/tool/_tool_def.py
+++ b/src/inspect_ai/tool/_tool_def.py
@@ -22,6 +22,7 @@ from ._tool import (
     TOOL_VIEWER,
     Tool,
     ToolSource,
+    validate_tool_max_output,
 )
 from ._tool_call import ToolCallModelInput, ToolCallViewer
 from ._tool_description import (
@@ -73,6 +74,8 @@ class ToolDef:
         Returns:
           Tool definition.
         """
+        validate_tool_max_output(max_output)
+
         # tool
         self.tool = tool
 

--- a/src/inspect_ai/tool/_tool_def.py
+++ b/src/inspect_ai/tool/_tool_def.py
@@ -14,6 +14,7 @@ from inspect_ai._util.registry import (
 )
 
 from ._tool import (
+    TOOL_MAX_OUTPUT,
     TOOL_MODEL_INPUT,
     TOOL_OPTIONS,
     TOOL_PARALLEL,
@@ -44,6 +45,7 @@ class ToolDef:
         parallel: bool | None = None,
         viewer: ToolCallViewer | None = None,
         model_input: ToolCallModelInput | None = None,
+        max_output: int | None = None,
         options: dict[str, object] | None = None,
     ) -> None:
         """Create a tool definition.
@@ -60,6 +62,11 @@ class ToolDef:
           viewer: Optional tool call viewer implementation.
           model_input: Optional function that determines how
               tool call results are played back as model input.
+          max_output: Maximum size (in bytes) of this tool's result before it
+              is truncated. `None` (the default) defers to `max_tool_output`
+              in the active `GenerateConfig` (16KB by default); `0` disables
+              truncation for this tool. A value specified here takes
+              precedence over the generate config.
           options: Optional property bag that can be used by the model provider
               to customize the implementation of the tool
 
@@ -84,6 +91,7 @@ class ToolDef:
             self.parallel = parallel if parallel is not None else tdef.parallel
             self.viewer = viewer or tdef.viewer
             self.model_input = model_input or tdef.model_input
+            self.max_output = max_output if max_output is not None else tdef.max_output
             self.options = options or tdef.options
 
         # if its not a tool then extract tool_info if all fields have not
@@ -115,6 +123,7 @@ class ToolDef:
             self.parallel = parallel is True
             self.viewer = viewer
             self.model_input = model_input
+            self.max_output = max_output
             self.options = options
 
     tool: Callable[..., Any]
@@ -138,6 +147,12 @@ class ToolDef:
     model_input: ToolCallModelInput | None
     """Custom model input presenter for tool calls."""
 
+    max_output: int | None = None
+    """Maximum size (in bytes) of tool result before truncation.
+
+    `None` defers to `max_tool_output` in the active `GenerateConfig`
+    (16KB by default); `0` disables truncation for this tool."""
+
     options: dict[str, object] | None = None
     """Optional property bag that can be used by the model provider to customize the implementation of the tool"""
 
@@ -150,6 +165,7 @@ class ToolDef:
             metadata={
                 TOOL_PARALLEL: self.parallel,
                 TOOL_VIEWER: self.viewer,
+                TOOL_MAX_OUTPUT: self.max_output,
                 TOOL_OPTIONS: self.options,
             },
         )
@@ -200,12 +216,14 @@ class ToolDefFields(NamedTuple):
     parallel: bool
     viewer: ToolCallViewer | None
     model_input: ToolCallModelInput | None
+    max_output: int | None
     options: dict[str, object] | None
 
 
 def tool_def_fields(tool: Tool) -> ToolDefFields:
     # get tool_info
-    name, prompt, parallel, viewer, model_input, options = tool_registry_info(tool)
+    reg = tool_registry_info(tool)
+    name, prompt = reg.name, reg.prompt
     tool_info = _parse_tool_info_shared(tool)
 
     # if there is a description then append any prompt to the
@@ -247,31 +265,35 @@ def tool_def_fields(tool: Tool) -> ToolDefFields:
         name=name,
         description=description,
         parameters=parameters,
-        parallel=parallel,
-        viewer=viewer,
-        model_input=model_input,
-        options=options,
+        parallel=reg.parallel,
+        viewer=reg.viewer,
+        model_input=reg.model_input,
+        max_output=reg.max_output,
+        options=reg.options,
     )
 
 
-def tool_registry_info(
-    tool: Tool,
-) -> tuple[
-    str,
-    str | None,
-    bool,
-    ToolCallViewer | None,
-    ToolCallModelInput | None,
-    dict[str, object] | None,
-]:
+class ToolRegistryInfo(NamedTuple):
+    name: str
+    prompt: str | None
+    parallel: bool
+    viewer: ToolCallViewer | None
+    model_input: ToolCallModelInput | None
+    max_output: int | None
+    options: dict[str, object] | None
+
+
+def tool_registry_info(tool: Tool) -> ToolRegistryInfo:
     info = registry_info(tool)
-    name = info.name.split("/")[-1]
-    prompt = info.metadata.get(TOOL_PROMPT, None)
-    parallel = info.metadata.get(TOOL_PARALLEL, False)
-    viewer = info.metadata.get(TOOL_VIEWER, None)
-    model_input = info.metadata.get(TOOL_MODEL_INPUT, None)
-    options = info.metadata.get(TOOL_OPTIONS, None)
-    return name, prompt, parallel, viewer, model_input, options
+    return ToolRegistryInfo(
+        name=info.name.split("/")[-1],
+        prompt=info.metadata.get(TOOL_PROMPT, None),
+        parallel=info.metadata.get(TOOL_PARALLEL, False),
+        viewer=info.metadata.get(TOOL_VIEWER, None),
+        model_input=info.metadata.get(TOOL_MODEL_INPUT, None),
+        max_output=info.metadata.get(TOOL_MAX_OUTPUT, None),
+        options=info.metadata.get(TOOL_OPTIONS, None),
+    )
 
 
 def validate_tool_parameters(tool_name: str, parameters: dict[str, ToolParam]) -> None:

--- a/tests/agent/deepagent/test_agent_tool.py
+++ b/tests/agent/deepagent/test_agent_tool.py
@@ -102,6 +102,56 @@ class TestAgentToolDispatch:
         assert tool_event is not None
         assert tool_event.function == "agent"
 
+    def test_long_result_not_truncated(self) -> None:
+        """A subagent report over max_tool_output comes back whole.
+
+        It used to be truncated twice: execute_tools clipped the child's
+        submit() result, react read the clipped text back as the completion,
+        and the parent's execute_tools clipped that again -- so the parent saw
+        one truncation notice nested inside another.
+        """
+        report = "R" * (32 * 1024)  # double the 16KB default max_tool_output
+        sa = _test_subagent("research", "Read-only information gathering.")
+        tt = agent_tool(subagents=[sa])
+
+        task = Task(
+            dataset=[Sample(input="Do some research")],
+            solver=[use_tools(tt), generate()],
+            message_limit=10,
+        )
+
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="agent",
+                    tool_arguments={"prompt": "Find relevant information."},
+                ),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": report},
+                ),
+                ModelOutput.from_content("mockllm/model", "Done"),
+            ],
+        )
+
+        log = eval(task, model=model)[0]
+        assert log.status == "success"
+
+        tool_event = get_tool_event(log)
+        assert tool_event is not None
+        assert tool_event.function == "agent"
+        assert tool_event.truncated is None
+        assert tool_event.result == report
+
+        assert log.samples
+        assert not any(
+            "too long to be displayed" in message.text
+            for message in log.samples[0].messages
+        )
+
     def test_invalid_subagent_type(self) -> None:
         # TWO subagents on purpose: `subagent_type` only exists when there is a genuine
         # choice, so a single-subagent tool would reject this call as an unknown PARAMETER

--- a/tests/agent/deepagent/test_deepagent_background.py
+++ b/tests/agent/deepagent/test_deepagent_background.py
@@ -1205,6 +1205,43 @@ class TestAgentList:
         assert "AGENT-2" in body
         assert "AGENT-1" not in body
 
+    def test_list_omits_results_and_stays_brief(self) -> None:
+        """agent_list must not embed reports — it is the re-orientation tool.
+
+        Completed futures stay in the registry for the whole sample, so a
+        listing that embedded their reports would grow without bound as
+        dispatches accumulate. agent_status is the retrieval path.
+        """
+        report_a = "A" * 40_000
+        report_b = "B" * 40_000
+        result = _eval_deepagent(
+            agent_kwargs={
+                "subagents": [
+                    _build_submit_subagent("alpha", report_a),
+                    _build_submit_subagent("beta", report_b),
+                ]
+            },
+            outputs=[
+                _agent_call("alpha"),
+                _agent_call("beta"),
+                _tool_call("agent_wait", agent_ids=["AGENT-1", "AGENT-2"]),
+                _tool_call("agent_list"),
+                _tool_call("agent_status", agent_id="AGENT-1"),
+                _submit("done"),
+            ],
+        )
+
+        listing = str(_events_for(result, "agent_list")[0].result)
+        assert "AGENT-1" in listing and "AGENT-2" in listing
+        assert report_a not in listing and report_b not in listing
+        # brief means brief, whatever the reports weigh
+        assert len(listing) < 1000
+        assert "agent_status" in listing  # points at the retrieval path
+
+        # ...and the retrieval path still returns the report whole
+        status = str(_events_for(result, "agent_status")[0].result)
+        assert report_a in status
+
 
 class TestFormatStatusUnit:
     """Unit tests for _format_future_status / _peek_messages."""

--- a/tests/agent/test_agent_execute.py
+++ b/tests/agent/test_agent_execute.py
@@ -187,6 +187,12 @@ def test_agent_as_tool():
     check_agent_as_tool(as_tool)
 
 
+def test_agent_as_tool_result_not_truncated():
+    # the agent's report is the payload the caller asked for, so it is exempt
+    # from max_tool_output (0 disables truncation)
+    assert ToolDef(as_tool(web_surfer())).max_output == 0
+
+
 def test_agent_as_tool_curry():
     check_agent_as_tool_curry(as_tool)
 

--- a/tests/agent/test_agent_execute.py
+++ b/tests/agent/test_agent_execute.py
@@ -193,6 +193,12 @@ def test_agent_as_tool_result_not_truncated():
     assert ToolDef(as_tool(web_surfer())).max_output == 0
 
 
+def test_agent_as_tool_max_output_overridable():
+    # callers who do want a cap can ask for one
+    assert ToolDef(as_tool(web_surfer(), max_output=2048)).max_output == 2048
+    assert ToolDef(as_tool(web_surfer(), max_output=None)).max_output is None
+
+
 def test_agent_as_tool_curry():
     check_agent_as_tool_curry(as_tool)
 

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -17,7 +17,12 @@ from inspect_ai.agent._types import (
 )
 from inspect_ai.dataset import Sample
 from inspect_ai.log import EvalLog
-from inspect_ai.model import ChatMessageUser, ModelOutput, get_model
+from inspect_ai.model import (
+    ChatMessageUser,
+    GenerateConfig,
+    ModelOutput,
+    get_model,
+)
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -268,6 +273,61 @@ def check_custom_submit(log: EvalLog, name: str, description: str) -> None:
 
 def addition_dataset() -> list[Sample]:
     return [Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])]
+
+
+def test_react_agent_long_submission_not_truncated() -> None:
+    """A submitted answer larger than max_tool_output reaches the completion intact.
+
+    The submit result is the scored answer, not model-facing tool output, so
+    clipping it would score a truncation notice in place of what the model
+    actually wrote.
+    """
+    answer = "A" * 2000
+    log = eval(
+        Task(
+            dataset=addition_dataset(),
+            solver=react(),
+            config=GenerateConfig(max_tool_output=100),
+        ),
+        model=mockllm_model_with_submissions([answer]),
+    )[0]
+    assert log.status == "success"
+    assert log.samples
+    # answer_only is False by default, so the answer is appended to the
+    # content the model generated alongside the submit call
+    assert log.samples[0].output.completion.endswith(answer)
+
+
+def test_react_agent_custom_submit_tool_long_submission_not_truncated() -> None:
+    """The exemption follows a caller-supplied submit ToolDef too."""
+
+    @tool
+    def custom_submit():
+        async def execute(answer: str) -> str:
+            """The tool used to submit.
+
+            Args:
+                answer: The submitted answer.
+            """
+            return answer
+
+        return execute
+
+    answer = "B" * 2000
+    submit_tool = ToolDef(custom_submit(), name="submit")
+    log = eval(
+        Task(
+            dataset=addition_dataset(),
+            solver=react(submit=AgentSubmit(tool=submit_tool)),
+            config=GenerateConfig(max_tool_output=100),
+        ),
+        model=mockllm_model_with_submissions([answer]),
+    )[0]
+    assert log.status == "success"
+    assert log.samples
+    assert log.samples[0].output.completion.endswith(answer)
+    # the caller's ToolDef is copied before the exemption is applied
+    assert submit_tool.max_output is None
 
 
 def test_react_agent_no_submit() -> None:

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -298,24 +298,21 @@ def test_react_agent_long_submission_not_truncated() -> None:
     assert log.samples[0].output.completion.endswith(answer)
 
 
-def test_react_agent_custom_submit_tool_long_submission_not_truncated() -> None:
-    """The exemption follows a caller-supplied submit ToolDef too."""
+@tool
+def custom_submit_tool():
+    async def execute(answer: str) -> str:
+        """The tool used to submit.
 
-    @tool
-    def custom_submit():
-        async def execute(answer: str) -> str:
-            """The tool used to submit.
+        Args:
+            answer: The submitted answer.
+        """
+        return answer
 
-            Args:
-                answer: The submitted answer.
-            """
-            return answer
+    return execute
 
-        return execute
 
-    answer = "B" * 2000
-    submit_tool = ToolDef(custom_submit(), name="submit")
-    log = eval(
+def _run_custom_submit(answer: str, submit_tool: ToolDef) -> EvalLog:
+    return eval(
         Task(
             dataset=addition_dataset(),
             solver=react(submit=AgentSubmit(tool=submit_tool)),
@@ -323,11 +320,33 @@ def test_react_agent_custom_submit_tool_long_submission_not_truncated() -> None:
         ),
         model=mockllm_model_with_submissions([answer]),
     )[0]
+
+
+def test_react_agent_custom_submit_tool_long_submission_not_truncated() -> None:
+    """The exemption is defaulted onto a caller-supplied submit ToolDef too."""
+    answer = "B" * 2000
+    log = _run_custom_submit(answer, ToolDef(custom_submit_tool(), name="submit"))
     assert log.status == "success"
     assert log.samples
     assert log.samples[0].output.completion.endswith(answer)
-    # the caller's ToolDef is copied before the exemption is applied
-    assert submit_tool.max_output is None
+
+
+def test_react_agent_custom_submit_tool_explicit_max_output_respected() -> None:
+    """React defaults the submit exemption but never overrides an explicit one.
+
+    Truncating a submission is normally a bug (the notice gets scored in place
+    of the answer), but a caller who asks for a cap on their own submit tool
+    gets it.
+    """
+    answer = "C" * 2000
+    log = _run_custom_submit(
+        answer, ToolDef(custom_submit_tool(), name="submit", max_output=500)
+    )
+    assert log.status == "success"
+    assert log.samples
+    completion = log.samples[0].output.completion
+    assert answer not in completion
+    assert len(completion) < len(answer)
 
 
 def test_react_agent_no_submit() -> None:

--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -147,10 +147,10 @@ def test_bash_default_description_unchanged() -> None:
     assert info.description == "Use this function to execute bash commands."
 
     # the model-facing name comes from the registry, not the raw function name
-    name, _, parallel, viewer, _, _ = tool_registry_info(bash())
-    assert name == "bash"
-    assert parallel is True
-    assert viewer is not None
+    reg = tool_registry_info(bash())
+    assert reg.name == "bash"
+    assert reg.parallel is True
+    assert reg.viewer is not None
 
 
 def test_bash_background_guidance() -> None:
@@ -169,10 +169,10 @@ def test_bash_background_guidance() -> None:
     )
 
     # viewer and parallel survive the ToolDef wrap
-    name, _, parallel, viewer, _, _ = tool_registry_info(bash(background=True))
-    assert name == "bash"
-    assert parallel is True
-    assert viewer is not None
+    reg = tool_registry_info(bash(background=True))
+    assert reg.name == "bash"
+    assert reg.parallel is True
+    assert reg.viewer is not None
 
 
 def test_bash_background_timeout_templated() -> None:

--- a/tests/tools/test_max_tool_output.py
+++ b/tests/tools/test_max_tool_output.py
@@ -77,6 +77,85 @@ def test_max_tool_output():
     check_log(log, 10, False)
 
 
+def test_per_tool_max_output():
+    """A tool's own `max_output` takes precedence over the generate config."""
+
+    @tool(max_output=0)
+    def unlimited():
+        async def execute():
+            """
+            Generate some output that must never be truncated
+
+            Returns:
+                The output
+            """
+            return "x" * 20
+
+        return execute
+
+    @tool(max_output=8)
+    def capped():
+        async def execute():
+            """
+            Generate some output truncated at the tool's own limit
+
+            Returns:
+                The output
+            """
+            return "x" * 20
+
+        return execute
+
+    @tool
+    def inherits():
+        async def execute():
+            """
+            Generate some output truncated at the config limit
+
+            Returns:
+                The output
+            """
+            return "x" * 20
+
+        return execute
+
+    tool_names = ["unlimited", "capped", "inherits"]
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model", tool_name=name, tool_arguments={}
+            )
+            for name in tool_names
+        ]
+        + [ModelOutput.from_content(model="mockllm/model", content="done")],
+    )
+
+    log = eval(
+        Task(
+            dataset=[Sample(input="Please call each of the tools in turn.")],
+            solver=[use_tools(unlimited(), capped(), inherits()), generate()],
+            config=GenerateConfig(max_tool_output=5),
+        ),
+        model,
+    )[0]
+
+    assert log.samples
+    messages = log.samples[0].messages
+    results = {}
+    for name in tool_names:
+        call = get_tool_call(messages, name)
+        assert call
+        response = get_tool_response(messages, call)
+        assert response
+        results[name] = response.content
+
+    assert results["unlimited"] == "x" * 20
+    # middle truncation preserves the head and tail around a newline
+    assert f"\n{'x' * 8}\n" in results["capped"]
+    assert f"\n{'x' * 5}\n" in results["inherits"]
+
+
 def test_truncate_str_no_truncation_needed():
     """Test that truncate_str returns None when input fits within limit."""
     result = truncate_str("hello", 10)

--- a/tests/tools/test_tool_def.py
+++ b/tests/tools/test_tool_def.py
@@ -1,3 +1,5 @@
+import pytest
+
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
@@ -104,3 +106,25 @@ def test_tool_max_output_declaration_inherited_by_outer_tool() -> None:
     assert ToolDef(inner()).max_output == 0
     assert ToolDef(outer()).max_output == 0
     assert ToolDef(overriding()).max_output == 64
+
+
+def test_negative_max_output_rejected() -> None:
+    # a negative value would silently disable truncation (truncate_string_to_bytes
+    # short-circuits on max_bytes <= 0) rather than cap it, so reject it up front
+    async def noop(x: int) -> int:
+        return x
+
+    with pytest.raises(ValueError, match="max_output must be"):
+
+        @tool(max_output=-1)
+        def bad():
+            return noop
+
+    with pytest.raises(ValueError, match="max_output must be"):
+        ToolDef(
+            tool=noop,
+            name="noop",
+            description="Noop",
+            parameters={"x": "Integer"},
+            max_output=-1,
+        )

--- a/tests/tools/test_tool_def.py
+++ b/tests/tools/test_tool_def.py
@@ -62,3 +62,45 @@ def test_tool_def_does_not_duplicate_prompt_text() -> None:
 
     assert first.description == second.description
     assert second.description.count("Use this tool when addition is required.") == 1
+
+
+def test_tool_def_max_output_round_trips() -> None:
+    async def addition(x: int, y: int):
+        return x + y
+
+    tool_def = ToolDef(
+        tool=addition,
+        name="addition",
+        description="Add two numbers",
+        parameters={"x": "Integer", "y": "Integer"},
+        max_output=0,
+    )
+    assert ToolDef(tool_def.as_tool()).max_output == 0
+
+
+def test_tool_max_output_declaration_inherited_by_outer_tool() -> None:
+    @tool(max_output=0)
+    def inner():
+        async def execute(x: int) -> int:
+            """Echo an integer.
+
+            Args:
+                x: The integer.
+            """
+            return x
+
+        return execute
+
+    # an unspecified outer max_output inherits the inner declaration
+    @tool
+    def outer():
+        return inner()
+
+    # an explicit outer max_output overrides it
+    @tool(max_output=64)
+    def overriding():
+        return inner()
+
+    assert ToolDef(inner()).max_output == 0
+    assert ToolDef(outer()).max_output == 0
+    assert ToolDef(overriding()).max_output == 64


### PR DESCRIPTION
### What is the current behavior? (You can also link to an open issue here)

A user running `deepagent()` reported that subagent reports frequently came back to the parent agent as a truncation notice rather than as the report — and, oddly, that the truncation appeared to happen *twice*. What they saw in the log viewer:

```
SUB-AGENT: RESEARCH

The output of your call to agent was too long to be displayed.
Here is a truncated version:
<START_TOOL_OUTPUT>

The output of your call to submit was too long to be displayed.
Here is a truncated version:
<START_TOOL_OUTPUT>
```

The nesting is the tell. `_execute_tools_impl` (`src/inspect_ai/model/_call_tools.py`) truncated *every* string tool result at `max_tool_output` (16KB by default), with no notion of a tool whose result is a control value rather than model-facing text. The `submit()` tool is exactly such a tool, so:

1. The subagent's model called `submit(answer=<long report>)`. `execute_tools` clipped the returned answer and wrapped it in the notice above.
2. `react()`'s `submission()` helper read that **post-truncation** `ChatMessageTool.text` and assigned it to `state.output.completion`.
3. The deep agent's `agent()` tool returned that string to the parent via `_extract_result()`.
4. The parent's `execute_tools` clipped it a second time — producing one notice nested inside another.

Truncating `submit()` is a bug in its own right, and not specific to deep agents: **any** `react()` or `basic_agent()` whose model produced an answer larger than `max_tool_output` had a truncation notice stored as `state.output.completion` — and therefore *scored* — in place of the model's actual answer. `as_tool()` had the same defect for its agent's report, and inconsistently: an agent whose final message content was a plain string was truncated, while one returning structured content already bypassed truncation entirely.

### What is the new behavior?

Tools can declare their own output limit, and it is set to "no limit" on the tools whose result is a payload the caller depends on in full.

**New per-tool declaration.** `@tool(max_output=...)` and `ToolDef(max_output=...)`:

- `None` (the default) — inherit, i.e. the `execute_tools(max_output=…)` argument, then `GenerateConfig.max_tool_output`, then 16KB.
- `0` — never truncate. This reuses the semantics `max_tool_output=0` already had (`truncate_string_to_bytes(s, 0)` returns `None`); it is not a new sentinel.
- `>0` — cap this tool's result at that many bytes.

A tool-level value takes precedence over the generate config, because the tool is making a semantic claim about its own result. Resolution happens in `_tool_max_output()` in `_call_tools.py`, which looks the call's `ToolDef` up in the same way `call_tool()` does and falls back to the caller/config value for unresolved names.

**Applied with `max_output=0` to:**

| Tool | Why |
|---|---|
| `submit()` in `react()` | Its result *is* `state.output.completion` — the scored answer |
| `submit()` in `basic_agent()` | Same |
| `agent()` in `deepagent()` (all four schema variants) | The subagent's report is the payload of the delegation |
| `agent_status()`, `agent_wait()`, `agent_cancel()`, `agent_list()` | They echo the same subagent results; `agent_wait()` joins several at once |
| `as_tool()` | An agent-as-tool's response is likewise the payload the caller asked for |

For `react()` the exemption is set on the *resolved* `ToolDef` rather than on the built-in submit tool, so it also covers a caller-supplied `AgentSubmit.tool`. When the caller supplies a `ToolDef`, it is shallow-copied first so their object is not mutated.

In practice these results stay bounded by the subagent model's own `max_tokens` — the model has to generate the report. `Subagent.limits` (e.g. `token_limit()`) remains the lever for bounding how much work a subagent does.

**Supporting refactor.** `tool_registry_info()` returned a bare 6-tuple that was unpacked positionally in two places in `src` and two in `tests`. Rather than grow it to a 7-tuple — exactly the failure mode AGENTS.md's "prefer a `NamedTuple` over a bare tuple" guidance warns about — it now returns a `ToolRegistryInfo` NamedTuple, and the call sites use attribute access.

**Docs.** A new "Output Size" section in `docs/tools-custom.qmd` documents `max_output` and is explicit that `0` is for tools whose result is a payload the caller depends on in full — not for tools that read files, run commands, or fetch pages, where an unbounded result can flood the context window. `docs/deepagent.qmd` notes that subagent reports are exempt from `max_tool_output`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No user-facing breaking change; no API is removed or renamed. Two behavior changes are worth calling out explicitly, since both mean these tools now return more text than before:

- A `submit()` answer, a deep agent subagent report, and an `as_tool()` agent response are no longer bounded by `max_tool_output`. An eval that was (knowingly or not) relying on that 16KB bound to cap context growth will now see the full text. This is the point of the change — the previous behavior substituted a truncation notice for the content — but it is a real change in the number of tokens these paths can put into a parent's context.
- `tool_registry_info()` is private (`inspect_ai.tool._tool_def`), but its return type changed from a 6-tuple to a 7-field `ToolRegistryInfo` NamedTuple. Attribute access and iteration still work; a positional unpack of exactly six names does not. Out-of-tree code destructuring it would need updating.

### Other information:

**Verification**

- `pytest tests/tools tests/agent tests/solver` — 2090 passed, 1739 skipped.
- `ruff format`, `ruff check`, and `mypy --exclude tests/test_package src tests` all clean.
- New tests:
  - `tests/tools/test_max_tool_output.py::test_per_tool_max_output` — in one eval with `max_tool_output=5`, a `@tool(max_output=0)` tool is untruncated, a `@tool(max_output=8)` tool truncates at 8, and a plain tool still truncates at the config's 5.
  - `tests/tools/test_tool_def.py` — `max_output` round-trips `ToolDef` → `as_tool()` → `ToolDef`, and an unspecified outer `@tool` inherits an inner tool's declaration while an explicit outer value overrides it.
  - `tests/agent/test_agent_react.py` — a >`max_tool_output` submission reaches the completion intact, for both the default submit tool and a caller-supplied `ToolDef` (which is also asserted not to have been mutated).
  - `tests/agent/deepagent/test_agent_tool.py::TestAgentToolDispatch::test_long_result_not_truncated` — the reported regression end-to-end: a 32KB subagent report arrives whole, with zero occurrences of `"too long to be displayed"` anywhere in the message list.
- The deep agent regression test was confirmed to actually catch the bug: with the fix temporarily reverted it fails with `truncated=(16517, 16384)` — the 16517 raw bytes being the already-truncated-once inner payload, i.e. the double truncation itself.
- **Live end-to-end**, against `anthropic/claude-sonnet-4-5`: a `deepagent()` delegated a long report to its `research()` subagent. The `agent()` tool result reached the parent at **82,473 bytes** with zero truncation notices anywhere in the conversation. Before this change that path capped at 16KB.

**Scope note for reviewers**

The `as_tool()` change goes marginally beyond the reported deep-agent bug, onto a broadly used public API. It is included because it is the identical defect (an agent's report clipped on its way to the caller) and because it removes the existing string-vs-structured-content inconsistency described above. It is a one-line change and easy to drop if you would rather keep this PR to deep agents and `submit()`.

`tool_with()` is deliberately unmodified: it shallow-copies `registry_info(tool)`, so a `@tool(max_output=…)` declaration already survives it (this is what makes `basic_agent`'s `tool_with(submit(), …)` work). Its pre-existing `elif` chain bug at `_tool_with.py:62-67` — where `viewer` and `model_input` are silently ignored whenever `parallel` is passed — is a separate issue and was left alone.


