### PR TITLE
store_as(strict=True): raise a clear error when stored data doesn't match the declared field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Mistral: Requests are no longer capped at the SDK's flat 5s timeout, which cut off generations that took longer.
 - Hugging Face: Chat templates that use dict methods (e.g. Gemma's `message.get(...)`) no longer fail with a Jinja `UndefinedError`.
 - Sandbox: When remote exec polling exhausts its retries, the error now names the sandbox's actual failure instead of an opaque tenacity RetryError.
+- Store: `StoreModel` subclasses can set `strict_coercion = True` to raise a clear error, rather than silently return the raw value, when a stored value fails field validation.
 
 ## 0.3.260 (21 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 - Mistral: Requests are no longer capped at the SDK's flat 5s timeout, which cut off generations that took longer.
 - Hugging Face: Chat templates that use dict methods (e.g. Gemma's `message.get(...)`) no longer fail with a Jinja `UndefinedError`.
 - Sandbox: When remote exec polling exhausts its retries, the error now names the sandbox's actual failure instead of an opaque tenacity RetryError.
-- Store: `StoreModel` subclasses can set `strict_coercion = True` to raise a clear error, rather than silently return the raw value, when a stored value fails field validation.
+- Store: `store_as()` accepts `strict=True` to raise a clear error, rather than silently return the raw value, when a stored value fails field validation.
 
 ## 0.3.260 (21 August 2026)
 

--- a/docs/_store_typing.md
+++ b/docs/_store_typing.md
@@ -52,6 +52,20 @@ blue_activity = state.store_as(Activity, instance="blue_team")
 ```
 
 
+#### Strict Coercion
+
+The `Store` is shared and untyped, so a value read through your model may not actually match the declared field type (for example, if other code wrote a different shape to the same key, or a log was written with an older version of your model). By default, a stored value that fails validation against the declared field type is returned as-is, and it is up to you to check its type. If you would rather fail fast, set `strict_coercion = True` on your model to raise an error (naming the store key, declared type, and actual value type) whenever a stored value fails validation:
+
+```python
+class Activity(StoreModel):
+    strict_coercion = True
+
+    active: bool = Field(default=False)
+    tries: int = Field(default=0)
+```
+
+Note that `strict_coercion` must be assigned without a type annotation (it is a class setting, not a model field). Validation uses Pydantic's default (lax) mode, so stored values that Pydantic can coerce to the declared type (e.g. `"5"` for an `int` field) are converted rather than rejected. Fields whose declared types Pydantic cannot validate (e.g. arbitrary types) are always returned as-is.
+
 #### Explicit Store
 
 The `store_as()` function automatically binds to the current sample `Store`. You can alternatively create an explicit `Store` and pass it directly to the model (e.g. for testing purposes):

--- a/docs/_store_typing.md
+++ b/docs/_store_typing.md
@@ -52,20 +52,6 @@ blue_activity = state.store_as(Activity, instance="blue_team")
 ```
 
 
-#### Strict Coercion
-
-The `Store` is shared and untyped, so a value read through your model may not actually match the declared field type (for example, if other code wrote a different shape to the same key, or a log was written with an older version of your model). By default, a stored value that fails validation against the declared field type is returned as-is, and it is up to you to check its type. If you would rather fail fast, set `strict_coercion = True` on your model to raise an error (naming the store key, declared type, and actual value type) whenever a stored value fails validation:
-
-```python
-class Activity(StoreModel):
-    strict_coercion = True
-
-    active: bool = Field(default=False)
-    tries: int = Field(default=0)
-```
-
-Note that `strict_coercion` must be assigned without a type annotation (it is a class setting, not a model field). Validation uses Pydantic's default (lax) mode, so stored values that Pydantic can coerce to the declared type (e.g. `"5"` for an `int` field) are converted rather than rejected. Fields whose declared types Pydantic cannot validate (e.g. arbitrary types) are always returned as-is.
-
 #### Explicit Store
 
 The `store_as()` function automatically binds to the current sample `Store`. You can alternatively create an explicit `Store` and pass it directly to the model (e.g. for testing purposes):

--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -228,6 +228,16 @@ from inspect_ai.util import store_as
 activity = store_as(Activity)
 ```
 
+### Strict Reads
+
+The `Store` is shared and untyped, so a value read through your model may not actually match the declared field type (for example, if other code wrote a different shape to the same key). By default, a stored value that fails validation against the declared field type is returned as-is, and it is up to you to check its type. If you would rather fail fast, pass `strict=True` to `store_as()` to get a model instance whose reads raise an error (naming the store key, declared type, and actual value type) whenever a stored value fails validation:
+
+``` python
+activity = store_as(Activity, strict=True)
+```
+
+Values already in the store are validated when `store_as()` is called; values written afterwards are validated when read. Strictness is a property of the returned instance, so live reads (e.g. in a solver or scorer) and reads of the same model from historical logs can use different settings. Validation uses Pydantic's default (lax) mode, so stored values that Pydantic can coerce to the declared type (e.g. `"5"` for an `int` field) are converted rather than rejected. Fields whose declared types Pydantic cannot validate (e.g. arbitrary types) are always returned as-is.
+
 ### Agent Instances
 
 If you want an agent to have a store-per-instance by default, add an `instance` parameter to your `@agent` function and pass it a unique value. Then, forward the `instance` on to `store_as()` as well as any tools you call that are also stateful (e.g. `bash_session()`). For example:

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -466,13 +466,22 @@ class EvalSample(BaseModel):
     store: dict[str, Any] = Field(default_factory=dict)
     """State at end of sample execution."""
 
-    def store_as(self, model_cls: Type[SMT], instance: str | None = None) -> SMT:
+    def store_as(
+        self, model_cls: Type[SMT], instance: str | None = None, strict: bool = False
+    ) -> SMT:
         """Pydantic model interface to the store.
 
         Args:
           model_cls: Pydantic model type (must derive from StoreModel)
           instance: Optional instances name for store (enables multiple instances
             of a given StoreModel type within a single sample)
+          strict: When `True`, reads through the returned instance raise
+            `ValueError` if a stored value fails validation against the
+            declared field type (see `store_as()` for details). Note that
+            the sample's logged store data is always validated by pydantic
+            when this interface is constructed (regardless of `strict`), so
+            this only affects values written through the returned model
+            afterwards.
 
         Returns:
           StoreModel: model_cls bound to sample store data.
@@ -490,7 +499,10 @@ class EvalSample(BaseModel):
             data["instance"] = instance
 
         # create the model
-        return model_cls.model_validate(data)
+        model = model_cls.model_validate(data)
+        if strict:
+            model._activate_strict_coercion()
+        return model
 
     events: list[DiscriminatedEvent] = Field(default_factory=list)
     """Events that occurred during sample execution."""

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -447,18 +447,26 @@ class TaskState:
 
         return metadata_as(self.metadata, metadata_cls)
 
-    def store_as(self, model_cls: Type[SMT], instance: str | None = None) -> SMT:
+    def store_as(
+        self, model_cls: Type[SMT], instance: str | None = None, strict: bool = False
+    ) -> SMT:
         """Pydantic model interface to the store.
 
         Args:
           model_cls: Pydantic model type (must derive from StoreModel)
           instance: Optional instances name for store (enables multiple instances
             of a given StoreModel type within a single sample)
+          strict: When `True`, reads through the returned instance raise
+            `ValueError` if a stored value fails validation against the
+            declared field type (see `store_as()` for details).
 
         Returns:
           StoreModel: model_cls bound to sample store data.
         """
-        return model_cls(store=self.store, instance=instance)
+        model = model_cls(store=self.store, instance=instance)
+        if strict:
+            model._activate_strict_coercion()
+        return model
 
 
 def sample_state() -> TaskState | None:

--- a/src/inspect_ai/util/_store_model.py
+++ b/src/inspect_ai/util/_store_model.py
@@ -1,6 +1,6 @@
-from typing import Any, ClassVar, Type, TypeVar
+from typing import Any, Type, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, TypeAdapter
 
 from ._store import Store, store
 
@@ -14,41 +14,16 @@ class StoreModel(BaseModel):
     your model fields (the latter approach is recommended).
     """
 
-    strict_coercion: ClassVar[bool] = False
-    """Raise on reads of stored values that fail field validation.
-
-    By default, when a value read from the store cannot be validated
-    against the declared field type, the raw stored value is returned
-    as-is and callers must check the type themselves. Set to `True` on a
-    subclass (as a plain assignment, not an annotated field) to instead
-    raise `ValueError` (naming the store key, the declared type, and the
-    actual value type) whenever a stored value — scalar or not — fails
-    validation. During model construction the error surfaces wrapped in a
-    pydantic `ValidationError`.
-
-    Validation uses pydantic's default (lax) mode, so stored values that
-    pydantic can coerce to the declared type (e.g. `"5"` for an `int`
-    field) are converted and cached back to the store, not rejected.
-    Fields whose declared types pydantic cannot build a validator for
-    (e.g. arbitrary types) are still returned as-is, as no validation is
-    possible for them.
-    """
-
     store: Store = Field(exclude=True, default_factory=store)
     instance: str | None = Field(exclude=True, default=None)
 
-    @classmethod
-    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
-        super().__pydantic_init_subclass__(**kwargs)
-        # an annotated `strict_coercion: bool = True` would become a model
-        # field, and reading it from _coerce_value would then recurse through
-        # __getattribute__ infinitely -- reject it with a legible error
-        if "strict_coercion" in cls.model_fields:
-            raise TypeError(
-                f"'strict_coercion' is a StoreModel class setting and may not be "
-                f"declared as a model field on {cls.__name__} (assign it without "
-                f"a type annotation, e.g. `strict_coercion = True`)."
-            )
+    _strict_coercion: bool = PrivateAttr(default=False)
+    """Raise on reads of stored values that fail field validation.
+
+    Set per instance by `store_as(strict=True)` (via
+    `_activate_strict_coercion()`), never directly. See `store_as()` for
+    the user-facing semantics.
+    """
 
     def model_post_init(self, __context: Any) -> None:
         for name in self.__class__.model_fields.keys():
@@ -113,9 +88,23 @@ class StoreModel(BaseModel):
             # in strict mode, a field with no stored value (e.g. deleted from
             # the store) has nothing to validate -- skip it rather than raising
             # about the None that Store.get returns for a missing key
-            if self.strict_coercion and self._ns_name(field_name) not in self.store:
+            if self._strict_coercion and self._ns_name(field_name) not in self.store:
                 continue
             self._get_and_coerce_field(field_name)
+
+    def _activate_strict_coercion(self) -> None:
+        """Make reads through this instance strict (see `store_as()`).
+
+        Sets the flag consulted by `_coerce_value`, then re-reads every field
+        currently present in the store so that invalid stored values raise at
+        the `store_as(strict=True)` call site rather than on first field access.
+        """
+        self._strict_coercion = True
+        for field_name in self.__class__.model_fields.keys():
+            if field_name == "store":
+                continue
+            if self._ns_name(field_name) in self.store:
+                self._get_and_coerce_field(field_name)
 
     def _validate_store(self, data: dict[str, Any] | None = None) -> None:
         # validate store or custom dict
@@ -184,7 +173,7 @@ class StoreModel(BaseModel):
         # Skip coercion for None and scalar values (they don't need it). In
         # strict mode they are validated like everything else, so that e.g. a
         # stored str where a model is declared raises rather than passing through.
-        if not self.strict_coercion and self._is_scalar(value):
+        if not self._strict_coercion and self._is_scalar(value):
             return value
 
         field_info = self.__class__.model_fields[field_name]  # pylint: disable=unsubscriptable-object
@@ -204,7 +193,7 @@ class StoreModel(BaseModel):
         try:
             return adapter.validate_python(value)
         except Exception as ex:
-            if self.strict_coercion:
+            if self._strict_coercion:
                 raise ValueError(
                     f"Stored value for key '{self._ns_name(field_name)}' does not "
                     f"validate against the declared type {field_type!r} of field "
@@ -228,16 +217,33 @@ class StoreModel(BaseModel):
 SMT = TypeVar("SMT", bound=StoreModel)
 
 
-def store_as(model_cls: Type[SMT], instance: str | None = None) -> SMT:
+def store_as(
+    model_cls: Type[SMT], instance: str | None = None, strict: bool = False
+) -> SMT:
     """Get a Pydantic model interface to the store.
 
     Args:
       model_cls: Pydantic model type (must derive from StoreModel)
       instance: Optional instance name for store (enables multiple instances
         of a given StoreModel type within a single sample)
-
+      strict: When `True`, reads through the returned instance raise
+        `ValueError` (naming the store key, the declared field type, and the
+        actual value's type) if a stored value fails validation against the
+        declared field type, rather than returning the raw value as-is.
+        Values already in the store are validated before this function
+        returns. Strictness is a property of the returned instance only —
+        other `store_as()` calls for the same model and store are
+        unaffected. Validation uses pydantic's default (lax) mode,
+        so stored values pydantic can coerce to the declared type (e.g.
+        `"5"` for an `int` field) are converted and cached back to the
+        store, not rejected; fields whose declared types pydantic cannot
+        build a validator for (e.g. arbitrary types) are always returned
+        as-is, as no validation is possible for them.
 
     Returns:
       StoreModel: model_cls bound to current Store.
     """
-    return model_cls(store=store(), instance=instance)
+    model = model_cls(store=store(), instance=instance)
+    if strict:
+        model._activate_strict_coercion()
+    return model

--- a/src/inspect_ai/util/_store_model.py
+++ b/src/inspect_ai/util/_store_model.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, TypeVar
+from typing import Any, ClassVar, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
@@ -14,8 +14,41 @@ class StoreModel(BaseModel):
     your model fields (the latter approach is recommended).
     """
 
+    strict_coercion: ClassVar[bool] = False
+    """Raise on reads of stored values that fail field validation.
+
+    By default, when a value read from the store cannot be validated
+    against the declared field type, the raw stored value is returned
+    as-is and callers must check the type themselves. Set to `True` on a
+    subclass (as a plain assignment, not an annotated field) to instead
+    raise `ValueError` (naming the store key, the declared type, and the
+    actual value type) whenever a stored value — scalar or not — fails
+    validation. During model construction the error surfaces wrapped in a
+    pydantic `ValidationError`.
+
+    Validation uses pydantic's default (lax) mode, so stored values that
+    pydantic can coerce to the declared type (e.g. `"5"` for an `int`
+    field) are converted and cached back to the store, not rejected.
+    Fields whose declared types pydantic cannot build a validator for
+    (e.g. arbitrary types) are still returned as-is, as no validation is
+    possible for them.
+    """
+
     store: Store = Field(exclude=True, default_factory=store)
     instance: str | None = Field(exclude=True, default=None)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        # an annotated `strict_coercion: bool = True` would become a model
+        # field, and reading it from _coerce_value would then recurse through
+        # __getattribute__ infinitely -- reject it with a legible error
+        if "strict_coercion" in cls.model_fields:
+            raise TypeError(
+                f"'strict_coercion' is a StoreModel class setting and may not be "
+                f"declared as a model field on {cls.__name__} (assign it without "
+                f"a type annotation, e.g. `strict_coercion = True`)."
+            )
 
     def model_post_init(self, __context: Any) -> None:
         for name in self.__class__.model_fields.keys():
@@ -76,6 +109,11 @@ class StoreModel(BaseModel):
         self._validate_store()
         for field_name in self.__class__.model_fields.keys():
             if field_name == "store":
+                continue
+            # in strict mode, a field with no stored value (e.g. deleted from
+            # the store) has nothing to validate -- skip it rather than raising
+            # about the None that Store.get returns for a missing key
+            if self.strict_coercion and self._ns_name(field_name) not in self.store:
                 continue
             self._get_and_coerce_field(field_name)
 
@@ -140,23 +178,39 @@ class StoreModel(BaseModel):
         This handles nested Pydantic models, lists of models, dicts of models,
         TypedDicts, dataclasses, tuples, and other complex types.
         """
-        if field_name not in self.__class__.model_fields or value is None:
+        if field_name not in self.__class__.model_fields:
+            return value
+
+        # Skip coercion for None and scalar values (they don't need it). In
+        # strict mode they are validated like everything else, so that e.g. a
+        # stored str where a model is declared raises rather than passing through.
+        if not self.strict_coercion and self._is_scalar(value):
             return value
 
         field_info = self.__class__.model_fields[field_name]  # pylint: disable=unsubscriptable-object
         field_type = field_info.annotation
 
-        # Skip coercion for scalar types (they don't need it)
-        if self._is_scalar(value):
-            return value
-
-        # For everything else, attempt coercion with TypeAdapter
-        # This handles BaseModels, TypedDicts, dataclasses, tuples, lists, dicts, etc.
-        # Since we cache the result in the Store, this only happens once per field
+        # Attempt coercion with TypeAdapter. This handles BaseModels, TypedDicts,
+        # dataclasses, tuples, lists, dicts, etc. Coerced non-scalar values are
+        # cached back into the Store; validation itself reruns on each read
         try:
             adapter: TypeAdapter[Any] = TypeAdapter(field_type)
-            return adapter.validate_python(value)
         except Exception:
+            # pydantic cannot build a validator for this field type (e.g. an
+            # arbitrary type permitted by arbitrary_types_allowed) so no
+            # coercion is possible -- return the stored value as-is
+            return value
+
+        try:
+            return adapter.validate_python(value)
+        except Exception as ex:
+            if self.strict_coercion:
+                raise ValueError(
+                    f"Stored value for key '{self._ns_name(field_name)}' does not "
+                    f"validate against the declared type {field_type!r} of field "
+                    f"'{field_name}' on {self.__class__.__name__} (stored value has "
+                    f"type {type(value).__name__}): {ex}"
+                ) from ex
             # If coercion fails, return the raw value
             return value
 

--- a/tests/util/test_store_nested_types.py
+++ b/tests/util/test_store_nested_types.py
@@ -7,7 +7,8 @@ import pytest
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
-from inspect_ai.util import Store, StoreModel
+from inspect_ai.util import Store, StoreModel, store_as
+from inspect_ai.util._store import init_subtask_store, store
 
 
 # Test models and types
@@ -376,19 +377,17 @@ def test_invalid_data_returns_raw() -> None:
 
 
 class StrictPersonStore(StoreModel):
-    strict_coercion = True
-
     person: Person = Field(default_factory=lambda: Person(name="", age=0))
     count: int = 0
 
 
-def test_strict_coercion_raises_on_invalid_data() -> None:
-    """Test that strict_coercion raises an informative error instead of returning raw."""
-    store = Store()
-    store.set("StrictPersonStore:person", {"invalid": "data"})
+def test_store_as_strict_raises_on_invalid_data() -> None:
+    """Test that store_as(strict=True) raises an informative error instead of returning raw."""
+    init_subtask_store(Store())
+    store().set("StrictPersonStore:person", {"invalid": "data"})
 
     with pytest.raises(ValueError) as excinfo:
-        StrictPersonStore(store=store)
+        store_as(StrictPersonStore, strict=True)
 
     message = str(excinfo.value)
     assert "StrictPersonStore:person" in message
@@ -396,23 +395,53 @@ def test_strict_coercion_raises_on_invalid_data() -> None:
     assert "dict" in message
 
 
-def test_strict_coercion_validates_scalar_values() -> None:
-    """Test that strict_coercion validates scalar stored values against the field type."""
-    store = Store()
+def test_store_as_strict_validates_scalar_values() -> None:
+    """Test that store_as(strict=True) validates scalar stored values against the field type."""
+    init_subtask_store(Store())
     # a scalar stored where a model is declared skips coercion entirely in
     # lenient mode; strict mode must catch it
-    store.set("StrictPersonStore:person", "not a person")
+    store().set("StrictPersonStore:person", "not a person")
 
     with pytest.raises(ValueError, match="StrictPersonStore:person"):
-        StrictPersonStore(store=store)
+        store_as(StrictPersonStore, strict=True)
 
 
-def test_strict_coercion_valid_data_round_trip() -> None:
-    """Test that strict_coercion leaves valid data behavior unchanged."""
-    store = Store()
-    store.set("StrictPersonStore:person", {"name": "Alice", "age": 30, "address": None})
+def test_store_as_strict_raises_on_reads_after_creation() -> None:
+    """Test that a strict instance validates values written after store_as()."""
+    init_subtask_store(Store())
+    model = store_as(StrictPersonStore, strict=True)
 
-    model = StrictPersonStore(store=store)
+    # corrupt the shared store behind the model's back
+    store().set("StrictPersonStore:person", {"invalid": "data"})
+
+    with pytest.raises(ValueError, match="StrictPersonStore:person"):
+        _ = model.person
+
+
+def test_store_as_strictness_is_per_instance() -> None:
+    """Test that strictness binds to the returned instance, not the model class."""
+    init_subtask_store(Store())
+    store().set("StrictPersonStore:person", {"invalid": "data"})
+
+    # a lenient view of the same store still returns the raw value
+    lenient = store_as(StrictPersonStore)
+    assert lenient.person == {"invalid": "data"}  # type: ignore[comparison-overlap]
+
+    with pytest.raises(ValueError, match="StrictPersonStore:person"):
+        store_as(StrictPersonStore, strict=True)
+
+    # and the lenient view is unaffected by the strict one having existed
+    assert lenient.person == {"invalid": "data"}  # type: ignore[comparison-overlap]
+
+
+def test_store_as_strict_valid_data_round_trip() -> None:
+    """Test that strict reads leave valid data behavior unchanged."""
+    init_subtask_store(Store())
+    store().set(
+        "StrictPersonStore:person", {"name": "Alice", "age": 30, "address": None}
+    )
+
+    model = store_as(StrictPersonStore, strict=True)
     assert isinstance(model.person, Person)
     assert model.person.name == "Alice"
 
@@ -421,45 +450,59 @@ def test_strict_coercion_valid_data_round_trip() -> None:
     assert model.count == 0
     model.count = 3
     assert model.count == 3
-    assert store.get("StrictPersonStore:count") == 3
+    assert store().get("StrictPersonStore:count") == 3
 
 
-def test_strict_coercion_dump_skips_missing_keys() -> None:
-    """Test that strict_coercion model_dump tolerates fields deleted from the store."""
-    store = Store()
-    model = StrictPersonStore(store=store)
-    store.delete("StrictPersonStore:count")
+def test_store_as_strict_dump_skips_missing_keys() -> None:
+    """Test that strict model_dump tolerates fields deleted from the store."""
+    init_subtask_store(Store())
+    model = store_as(StrictPersonStore, strict=True)
+    store().delete("StrictPersonStore:count")
 
     dumped = model.model_dump()
     assert dumped["person"] == Person(name="", age=0).model_dump()
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")  # pydantic's shadow warning
-def test_strict_coercion_may_not_be_a_field() -> None:
-    """Test that declaring strict_coercion as an annotated field raises clearly."""
-    with pytest.raises(TypeError, match="strict_coercion"):
-
-        class ShadowStore(StoreModel):
-            strict_coercion: bool = True  # type: ignore[misc]
-
-
-def test_strict_coercion_arbitrary_types_returned_as_is() -> None:
-    """Test that strict_coercion leaves fields of non-validatable types alone."""
+def test_store_as_strict_arbitrary_types_returned_as_is() -> None:
+    """Test that strict reads leave fields of non-validatable types alone."""
 
     class Opaque:
         pass
 
     class ArbitraryStore(StoreModel):
-        strict_coercion = True
-
         obj: Opaque | None = None
 
-    store = Store()
+    init_subtask_store(Store())
     opaque = Opaque()
-    store.set("ArbitraryStore:obj", opaque)
+    store().set("ArbitraryStore:obj", opaque)
 
-    model = ArbitraryStore(store=store)
+    model = store_as(ArbitraryStore, strict=True)
     assert model.obj is opaque
+
+
+def test_eval_sample_store_as_strict() -> None:
+    """Test the strict parameter on EvalSample.store_as."""
+    from inspect_ai.log._log import EvalSample
+
+    sample = EvalSample(
+        id=1,
+        epoch=1,
+        input="input",
+        target="target",
+        store={"StrictPersonStore:person": {"name": "Alice", "age": 30}},
+    )
+
+    # default is lenient for post-construction reads
+    lenient = sample.store_as(StrictPersonStore)
+    lenient.store.set("StrictPersonStore:person", {"invalid": "data"})
+    assert lenient.person == {"invalid": "data"}  # type: ignore[comparison-overlap]
+
+    # strict instances validate post-construction reads
+    strict = sample.store_as(StrictPersonStore, strict=True)
+    assert strict.person.name == "Alice"
+    strict.store.set("StrictPersonStore:person", {"invalid": "data"})
+    with pytest.raises(ValueError, match="StrictPersonStore:person"):
+        _ = strict.person
 
 
 def test_multiple_instances_with_nested_types():

--- a/tests/util/test_store_nested_types.py
+++ b/tests/util/test_store_nested_types.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
+import pytest
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
@@ -372,6 +373,93 @@ def test_invalid_data_returns_raw() -> None:
     person = model.person
     assert isinstance(person, dict)
     assert person == {"invalid": "data"}
+
+
+class StrictPersonStore(StoreModel):
+    strict_coercion = True
+
+    person: Person = Field(default_factory=lambda: Person(name="", age=0))
+    count: int = 0
+
+
+def test_strict_coercion_raises_on_invalid_data() -> None:
+    """Test that strict_coercion raises an informative error instead of returning raw."""
+    store = Store()
+    store.set("StrictPersonStore:person", {"invalid": "data"})
+
+    with pytest.raises(ValueError) as excinfo:
+        StrictPersonStore(store=store)
+
+    message = str(excinfo.value)
+    assert "StrictPersonStore:person" in message
+    assert "Person" in message
+    assert "dict" in message
+
+
+def test_strict_coercion_validates_scalar_values() -> None:
+    """Test that strict_coercion validates scalar stored values against the field type."""
+    store = Store()
+    # a scalar stored where a model is declared skips coercion entirely in
+    # lenient mode; strict mode must catch it
+    store.set("StrictPersonStore:person", "not a person")
+
+    with pytest.raises(ValueError, match="StrictPersonStore:person"):
+        StrictPersonStore(store=store)
+
+
+def test_strict_coercion_valid_data_round_trip() -> None:
+    """Test that strict_coercion leaves valid data behavior unchanged."""
+    store = Store()
+    store.set("StrictPersonStore:person", {"name": "Alice", "age": 30, "address": None})
+
+    model = StrictPersonStore(store=store)
+    assert isinstance(model.person, Person)
+    assert model.person.name == "Alice"
+
+    model.person = Person(name="Bob", age=25)
+    assert model.person.name == "Bob"
+    assert model.count == 0
+    model.count = 3
+    assert model.count == 3
+    assert store.get("StrictPersonStore:count") == 3
+
+
+def test_strict_coercion_dump_skips_missing_keys() -> None:
+    """Test that strict_coercion model_dump tolerates fields deleted from the store."""
+    store = Store()
+    model = StrictPersonStore(store=store)
+    store.delete("StrictPersonStore:count")
+
+    dumped = model.model_dump()
+    assert dumped["person"] == Person(name="", age=0).model_dump()
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")  # pydantic's shadow warning
+def test_strict_coercion_may_not_be_a_field() -> None:
+    """Test that declaring strict_coercion as an annotated field raises clearly."""
+    with pytest.raises(TypeError, match="strict_coercion"):
+
+        class ShadowStore(StoreModel):
+            strict_coercion: bool = True  # type: ignore[misc]
+
+
+def test_strict_coercion_arbitrary_types_returned_as_is() -> None:
+    """Test that strict_coercion leaves fields of non-validatable types alone."""
+
+    class Opaque:
+        pass
+
+    class ArbitraryStore(StoreModel):
+        strict_coercion = True
+
+        obj: Opaque | None = None
+
+    store = Store()
+    opaque = Opaque()
+    store.set("ArbitraryStore:obj", opaque)
+
+    model = ArbitraryStore(store=store)
+    assert model.obj is opaque
 
 
 def test_multiple_instances_with_nested_types():


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

> **Draft on purpose** — the mechanism is small, but the API surface (naming, error type, scoping) deserves maintainer input before this is polished. Open questions below.

### What is the current behavior? (You can also link to an open issue here)

`StoreModel`'s value coercion (`_coerce_value` in `src/inspect_ai/util/_store_model.py`) ends in `except Exception: return value`: when a stored value fails validation against the declared field type, the **raw stored value is silently returned in the typed field's place**. Scalar stored values (and `None`) bypass coercion entirely, so e.g. a `str` sitting under a field declared as a `BaseModel` is also returned as-is.

The practical consequence is that a typed read through `store_as()` is not actually typed: every downstream consumer that cares must `isinstance`-guard each read — the isinstance check *is* the validation — and a copy-pasted or weakened guard is a realistic silent-data-corruption path (the value flows on with the wrong shape and fails, or worse doesn't fail, far from the store read).

Reproduction (passes today; kept as a regression test for the lenient default):

```python
class MyStore(StoreModel):
    person: Person = Field(default_factory=lambda: Person(name="", age=0))

store = Store()
store.set("MyStore:person", {"invalid": "data"})
model = MyStore(store=store)
model.person  # == {"invalid": "data"} — a dict, not a Person, no error
```

#### Why the leniency exists (history)

The coercion path and its lenient fallback were introduced in fcbc5bb (#2214, "store: support for serializing complex nested types (e.g. to read in an offline scorer)"). Reasons it can't simply become strict for everyone:

1. **`arbitrary_types_allowed=True`**: `StoreModel` permits field types pydantic cannot build a `TypeAdapter` for at all — the single `except` also swallowed *adapter construction* failures, not just data mismatches. Those fields have no possible validation and must keep returning the stored object.
2. **The `Store` is a shared untyped namespace**: other solvers/tools can legitimately write values a given `StoreModel` view doesn't expect.
3. The lenient behavior is pinned by an existing test (`test_invalid_data_returns_raw`), whose comment already anticipated "strict validation" as a possible opt-in.

(An earlier revision of this PR also cited "reading historical logs would break" here, but that turns out to be empirically wrong: `EvalSample.store_as()` builds the model with `model_cls.model_validate(data)`, which pydantic-validates the logged store data at construction and **already raises `ValidationError` on drifted shapes today**, lenient coercion notwithstanding. The lenient fallback only governs the live read paths, where fields are hydrated from the `Store` after construction.)

### What is the new behavior?

Strictness is now a **per-call opt-in on `store_as()`** (and on `TaskState.store_as()` / `EvalSample.store_as()`), not a class-level declaration:

```python
activity = store_as(Activity, strict=True)
```

- `strict: bool = False` — nothing changes unless a call site opts in; the default path is byte-for-byte the pre-PR behavior (the strict machinery runs only when requested).
- With `strict=True`, a stored value that fails validation against the declared field type raises a plain `ValueError` naming the store key, the declared type, the actual value's type, and the underlying pydantic error (also chained via `raise ... from`):

  ```
  ValueError: Stored value for key 'Activity:active' does not validate against the
  declared type <class 'bool'> of field 'active' on Activity (stored value has type
  dict): 1 validation error for bool ...
  ```

- Values already in the store are validated before `store_as()` returns (so bad existing state fails at the call site); values written afterwards are validated on each read through the instance.
- **Strictness is a property of the returned instance** (set at the `store_as()` call, effective for that instance's lifetime). There is no instance caching anywhere — every `store_as()` call constructs a fresh model — so a strict view and a lenient view of the same store coexist without interacting. This is the point of the per-call design: the same `StoreModel` class is read live in a scorer (strict often wanted) and from historical logs or by unrelated code (lenient may be correct), and the right policy belongs to the call site, not the class.
- Strict mode also validates scalar and `None` stored values (lenient mode short-circuits those before any validation), so a `str` stored under a model-typed field, or `None` under a non-optional field, is caught too.
- Validation uses pydantic's default (lax) mode — stored values pydantic can coerce (e.g. `"5"` for an `int` field) are converted and cached back to the store, not rejected. (Pydantic *strict* mode is not usable here: it would reject the dict → `BaseModel` re-hydration that is this coercion path's whole purpose.) Documented on `store_as()` and in the docs.
- Fields whose declared types pydantic cannot build a validator for (arbitrary types) are returned as-is in **both** modes — adapter-construction failure is a property of the type, not bad data, so strict mode does not punish it (this keeps `arbitrary_types_allowed` usage working under strict).
- `model_dump()`/`_sync_model` on a strict instance skip fields with no stored value (e.g. deleted from the store) — `Store.get` returns `None` for a missing key, and raising "stored value has type NoneType" for a value that was never stored would mislead.
- On `EvalSample.store_as()` the parameter exists for surface consistency, but note (documented in its docstring) that logged store data is **always** pydantic-validated at construction regardless of `strict` (pre-existing behavior, see above); `strict` there only affects reads of values written through the returned model afterwards.

Successful coercion is unchanged: valid data round-trips identically in both modes, and coerced values are still cached back into the store.

Docs note: the strict-reads documentation lives in `docs/agent-custom.qmd` (the "Typed Store" section users actually see). `docs/_store_typing.md`, where an earlier revision put it, turns out to be an **orphaned include** — no rendered page references it (maintainers may want to delete it separately).

#### Design + alternatives (maintainer input wanted)

- **Per-call `strict` vs class-level `ClassVar`**: the first revision of this PR used a `strict_coercion` ClassVar on the subclass. Superseded: a class-level declaration forces one policy onto every reader of that model, including historical-log and cross-component reads that may legitimately want leniency; it also needed a `__pydantic_init_subclass__` guard against field/ClassVar shadowing that the per-call design makes unnecessary (the instance flag is a pydantic `PrivateAttr`, and field names cannot start with an underscore). A class-level *default* (overridable per call) could be added later without breaking anything; it was left out to keep the surface minimal.
- **`model_config["strict"]` piggyback**: rejected — pydantic's strict flag couples "raise on failure" with pydantic's coercion-laxness axis, so `"5"` → `5` (and, more importantly, the dict → `BaseModel` re-hydration this whole path exists for) would stop validating everywhere the class is used.
- **Error type**: currently `ValueError` (chaining the `ValidationError`). Would a dedicated exception (e.g. `StoreCoercionError`) be preferred so callers can catch it specifically? That adds exported API surface, so I kept it minimal for the draft.
- **Performance**: strict reads construct a `TypeAdapter` per read for scalars too (matching the existing non-scalar path). Adapters could be cached per (class, field) if this matters.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `strict` defaults to `False` and the lenient path is byte-for-byte the same behavior as before (including raw-value fallback and adapter-construction fallback); the pre-existing test pinning the raw-return behavior still passes unchanged. The new parameter is appended after `instance` on all three `store_as` signatures, so existing positional callers are unaffected.

### Other information:

**Testing** (run on Linux, Python 3.13):
- `pytest tests/util/test_store_nested_types.py tests/util/test_store_from_events.py tests/util/test_kvstore.py` — 68 passed (includes 8 new tests: strict `store_as()` raises with informative message at the call site; strict catches scalar-under-model-field; strict validates values written after creation; strictness binds to the instance, and a lenient view of the same store is unaffected before and after a strict view exists; valid-data round-trip unchanged under strict; arbitrary-typed fields untouched under strict; strict `model_dump()` tolerates a field deleted from the store; `EvalSample.store_as(strict=...)` semantics; plus the pre-existing lenient raw-return test unchanged).
- `make check` equivalent (full repo, non-mutating): `ruff check` + `ruff format --check` — clean; `mypy --exclude tests/test_package src tests` — no issues in 1427 source files.
- **The full `make test` suite was NOT run** (it needs provider credentials/sandboxes not available in this environment); only the store/util test files above were run. CI should be authoritative.

**Agent involvement disclosure**: implemented with Claude Code (Claude Fable 5). The PR description and design analysis were agent-drafted and human-directed.

### Agent review
- Reviewer: Claude Fable 5, 3 passes, each in a fresh context (a correctness/differential pass and an adversarial/empirical pass on the original ClassVar revision before this PR was opened; then an independent adversarial third pass, during which the owner redirected the API from the class-level ClassVar to the per-call `strict` flag now in the PR — the third pass implemented and re-verified that shape).
- Passes 1–2 (on the ClassVar revision): 8 substantive findings — 5 fixed, 3 dismissed:
  - Fixed: annotated `strict_coercion: bool` field on a subclass caused an opaque `RecursionError` (rejected at class definition; the guard is now obsolete — see pass 3).
  - Fixed: strict `model_dump()` raised a misleading "stored value has type NoneType" for a field *missing* from the store (missing keys skipped under strict + test; retained in the per-call design).
  - Fixed: "strict" mode's use of pydantic lax validation was undocumented (now documented).
  - Fixed: stale comment claiming coercion "only happens once per field"; redundant `value is None or` check; CHANGELOG entry placement.
  - Dismissed: construction-time `ValidationError` wrapping (obsolete — the per-call design raises the plain `ValueError` at the `store_as()` call site); per-read `TypeAdapter` cost for scalars (~27µs vs ~9µs, matches the pre-existing non-scalar path; open question above); lax-coercion write-back mutating the shared store (pre-existing cache-back design, documented).
- Pass 3 (adversarial, fresh context; also carried out the owner-directed per-call rework): verified per-exception-class that the split construction/validation try-blocks preserve lenient behavior exactly (both buckets return the raw value when `strict` is off); confirmed `BaseException`s (e.g. `KeyboardInterrupt`) propagate in both revisions as on `main`. Findings beyond the rework itself, all fixed or reported:
  - Fixed: the docs addition targeted `docs/_store_typing.md`, which no rendered page includes — moved to `docs/agent-custom.qmd`.
  - Fixed (by the rework): the earlier body's claim that `model_dump()` raises the plain `ValueError` was empirically wrong (it surfaced a `ValidationError` via `_sync_model`'s pre-existing `_validate_store` call).
  - Corrected in this description: the "historical log reads would break" rationale — `EvalSample.store_as()` already hard-fails on drifted data via `model_validate` (verified empirically), so the lenient fallback only ever governed live reads.
  - Reported to the owner (pre-existing, out of scope): `EvalSample.store_as(cls, instance="x")` silently drops instance-namespaced store data (`Cls:x:field` keys are not un-namespaced), returning field defaults.
  - Probed and clean: strict-subclass inheritance chains, generic `StoreModel` subclasses, deepcopy stickiness of the instance flag, lax scalar write-back (`"5"` → `5`), `TaskState.store_as(strict=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
