### PR TITLE
score: optionally keep replaced scores in edit history when re-scoring with overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scoring: `score()` / `score_async()` accept `preserve_history=True` to keep each overwritten score's previous values in the new score's edit history instead of discarding them.
 - Scorers: `match(numeric=True)` now parses numbers with attached sentence or enclosing punctuation (e.g. "42!", "(42)"); operator prefixes (`<42`, `~42`) still do not match, and `location="exact"` remains strict. (#4742)
 - Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices always score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)

--- a/docs/scoring-workflow.qmd
+++ b/docs/scoring-workflow.qmd
@@ -128,6 +128,15 @@ for model, scored_log in zip(grader_models, scoring_logs):
     write_eval_log(scored_log, output_file)
 ```
 
+When overwriting, you can keep the replaced scores as part of each new score's edit history rather than discarding them:
+
+``` python
+scored_log = score(log, model_graded_qa(), action="overwrite",
+                   preserve_history=True)
+```
+
+For each sample score that is replaced, the previous score's values are snapshotted into the new score's `history` (exactly as `edit_score()` does) and a `ScoreEditEvent` is recorded in the sample transcript with provenance for the change. A score counts as replaced when the new scoring pass produces a score with the same name — existing scores whose scorer is not re-run are still dropped by the overwrite. See [Editing Logs](eval-logs.qmd#sec-eval-log-modification) for details on score history.
+
 ## Editing Scores
 
 You may need to modify the results, for example correcting scoring errors or adjusting sample scores based on manual review. Inspect provides functions for modifying logs while maintaining data integrity and audit trails. Learn more about modifying scores in [Editing Logs](eval-logs.qmd#sec-eval-log-modification).

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -33,6 +33,7 @@ from inspect_ai._util.registry import (
     registry_params,
     registry_unqualified_name,
 )
+from inspect_ai._view.user_info import user_info
 from inspect_ai.event._event import Event
 from inspect_ai.event._score import ScoreEvent
 from inspect_ai.event._tree import (
@@ -45,17 +46,22 @@ from inspect_ai.log import (
     EvalLog,
 )
 from inspect_ai.log._condense import resolve_sample_attachments
+from inspect_ai.log._edit import ProvenanceData
 from inspect_ai.log._headline import headline_metric_ref, resolve_headline_metric
 from inspect_ai.log._log import EvalMetricDefinition, EvalSample
 from inspect_ai.log._resolve import rebind_sample_timelines
-from inspect_ai.log._score import _find_scorers_span
+from inspect_ai.log._score import (
+    _find_scorers_span,
+    apply_score_edit,
+    insert_score_edit_event,
+)
 from inspect_ai.log._transcript import Transcript, init_transcript, transcript
 from inspect_ai.model import ModelName
 from inspect_ai.model._model import Model, ModelRoles, get_model
 from inspect_ai.model._model_config import model_roles_config_to_model_roles
 from inspect_ai.model._util import resolve_model_roles
 from inspect_ai.scorer import Metric, Scorer, Target
-from inspect_ai.scorer._metric import SampleScore, Score, metric_create
+from inspect_ai.scorer._metric import SampleScore, Score, ScoreEdit, metric_create
 from inspect_ai.scorer._reducer import (
     ScoreReducer,
     ScoreReducers,
@@ -88,6 +94,7 @@ def score(
     model: str | Model | None = None,
     model_roles: ModelRoles | None = None,
     action: ScoreAction | None = None,
+    preserve_history: bool = False,
     display: DisplayType | None = None,
     copy: bool = True,
 ) -> EvalLog:
@@ -107,6 +114,12 @@ def score(
        model_roles: Optional. Named model roles used for re-scoring
            (merged over the model roles reconstructed from the log header).
        action: Whether to append or overwrite this score
+       preserve_history: Carry each replaced score's prior values into the
+           replacement's `Score.history` and record a `ScoreEditEvent` (as
+           `edit_score()` does), rather than discarding them. A score is
+           replaced when this pass produces a score with the same name;
+           existing scores whose scorer is not re-run are still dropped by
+           the overwrite. Only valid with `action="overwrite"`.
        display: Progress/status display
        copy: Whether to deepcopy the log before scoring.
 
@@ -132,6 +145,7 @@ def score(
                 model=model,
                 model_roles=model_roles,
                 action=action,
+                preserve_history=preserve_history,
                 copy=copy,
             )
         )
@@ -142,6 +156,7 @@ def score(
                 model=model,
                 model_roles=model_roles,
                 action=action,
+                preserve_history=preserve_history,
                 copy=copy,
             ),
             log,
@@ -220,6 +235,7 @@ async def score_async(
     model: str | Model | None = None,
     model_roles: ModelRoles | None = None,
     action: ScoreAction | None = None,
+    preserve_history: bool = False,
     display: DisplayType | None = None,
     copy: bool = True,
     samples: Callable[[int], AsyncContextManager[EvalSample]] | None = None,
@@ -242,6 +258,12 @@ async def score_async(
        model_roles: Optional. Named model roles used for re-scoring
          (merged over the model roles reconstructed from the log header).
        action: Whether to append or overwrite this score
+       preserve_history: Carry each replaced score's prior values into the
+         replacement's `Score.history` and record a `ScoreEditEvent` (as
+         `edit_score()` does), rather than discarding them. A score is
+         replaced when this pass produces a score with the same name;
+         existing scores whose scorer is not re-run are still dropped by
+         the overwrite. Only valid with `action="overwrite"`.
        display: Progress/status display
        copy: Whether to deepcopy the log before scoring.
        samples:
@@ -254,6 +276,9 @@ async def score_async(
     """
     if samples is None and log.samples is None:
         raise ValueError("There are no samples to score in the log.")
+
+    if preserve_history and action != "overwrite":
+        raise ValueError('preserve_history is only valid with action="overwrite"')
 
     # resolve scorers
     resolved_scorers = resolve_scorer(scorers)
@@ -323,7 +348,13 @@ async def score_async(
                 # since the sample score carries the scorer name that generated
                 # it (so using sample.scores directly isn't enough)
                 sample_score, names = await _run_score_task(
-                    log, sample, resolved_scorers, active_model, active_roles, action
+                    log,
+                    sample,
+                    resolved_scorers,
+                    active_model,
+                    active_roles,
+                    action,
+                    preserve_history=preserve_history,
                 )
 
             assert sample.scores is not None
@@ -495,6 +526,7 @@ async def _run_score_task(
     model: Model,
     model_roles: dict[str, Model | list[Model]],
     action: ScoreAction,
+    preserve_history: bool = False,
 ) -> Tuple[dict[str, SampleScore], list[str]]:
     state, target, resolved_sample = task_state_from_sample(
         sample,
@@ -548,12 +580,75 @@ async def _run_score_task(
     # slice off only the newly added events
     new_events = transcript().events[len(resolved_sample.events) :]
 
+    # capture the scores the overwrite below will replace so they can be
+    # carried into the replacement scores' history
+    previous_scores: dict[str, Score] = (
+        dict(sample.scores or {}) if preserve_history and action == "overwrite" else {}
+    )
+
     sample.scores = _get_updated_scores(sample, results, action=action)
     sample.events = _get_updated_events(sample, new_events, action=action)
+
+    for scorer_name, sample_score in results.items():
+        previous_score = previous_scores.get(scorer_name)
+        if previous_score is not None:
+            _preserve_score_history(sample, scorer_name, sample_score, previous_score)
 
     # return the actual sample scorers and scorer names that
     # were used to generate this set of scores
     return results, scorer_names
+
+
+def _preserve_score_history(
+    sample: EvalSample,
+    scorer_name: str,
+    sample_score: SampleScore,
+    previous_score: Score,
+) -> None:
+    """Carry a replaced score's predecessor into the replacement's edit history.
+
+    A `ScoreEdit` describing the newly generated score is applied to a copy
+    of the predecessor with the same machinery `edit_score()` uses: the
+    predecessor's values are snapshotted into `history[0]` (unless it already
+    carries a history, which is carried forward instead) and the edit is
+    appended. The resulting history is attached to the new score -- whose
+    fields are otherwise exactly as the scorer produced them -- and a
+    `ScoreEditEvent` is recorded within the (new) scorers span. The
+    predecessor is copied rather than mutated so callers using `copy=False`
+    don't see score objects they hold rewritten.
+
+    A new field value that literally equals the `"UNCHANGED"` sentinel is
+    recorded as such in the edit (a `ScoreEdit` schema limitation shared with
+    `edit_score()`); the score itself is unaffected.
+    """
+    new_score = sample_score.score
+    edit = ScoreEdit(
+        value=new_score.value,
+        answer=new_score.answer,
+        explanation=new_score.explanation,
+        reason=new_score.reason,
+        metadata=new_score.metadata or {},
+        provenance=ProvenanceData(
+            author=_rescore_author(),
+            reason=f"Re-scored with scorer '{scorer_name}' (action='overwrite').",
+        ),
+    )
+    predecessor = previous_score.model_copy(deep=True)
+    apply_score_edit(predecessor, edit)
+    new_score.history = predecessor.history
+    insert_score_edit_event(sample, scorer_name, edit)
+
+
+@functools.cache
+def _rescore_author() -> str:
+    """The provenance author for re-score edits.
+
+    The same best-effort identity the viewer prefills in its edit dialogs
+    (git email local-part, then git user.name, then OS login), so a person's
+    re-score edits and manual edits record the same author. Cached because
+    `user_info()` shells out to git.
+    """
+    return user_info().name or "unknown"
 
 
 def metrics_from_log_header(

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -611,23 +611,28 @@ def _preserve_score_history(
     of the predecessor with the same machinery `edit_score()` uses: the
     predecessor's values are snapshotted into `history[0]` (unless it already
     carries a history, which is carried forward instead) and the edit is
-    appended. The resulting history is attached to the new score -- whose
-    fields are otherwise exactly as the scorer produced them -- and a
-    `ScoreEditEvent` is recorded within the (new) scorers span. The
-    predecessor is copied rather than mutated so callers using `copy=False`
-    don't see score objects they hold rewritten.
+    appended. The resulting history is attached to a copy of the new score --
+    whose fields are otherwise exactly as the scorer produced them -- which
+    replaces the original in `sample.scores` and the returned results, and a
+    `ScoreEditEvent` is recorded within the (new) scorers span. Copies are
+    used on both sides of the graft: the predecessor so callers using
+    `copy=False` don't see score objects they hold rewritten, and the new
+    score because the scorer-produced object is also embedded in the
+    already-recorded `ScoreEvent`, whose payload should stay exactly what a
+    plain overwrite records (lineage lives on `Score.history` and in the
+    `ScoreEditEvent`, not in the `ScoreEvent`).
 
     A new field value that literally equals the `"UNCHANGED"` sentinel is
     recorded as such in the edit (a `ScoreEdit` schema limitation shared with
     `edit_score()`); the score itself is unaffected.
     """
-    new_score = sample_score.score
+    produced_score = sample_score.score
     edit = ScoreEdit(
-        value=new_score.value,
-        answer=new_score.answer,
-        explanation=new_score.explanation,
-        reason=new_score.reason,
-        metadata=new_score.metadata or {},
+        value=produced_score.value,
+        answer=produced_score.answer,
+        explanation=produced_score.explanation,
+        reason=produced_score.reason,
+        metadata=produced_score.metadata or {},
         provenance=ProvenanceData(
             author=_rescore_author(),
             reason=f"Re-scored with scorer '{scorer_name}' (action='overwrite').",
@@ -635,7 +640,11 @@ def _preserve_score_history(
     )
     predecessor = previous_score.model_copy(deep=True)
     apply_score_edit(predecessor, edit)
+    new_score = produced_score.model_copy()
     new_score.history = predecessor.history
+    sample_score.score = new_score
+    assert sample.scores is not None
+    sample.scores[scorer_name] = new_score
     insert_score_edit_event(sample, scorer_name, edit)
 
 

--- a/src/inspect_ai/log/_score.py
+++ b/src/inspect_ai/log/_score.py
@@ -6,7 +6,7 @@ from inspect_ai.event._score_edit import ScoreEditEvent
 from inspect_ai.event._tree import EventTree, EventTreeSpan, event_tree, walk_node_spans
 from inspect_ai.scorer._metric import Score, ScoreEdit
 
-from ._log import EvalLog
+from ._log import EvalLog, EvalSample
 from ._metric import recompute_metrics as _recompute_metrics
 
 
@@ -94,46 +94,69 @@ def edit_score(
         )
         sample.scores[score_name] = new_score
     else:
-        score = sample.scores[score_name]
+        apply_score_edit(sample.scores[score_name], edit)
 
-        if not score.history:
-            original = ScoreEdit(
-                value=score.value,
-                answer=score.answer,
-                explanation=score.explanation,
-                reason=score.reason,
-                metadata=score.metadata or {},
-            )
-            score.history.append(original)
+    insert_score_edit_event(sample, score_name, edit)
 
-        if edit.value != "UNCHANGED":
-            score.value = edit.value
-        if edit.answer != "UNCHANGED":
-            score.answer = edit.answer
-        if edit.explanation != "UNCHANGED":
-            score.explanation = edit.explanation
-        if edit.reason != "UNCHANGED":
-            score.reason = edit.reason
-        if edit.metadata != "UNCHANGED":
-            score.metadata = edit.metadata
+    if recompute_metrics:
+        _recompute_metrics(log)
 
-        if edit.reason != "UNCHANGED":
-            # An explicit edit to `reason` (including clearing it to None)
-            # supersedes any legacy `metadata["unscored_reason"]` left over
-            # from pre-#4567 logs - otherwise a future re-read of the
-            # persisted log would resurrect the old reason via the
-            # `_lift_unscored_reason` shim.
-            score.metadata = _drop_legacy_unscored_reason(score.metadata)
 
-        score.history.append(edit)
+def apply_score_edit(score: Score, edit: ScoreEdit) -> None:
+    """Apply an edit to an existing score in place, maintaining `Score.history`.
 
+    On the first recorded change the pre-edit state is snapshotted into
+    `history` (with `provenance=None`, marking it as the original score), so
+    `history[0]` always preserves the original values. The applied edit is
+    then appended, so `history[-1]` always describes the current state.
+    """
+    if not score.history:
+        original = ScoreEdit(
+            value=score.value,
+            answer=score.answer,
+            explanation=score.explanation,
+            reason=score.reason,
+            metadata=score.metadata or {},
+        )
+        score.history.append(original)
+
+    if edit.value != "UNCHANGED":
+        score.value = edit.value
+    if edit.answer != "UNCHANGED":
+        score.answer = edit.answer
+    if edit.explanation != "UNCHANGED":
+        score.explanation = edit.explanation
+    if edit.reason != "UNCHANGED":
+        score.reason = edit.reason
+    if edit.metadata != "UNCHANGED":
+        score.metadata = edit.metadata
+
+    if edit.reason != "UNCHANGED":
+        # An explicit edit to `reason` (including clearing it to None)
+        # supersedes any legacy `metadata["unscored_reason"]` left over
+        # from pre-#4567 logs - otherwise a future re-read of the
+        # persisted log would resurrect the old reason via the
+        # `_lift_unscored_reason` shim.
+        score.metadata = _drop_legacy_unscored_reason(score.metadata)
+
+    score.history.append(edit)
+
+
+def insert_score_edit_event(
+    sample: EvalSample, score_name: str, edit: ScoreEdit
+) -> None:
+    """Record a `ScoreEditEvent` on the sample.
+
+    The event is attributed to the sample's final scorers span (when present)
+    and inserted just before that span's end; otherwise it is appended to the
+    end of the event list.
+    """
     final_scorers_node = _find_scorers_span(event_tree(sample.events))
     score_edit_event = ScoreEditEvent(score_name=score_name, edit=edit)
 
     if final_scorers_node:
         score_edit_event.span_id = final_scorers_node.begin.id
 
-    # Insert event just before the end of the scorers span, or at end if no span
     end_index = len(sample.events)
     if final_scorers_node and final_scorers_node.end is not None:
         for i, ev in enumerate(reversed(sample.events)):
@@ -142,9 +165,6 @@ def edit_score(
                 break
 
     sample.events.insert(end_index, score_edit_event)
-
-    if recompute_metrics:
-        _recompute_metrics(log)
 
 
 def _find_scorers_span(tree: EventTree) -> EventTreeSpan | None:

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -22,6 +22,7 @@ from inspect_ai.event._model import ModelEvent
 from inspect_ai.event._sample_init import SampleInitEvent
 from inspect_ai.event._score import ScoreEvent
 from inspect_ai.log import (
+    EvalLog,
     EvalSample,
     Transcript,
 )
@@ -848,3 +849,275 @@ async def test_score_restores_sample_timelines() -> None:
         action="append",
     )
     assert seen == ["target"]
+
+
+def _preserve_history_log(sample: EvalSample) -> EvalLog:
+    from inspect_ai.log._log import (
+        EvalConfig,
+        EvalDataset,
+        EvalPlan,
+        EvalPlanStep,
+        EvalSpec,
+    )
+
+    return EvalLog(
+        version=2,
+        status="success",
+        eval=EvalSpec(
+            created="2025-01-01T00:00:00Z",
+            task="t",
+            task_id="t",
+            run_id="r",
+            dataset=EvalDataset(),
+            model="mockllm/model",
+            config=EvalConfig(),
+        ),
+        plan=EvalPlan(
+            name="t", steps=[EvalPlanStep(solver="generate")], config=GenerateConfig()
+        ),
+        samples=[sample],
+    )
+
+
+def _preserve_history_sample() -> EvalSample:
+    return EvalSample(
+        id="test-1",
+        epoch=1,
+        input="q",
+        target="a",
+        messages=[ChatMessageUser(role="user", content="q")],
+        output=ModelOutput(
+            choices=[
+                ChatCompletionChoice(
+                    message=ChatMessageAssistant(role="assistant", content="a")
+                )
+            ]
+        ),
+    )
+
+
+@scorer(metrics=[accuracy()])
+def fixed_scorer(value: float | str, answer: str | None = None) -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=value, answer=answer)
+
+    return score
+
+
+@scorer(metrics=[accuracy()])
+def another_scorer() -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=0.5)
+
+    return score
+
+
+async def test_score_overwrite_preserve_history() -> None:
+    """Overwrite with preserve_history carries the replaced score into history.
+
+    The predecessor's values must land in `history[0]` (provenance None, as
+    with `edit_score()`), the re-scored values must be appended as an edit
+    with provenance, and a `ScoreEditEvent` must be recorded within the new
+    scorers span. Scores without a predecessor are unaffected.
+    """
+    from inspect_ai.event import ScoreEditEvent, SpanBeginEvent, SpanEndEvent
+
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(log, [fixed_scorer(0.0, "old")], action="overwrite")
+    rescored = await score_async(
+        scored,
+        [fixed_scorer(1.0, "new"), another_scorer()],
+        action="overwrite",
+        preserve_history=True,
+    )
+
+    assert rescored.samples is not None
+    sample = rescored.samples[0]
+    assert sample.scores is not None
+
+    # the replaced score carries the new values plus its predecessor in history
+    replaced = sample.scores["fixed_scorer"]
+    assert replaced.value == 1.0
+    assert replaced.answer == "new"
+    assert replaced.metadata is None  # scorer-produced fields are untouched
+    assert len(replaced.history) == 2
+    original, edit = replaced.history
+    assert original.value == 0.0
+    assert original.answer == "old"
+    assert original.provenance is None
+    assert edit.value == 1.0
+    assert edit.answer == "new"
+    assert edit.provenance is not None
+    assert edit.provenance.author
+
+    # a score without a predecessor gets no history and no edit event
+    fresh = sample.scores["another_scorer"]
+    assert fresh.value == 0.5
+    assert fresh.history == []
+
+    # a single ScoreEditEvent records the replacement, inside the new scorers span
+    edit_events = [e for e in sample.events if isinstance(e, ScoreEditEvent)]
+    assert len(edit_events) == 1
+    edit_event = edit_events[0]
+    assert edit_event.score_name == "fixed_scorer"
+    assert edit_event.edit == edit
+    scorers_spans = [
+        e
+        for e in sample.events
+        if isinstance(e, SpanBeginEvent) and e.name == "scorers"
+    ]
+    assert len(scorers_spans) == 1  # the overwrite replaced the original span
+    assert edit_event.span_id == scorers_spans[0].id
+    span_end_index = next(
+        i
+        for i, e in enumerate(sample.events)
+        if isinstance(e, SpanEndEvent) and e.id == scorers_spans[0].id
+    )
+    assert sample.events.index(edit_event) < span_end_index
+
+    # the input log was deep-copied, not mutated
+    assert scored.samples is not None
+    assert scored.samples[0].scores is not None
+    assert scored.samples[0].scores["fixed_scorer"].value == 0.0
+    assert scored.samples[0].scores["fixed_scorer"].history == []
+
+
+async def test_score_overwrite_preserve_history_previously_edited() -> None:
+    """A predecessor's existing edit history is carried forward, not re-snapshotted."""
+    from inspect_ai.log import edit_score
+    from inspect_ai.log._edit import ProvenanceData
+    from inspect_ai.scorer._metric import ScoreEdit
+
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(log, [fixed_scorer(0.0, "old")], action="overwrite")
+    edit_score(
+        scored,
+        "test-1",
+        "fixed_scorer",
+        ScoreEdit(
+            value=0.25,
+            provenance=ProvenanceData(author="human", reason="manual review"),
+        ),
+        recompute_metrics=False,
+    )
+
+    rescored = await score_async(
+        scored, [fixed_scorer(1.0, "new")], action="overwrite", preserve_history=True
+    )
+
+    assert rescored.samples is not None
+    assert rescored.samples[0].scores is not None
+    replaced = rescored.samples[0].scores["fixed_scorer"]
+    assert replaced.value == 1.0
+    assert [e.value for e in replaced.history] == [0.0, 0.25, 1.0]
+    assert replaced.history[0].provenance is None
+    human_edit = replaced.history[1]
+    assert human_edit.provenance is not None
+    assert human_edit.provenance.author == "human"
+    assert replaced.history[2].provenance is not None
+
+
+async def test_score_overwrite_default_discards_history() -> None:
+    """Without preserve_history an overwrite behaves as before.
+
+    The replacement score has no history (even when the predecessor carried
+    one) and no `ScoreEditEvent` is recorded.
+    """
+    from inspect_ai.event import ScoreEditEvent
+    from inspect_ai.log import edit_score
+    from inspect_ai.log._edit import ProvenanceData
+    from inspect_ai.scorer._metric import ScoreEdit
+
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(log, [fixed_scorer(0.0, "old")], action="overwrite")
+    edit_score(
+        scored,
+        "test-1",
+        "fixed_scorer",
+        ScoreEdit(value=0.25, provenance=ProvenanceData(author="human")),
+        recompute_metrics=False,
+    )
+
+    rescored = await score_async(scored, [fixed_scorer(1.0, "new")], action="overwrite")
+
+    assert rescored.samples is not None
+    sample = rescored.samples[0]
+    assert sample.scores is not None
+    replaced = sample.scores["fixed_scorer"]
+    assert replaced.value == 1.0
+    assert replaced.history == []
+    assert not any(isinstance(e, ScoreEditEvent) for e in sample.events)
+
+
+async def test_score_preserve_history_requires_overwrite() -> None:
+    log = _preserve_history_log(_preserve_history_sample())
+    with pytest.raises(ValueError, match="preserve_history"):
+        await score_async(
+            log, [fixed_scorer(0.0)], action="append", preserve_history=True
+        )
+    # action=None defaults to append, so it is rejected too
+    with pytest.raises(ValueError, match="preserve_history"):
+        await score_async(log, [fixed_scorer(0.0)], preserve_history=True)
+
+
+async def test_score_preserve_history_unscored_sample() -> None:
+    """preserve_history on a never-scored sample is a no-op."""
+    from inspect_ai.event import ScoreEditEvent
+
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(
+        log, [fixed_scorer(0.0)], action="overwrite", preserve_history=True
+    )
+
+    assert scored.samples is not None
+    sample = scored.samples[0]
+    assert sample.scores is not None
+    assert sample.scores["fixed_scorer"].history == []
+    assert not any(isinstance(e, ScoreEditEvent) for e in sample.events)
+
+
+async def test_score_preserve_history_unchanged_sentinel_value() -> None:
+    """A score value that literally equals the "UNCHANGED" sentinel survives.
+
+    The replacement keeps the scorer-produced fields verbatim (only its
+    history comes from the edit machinery), so the `ScoreEdit` sentinel
+    cannot swallow a legitimate "UNCHANGED" value.
+    """
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(log, [fixed_scorer(0.0, "old")], action="overwrite")
+    rescored = await score_async(
+        scored,
+        [fixed_scorer("UNCHANGED")],
+        action="overwrite",
+        preserve_history=True,
+    )
+
+    assert rescored.samples is not None
+    assert rescored.samples[0].scores is not None
+    replaced = rescored.samples[0].scores["fixed_scorer"]
+    assert replaced.value == "UNCHANGED"
+    assert len(replaced.history) == 2
+    assert replaced.history[0].value == 0.0
+
+
+async def test_score_preserve_history_does_not_mutate_predecessor() -> None:
+    """With copy=False the caller-held predecessor Score object is not rewritten."""
+    log = _preserve_history_log(_preserve_history_sample())
+    scored = await score_async(log, [fixed_scorer(0.0, "old")], action="overwrite")
+    assert scored.samples is not None
+    assert scored.samples[0].scores is not None
+    predecessor = scored.samples[0].scores["fixed_scorer"]
+
+    await score_async(
+        scored,
+        [fixed_scorer(1.0, "new")],
+        action="overwrite",
+        preserve_history=True,
+        copy=False,
+    )
+
+    # the log itself was mutated (copy=False), but not the old Score object
+    assert scored.samples[0].scores["fixed_scorer"].value == 1.0
+    assert predecessor.value == 0.0
+    assert predecessor.answer == "old"
+    assert predecessor.history == []

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -975,6 +975,17 @@ async def test_score_overwrite_preserve_history() -> None:
     )
     assert sample.events.index(edit_event) < span_end_index
 
+    # the recorded ScoreEvent keeps the scorer-produced payload -- exactly what
+    # a plain overwrite records -- with no grafted history
+    score_events = [
+        e
+        for e in sample.events
+        if isinstance(e, ScoreEvent) and e.scorer == "fixed_scorer"
+    ]
+    assert len(score_events) == 1
+    assert score_events[0].score.value == 1.0
+    assert score_events[0].score.history == []
+
     # the input log was deep-copied, not mutated
     assert scored.samples is not None
     assert scored.samples[0].scores is not None


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Re-scoring a log with `score(..., action="overwrite")` (or `score_async`) discards the replaced scores entirely: `sample.scores` and the scorers span in the transcript are replaced wholesale, so the previous grades leave no trace in the log.

The only path that records score lineage today is `edit_score()`, which snapshots the pre-edit score into `Score.history` and emits a `ScoreEditEvent`. Downstream regrade tooling that wants "overwrite, but keep the old grade in history with provenance" therefore has to do a manual read-old / score-new / `edit_score`-swap dance per sample, reimplementing what the scoring pipeline already does.

The user-facing trigger: regrade pipelines (e.g. swapping an improved grader in over a set of existing logs) want the convenience and metrics handling of `action="overwrite"` without silently destroying the audit trail of what the previous grader said.

### What is the new behavior?

`score()` / `score_async()` gain `preserve_history: bool = False`. With `action="overwrite"` and `preserve_history=True`, each replaced score's predecessor is folded into the replacement's edit history using the same machinery as `edit_score()`.

**Exact semantics — what lands in `Score.history`** (for each score name produced by this scoring pass that already existed on the sample):

- If the predecessor had no history, its values (`value`, `answer`, `explanation`, `reason`, `metadata or {}`) are snapshotted into `history[0]` as a `ScoreEdit` with `provenance=None` (the marker for "original score", exactly as `edit_score()` does). If the predecessor already carried history (from previous `edit_score()` calls or previous preserved re-scores), that history is carried forward unchanged and no re-snapshot occurs.
- The re-scored values are appended as the final `ScoreEdit`, with `provenance=ProvenanceData(author=<user identity>, reason="Re-scored with scorer '<name>' (action='overwrite').")`. The author uses the same best-effort identity the viewer prefills in its edit dialogs (`user_info()`: git email local-part, then git `user.name`, then OS login), so a person's re-score edits and manual edits record the same author. The `edit_score()` invariants therefore hold: `history[0]` is always the original score, `history[-1]` always describes the current values, and a later `edit_score()` composes correctly (it sees a non-empty history and just appends).
- The replacement score's own fields are exactly the newly generated scorer output: the edit is applied to a *copy* of the predecessor and only the resulting history is attached to the new score. This keeps the score object itself identical to a plain overwrite (e.g. `metadata=None` stays `None`), means a value that legitimately equals the `"UNCHANGED"` sentinel cannot be swallowed by `ScoreEdit` semantics, and leaves caller-held predecessor objects untouched even with `copy=False`. Within the history record itself, `ScoreEdit.metadata` cannot be `None`, so it is recorded as `{}` — the same convention as `edit_score()`.

**What lands in the events:** the scorers span is replaced by the new one exactly as a plain overwrite does — the new `ScoreEvent`s live there, and the old span (including any old `ScoreEditEvent`s inside it) is still removed; lineage lives on `Score.history`, which survives. Additionally, one `ScoreEditEvent` per replaced score is inserted just before the end of the new scorers span, attributed to it via `span_id`, carrying the same `ScoreEdit` that was appended to history — identical placement and shape to `edit_score()`. The new `ScoreEvent`s record exactly what the scorer produced — the history is grafted onto a copy of the score, not onto the object embedded in the already-recorded event — so with `preserve_history` the event stream differs from a plain overwrite only by the inserted `ScoreEditEvent`s.

**Out of scope / unchanged:** a score counts as replaced only when the pass produces a score with the same name — existing scores whose scorer is not re-run are still dropped by the overwrite (there is no replacement score to attach them to; documented in the docstrings and docs). Scores with no same-name predecessor get an empty history and no event. `preserve_history=True` with `action="append"` (or the default action) raises `ValueError`, since append never replaces anything.

To reuse rather than reimplement, `edit_score()`'s existing-score edit application and its `ScoreEditEvent` insertion are extracted into `apply_score_edit()` and `insert_score_edit_event()` in `src/inspect_ai/log/_score.py`; `edit_score()` now calls them and its behavior is unchanged (covered by the existing edit tests).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `preserve_history` defaults to `False`, in which case the new code path is never entered — scores, events, results and reductions are produced exactly as before (tests assert the default overwrite still yields empty history and no `ScoreEditEvent`, including when the predecessor carried an edit history). The new parameter is inserted after `action` in both signatures (as `model`/`model_roles` were in #4264), which could only affect callers passing `display`/`copy` positionally past seven prior arguments.

### Other information:

**Testing** (the suite is large, so I ran the scoring/log-related test files plus lint/typecheck rather than the full suite):

- `pytest tests/_eval/test_score.py` — 18 passed (asyncio), 15 passed with `--runtrio`, 26 passed with `--runapi`. Includes 7 new tests: predecessor lands in `history[0]` with the `ScoreEditEvent` recorded inside the new scorers span (and the input log not mutated under the default `copy=True`); prior edit history carried forward (a `[0.0, 0.25, 1.0]` value chain across `edit_score` + preserved re-score); default overwrite still discards history and emits no `ScoreEditEvent`; `preserve_history` without `action="overwrite"` raises; never-scored samples are a no-op; a literal `"UNCHANGED"` score value survives; `copy=False` does not rewrite caller-held predecessor `Score` objects.
- `pytest tests/scorer/test_score_editing.py tests/log/test_score_edit_events.py tests/_cli/test_score.py` — 32 passed (plus trio variants: 25 passed) — these exercise the extracted `edit_score()` machinery unchanged.
- `pytest tests/log/test_eval_log.py tests/log/test_log_formats.py` — 75 passed.
- `ruff check` / `ruff format --check` clean; `mypy --exclude tests/test_package src tests` — no issues (1427 files).

**Tooling disclosure:** implemented with Claude Code (Claude Fable 5).

No merge conflict with #5121 (which also touches scoring): #5121's tests now live in their own file (`tests/_eval/test_score_init.py`), and a local test-merge of the two branches applied cleanly with the combined `tests/_eval/` suite passing — the two PRs can merge in either order.

### Agent review
- Reviewer: Claude Fable 5 via Claude Code subagents (each in a fresh context, same model as the author), 2 passes: one correctness-focused (aliasing/mutation, event-tree placement, metrics/reductions interplay, refactor fidelity — verified the extraction against `HEAD~1` line by line and reproduced edge cases empirically), one API/conventions/docs/tests-focused.
- Findings: 12 across the two passes (some overlapping) — 4 fixed, 8 dismissed.
  - Fixed: (1) a scorer legitimately returning the literal string `"UNCHANGED"` was swallowed by the `ScoreEdit` sentinel, silently keeping the old value in the score while the `ScoreEvent` showed the new one — the replacement now keeps the scorer-produced `Score` verbatim and only grafts history (regression test added); (2) the predecessor `Score` was mutated in place, visible to callers holding a reference under `copy=False` — the edit is now applied to a deep copy (regression test added); (3) the name-matching precondition for preservation was undocumented — now stated in both docstrings and the docs page; (4) provenance author used a bare `getpass` lookup, diverging from the identity convention the viewer prefills for manual edits — now uses the same `user_info()` helper.
  - Dismissed: parameter placement after `action` rather than appended (mid-signature insertion has direct precedent in these same functions, #4264; noted under breaking changes); no caller-supplied provenance and no CLI `--preserve-history` flag (kept minimal; natural follow-ups if there is demand); metadata `None`→`{}` drift (eliminated for the score itself by fix 1; inside the history record `ScoreEdit.metadata` cannot be `None`, same as `edit_score()`); helper naming/visibility (`apply_score_edit`/`insert_score_edit_event` stay unexported module helpers, consistent with the existing cross-module use of `_find_scorers_span`); default value on the internal `_run_score_task` parameter (kept — existing tests call it directly); tests importing `ScoreEditEvent` from a private module (fixed anyway — now imported from `inspect_ai.event`); preserving scores whose scorer is not re-run (would require inventing a place to hang them; documented instead).
- Pass 3 (independent adversarial pass, fresh context, Claude Fable 5): re-derived the invariant claims empirically — built a sample, scored, re-scored with `preserve_history`, ran `edit_score()` on the result, and round-tripped through a `.eval` file: `history == [original, re-score, manual edit]` with the provenance chain `[None, <user>, "human"]`, metrics recomputed from the edited value. Also verified `user_info()` determinism offline (git-config lookup with timeout, `getpass` fallback, no network) and that the bundled viewer branches on provenance truthiness (a `provenance=None` history entry is the exact shape `edit_score()` has always produced). Findings: 1 fixed, rest clean:
  - Fixed: the scorer-produced `Score` object is aliased into the recorded `ScoreEvent`, so grafting history onto it made the serialized `ScoreEvent` payload embed the edit history (and a later in-memory `edit_score()` retro-mutated the event through the shared reference) — the history is now grafted onto a copy that replaces the original in `sample.scores`/results, keeping the event payload byte-identical to a plain overwrite (regression assertion added). The equivalent aliasing on the plain scoring path is pre-existing on `main` and untouched.
  - Clean: renamed-scorer semantics documented at the parameter (where a user looks) and in the docs page; `preserve_history` with the implicit default action (`None` → append) correctly rejected; CHANGELOG entry grouped under `## Unreleased` with the other scoring items.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


