### PR TITLE
score()/score_async() work from a plain Python process without private init imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Scorers: `match(numeric=True)` now parses numbers with attached sentence or enclosing punctuation (e.g. "42!", "(42)"); operator prefixes (`<42`, `~42`) still do not match, and `location="exact"` remains strict. (#4742)
+- Scoring: `score()` and `score_async()` now initialize the runtime environment (startup hooks, `.env` resolution, log capture) automatically when called from a plain Python process.
 - Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices always score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)

--- a/src/inspect_ai/_eval/context.py
+++ b/src/inspect_ai/_eval/context.py
@@ -1,3 +1,5 @@
+from contextvars import ContextVar
+
 from anyio.abc import TaskGroup
 
 from inspect_ai._control.pause import reset_task_pause_gates
@@ -19,6 +21,10 @@ from inspect_ai.model._model import (
 from inspect_ai.util._concurrency import init_concurrency
 from inspect_ai.util._input.manager import init_human_question_manager
 from inspect_ai.util._subprocess import init_max_subprocesses
+
+_eval_context_active: ContextVar[bool] = ContextVar(
+    "_eval_context_active", default=False
+)
 
 
 def init_runtime_context(
@@ -46,6 +52,20 @@ def init_eval_context(
     init_human_approval_manager()
     init_human_question_manager()
     set_background_task_group(task_group)
+    _eval_context_active.set(True)
+
+
+def have_eval_context() -> bool:
+    """Has `init_eval_context()` run in the current execution context?
+
+    Tracked with a `ContextVar` scoped to the current task tree: set by
+    `eval()` / the CLI before they spawn task groups (and therefore
+    inherited by sample and scorer tasks) and by `score_async()` when it
+    self-initializes. Not visible from sibling task trees, so a top-level
+    caller that skipped initialization is detected even in a process that
+    performed one before.
+    """
+    return _eval_context_active.get()
 
 
 def init_model_context(

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -411,6 +411,11 @@ def eval(
 _eval_async_running = False
 
 
+def eval_async_running() -> bool:
+    """Is a call to `eval_async()` currently executing in this process?"""
+    return _eval_async_running
+
+
 async def eval_async(
     tasks: Tasks,
     model: str | Model | list[str] | list[Model] | None | NotGiven = NOT_GIVEN,

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -22,7 +22,12 @@ if TYPE_CHECKING:
 import anyio
 
 from inspect_ai._display import display as display_manager
-from inspect_ai._eval.context import init_task_context
+from inspect_ai._eval.context import (
+    have_eval_context,
+    init_eval_context,
+    init_task_context,
+)
+from inspect_ai._eval.eval import eval_async_running
 from inspect_ai._eval.loader import load_file_tasks, scorer_from_spec
 from inspect_ai._eval.task.task import resolve_scorer, resolve_scorer_metrics
 from inspect_ai._util._async import configured_async_backend, run_coroutine, tg_collect
@@ -226,6 +231,11 @@ async def score_async(
 ) -> EvalLog:
     """Score an evaluation log.
 
+    Can be called directly from any async Python code: when no eval
+    context is active (i.e. the call isn't made from within an eval or
+    the `inspect score` CLI) the runtime environment is initialized
+    automatically.
+
     Args:
        log (EvalLog):
          Evaluation log. Only the headers are needed if `samples`
@@ -252,6 +262,13 @@ async def score_async(
     Returns:
        Log with scores yielded by scorer.
     """
+    # self-initialize when called outside of an eval or the `inspect score`
+    # CLI (log_refusals matches the CLI). skipped while an eval is running
+    # in this process so a call from a sibling task can't reset its state.
+    if not have_eval_context() and not eval_async_running():
+        platform_init()
+        init_eval_context(None, None, log_refusals=True)
+
     if samples is None and log.samples is None:
         raise ValueError("There are no samples to score in the log.")
 

--- a/tests/_eval/test_score_init.py
+++ b/tests/_eval/test_score_init.py
@@ -1,0 +1,137 @@
+"""Tests for score_async() self-initializing its runtime context."""
+
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from test_helpers.utils import skip_if_no_openai_package
+
+from inspect_ai._eval.score import score_async
+from inspect_ai.log._file import read_eval_log_async
+from inspect_ai.scorer import match
+
+from .test_score import LOG_UNSCORED
+
+
+@skip_if_no_openai_package
+def test_score_self_initializes_in_fresh_process(tmp_path: pathlib.Path) -> None:
+    """Public score_async() works from a plain Python process.
+
+    A process that hasn't run an eval or the `inspect score` CLI has no
+    platform/eval context, and users shouldn't need the private
+    `platform_init()` / `init_eval_context()` pair to prepare one — this
+    script deliberately uses only public imports. The model api key is
+    provided solely via a `.env` in the working directory (and stripped
+    from the environment), so the test fails unless `score_async()`
+    established the runtime context (`.env` resolution in particular)
+    itself. `match()` never calls the model, so a placeholder key is fine.
+    """
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=sk-placeholder\n")
+    script = textwrap.dedent(
+        f"""
+        import anyio
+        from inspect_ai import score_async
+        from inspect_ai.log import read_eval_log
+        from inspect_ai.scorer import match
+
+        async def main() -> None:
+            log = read_eval_log({str(LOG_UNSCORED)!r})
+            scored = await score_async(
+                log, match(), action="overwrite", model="openai/gpt-4o"
+            )
+            assert scored.results is not None
+            assert [score.name for score in scored.results.scores] == ["match"]
+            print("SCORED-OK")
+
+        anyio.run(main)
+        """
+    )
+    # strip the api key (it must come from .env) along with hook config a
+    # plain fresh process wouldn't have (platform_init() enforces it)
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k
+        not in (
+            "OPENAI_API_KEY",
+            "INSPECT_TELEMETRY",
+            "INSPECT_API_KEY_OVERRIDE",
+            "INSPECT_REQUIRED_HOOKS",
+        )
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "SCORED-OK" in result.stdout
+
+
+def _clear_hook_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear hook config these tests may inherit from a dev machine.
+
+    Hook initialization (run by self-init's platform_init() and by
+    get_model()) raises if a configured hook provider isn't installed.
+    """
+    for var in (
+        "INSPECT_TELEMETRY",
+        "INSPECT_API_KEY_OVERRIDE",
+        "INSPECT_REQUIRED_HOOKS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+async def test_score_async_self_initializes_eval_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_ai._eval.context import _eval_context_active, have_eval_context
+
+    _clear_hook_env(monkeypatch)
+    token = _eval_context_active.set(False)
+    try:
+        log = await read_eval_log_async(LOG_UNSCORED)
+        scored = await score_async(log, match(), model="mockllm/model")
+        assert have_eval_context()
+        assert scored.results is not None
+    finally:
+        _eval_context_active.reset(token)
+
+
+async def test_score_async_skips_self_init_while_eval_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sibling-task score_async() must not reset a running eval's state."""
+    import inspect_ai._eval.eval as eval_module
+    from inspect_ai._eval.context import _eval_context_active, have_eval_context
+
+    _clear_hook_env(monkeypatch)
+    monkeypatch.setattr(eval_module, "_eval_async_running", True)
+    token = _eval_context_active.set(False)
+    try:
+        log = await read_eval_log_async(LOG_UNSCORED)
+        scored = await score_async(log, match(), model="mockllm/model")
+        assert not have_eval_context()
+        assert scored.results is not None
+    finally:
+        _eval_context_active.reset(token)
+
+
+async def test_score_async_preserves_active_eval_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an eval context is already active (CLI / in-eval), don't re-init."""
+    from inspect_ai._eval.context import init_eval_context
+    from inspect_ai.approval._human.manager import human_approval_manager
+
+    _clear_hook_env(monkeypatch)
+    init_eval_context(None, None, None)
+    manager = human_approval_manager()
+    log = await read_eval_log_async(LOG_UNSCORED)
+    await score_async(log, match(), model="mockllm/model")
+    assert human_approval_manager() is manager


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

The public `score()` / `score_async()` API cannot reliably be used from a plain Python process. Inspect's own CLI works around this: `_cli/score.py` prepares the environment with the private `platform_init()` + `init_eval_context(None, None, log_refusals=True)` pair before calling the same public `score_async()` function — and downstream programmatic users must copy exactly that private-import pair to get the same behavior.

Concretely, that pair provides five things a bare programmatic `score()` call lacks:

1. **`.env` resolution** (`init_dotenv()`, inside `init_eval_context()`) — a model API key that lives in a `.env` file in the working directory is never read, so scoring fails with `PrerequisiteError` even though the same log scores fine via `inspect score`. This is the one that errors loudly, and the one the regression test pins:

   ```python
   import anyio
   from inspect_ai import score_async
   from inspect_ai.log import read_eval_log
   from inspect_ai.scorer import match

   async def main():
       log = read_eval_log("logs/mylog.eval")
       # raises PrerequisiteError: no OPENAI_API_KEY -- the .env is never read,
       # because init_eval_context() (which runs init_dotenv()) never ran
       await score_async(log, match(), action="overwrite", model="openai/gpt-4o")

   anyio.run(main)
   ```

2. **Refusal logging** (`init_refusal_tracking(log_refusals=True)`, matching the CLI) — model refusals encountered during a programmatic scoring pass are currently not counted or logged.

3. **Log capture and log-level handling** (`init_logger()`) — inspect's python-log capture and `INSPECT_LOG_LEVEL` handling are not initialized, so warnings emitted by scorers land wherever the host process happens to route them (often nowhere) instead of being handled the way every other inspect entry point handles them.

4. **Startup hooks** (`platform_init()` → `init_hooks()`, plus the exception display hook) — organization-registered hooks (e.g. telemetry, key management) fire for CLI score runs but not for programmatic ones, so the two paths aren't equivalent from an operations standpoint.

5. **Runtime/concurrency context established before model resolution** (`init_runtime_context()`: concurrency registry, subprocess limits, active-sample bookkeeping) — today the trivial programmatic path works only because the module-level defaults happen to be serviceable, not because the context was set up for it.

The scoring-workflow docs advertise programmatic `score()` usage without mentioning any of this — it works or breaks depending on which init side effects the process happened to pick up.

### What is the new behavior?

`score_async()` self-initializes when no eval context is active: it performs the same `platform_init()` + `init_eval_context(None, None, log_refusals=True)` sequence the CLI does, so all five of the effects above hold for programmatic callers too (`log_refusals=True` matches the CLI). The sync `score()` wrapper gets this for free.

**Design choice.** Of the two options (self-initialization vs. exporting a public `init_score_context()` helper), self-initialization was chosen because "already initialized" is cheaply and reliably detectable, and it fixes existing documented usage without asking users to learn a new call. Detection works via a new `ContextVar` (`_eval_context_active` in `_eval/context.py`, accessor `have_eval_context()`) set at the end of `init_eval_context()`:

- **CLI path unchanged**: `inspect score` calls `init_eval_context()` in the same task that awaits `score_async()`, so the flag is visible and self-init is skipped.
- **In-eval path unchanged**: `eval_init()` sets the flag before task groups spawn; sample/scorer tasks inherit it.
- **Fresh process / fresh `anyio.run()`**: the flag is set inside the loop's task context and does not leak back out, so each top-level entry initializes exactly once, at the right time (before `get_model()` resolves the model from the log header, so `.env` keys are found).
- **Guard against clobbering a live eval**: self-init is also skipped while `eval_async()` is running in the process (new `eval_async_running()` accessor), so a `score_async()` call from a sibling task cannot reset a running eval's process-global state (concurrency registry, active samples, pause gates). Behavior in that situation is exactly the pre-PR status quo.

Known, accepted limitation: two *concurrent* top-level `score_async()` calls as sibling tasks (no eval running) each self-initialize; the second re-init is harmless for scoring (context-scoped managers are per-task-tree ContextVars; re-created concurrency semaphores still enforce limits).

### Does this PR introduce a breaking change?

No. Both existing init paths skip the new code entirely. `platform_init()` running twice on the sync `score()` path is idempotent (hook loading and the exception hook are guarded), and there is precedent: the `inspect eval` CLI already calls `platform_init()` before `eval()` calls it again. Users who already perform the private `platform_init()` + `init_eval_context()` workaround are also unaffected: the flag they set is visible inside subsequent `anyio.run()` invocations (context is copied in), so self-init is skipped and their configuration (e.g. an explicit `log_level`) is preserved. Hook enforcement is not new either — `get_model()` already runs `init_hooks()` on `main`, so a misconfigured hook environment failed programmatic scoring before this change too.

### Other information:

Tooling disclosure: implemented and reviewed with Claude Code (Claude Fable 5); every line reviewed and understood by the submitting account.

No merge conflict with #5120 (which also touches scoring): this PR's tests live in their own file, `tests/_eval/test_score_init.py`, and a local test-merge of the two branches applied cleanly with the combined `tests/_eval/` suite passing — the two PRs can merge in either order.

Testing (new tests in `tests/_eval/test_score_init.py`):
- `test_score_self_initializes_in_fresh_process` — subprocess with public imports only; the model key is provided solely via `.env` in the cwd and stripped from the environment, so the test fails without the fix (verified: fails on `main`, passes with this change).
- `test_score_async_self_initializes_eval_context` — flag transitions on self-init.
- `test_score_async_skips_self_init_while_eval_running` — no self-init while `eval_async()` is running.
- `test_score_async_preserves_active_eval_context` — a pre-established context (CLI/in-eval shape) is not re-initialized (`human_approval_manager()` identity preserved).

Ran locally: `tests/_eval/test_score.py`, `tests/_cli/test_score.py`, `tests/test_score_on_error.py` — 54 passed with `--runapi` (asyncio), new tests also pass under `--runtrio`; `ruff format --check`, `ruff check`, and `mypy` clean on all changed files; end-to-end smoke of `inspect eval` (mockllm) and `inspect score` CLI unchanged. The full `make test` suite was **not** run: it requires a broad matrix of provider keys, docker sandboxes, and network access not available in this environment; the scoring-adjacent files above plus CI are relied on for the rest.

### Agent review
- Reviewer: Claude Fable 5 (frontier-class), 3 independent passes, each in a fresh context separate from the author context.
- Passes 1–2: 11 findings (0 must-fix, 5 should-fix, 6 nits) — 8 fixed, 3 dismissed:
  - Fixed: sibling-task self-init could reset a live eval's process-global state (added the `eval_async_running()` guard + test); `have_eval_context()` docstring overclaimed no-leak across `anyio.run()` (sync `eval_set()` sets the flag in the main-thread context — reworded); new tests were sensitive to inherited `INSPECT_TELEMETRY`/`INSPECT_API_KEY_OVERRIDE`/`INSPECT_REQUIRED_HOOKS` (verified failing on a machine with them set; env now cleared in-test); oversized call-site comment replaying the docstring (trimmed); missing `skip_if_no_openai_package` guard; ContextVar declared below its accessors (moved above, matching `_util/background.py`).
  - Dismissed: "stripping `AZUREAI_OPENAI_API_KEY` is dead weight" vs. "azure env could make the test pass vacuously" — the two passes disagreed; traced `openai.py`: for `openai/gpt-4o` only `OPENAI_API_KEY` is consulted (`is_azure()` requires the azure service prefix), so the azure-env concern doesn't apply (kept a minimal strip list). `log_refusals=True` persisting process-globally after the call — deliberate CLI parity, same lifetime as the CLI's own setting. One reviewer suggested gating process-global init portions on a process-global latch — rejected as speculative complexity; the eval-running guard covers the demonstrated hazard.
- Pass 3 (independent adversarial pass): probed the `ContextVar` no-leak claim empirically on **both backends** (asyncio and trio): sequential `anyio.run(score_async)` calls each self-initialize (the flag never leaks back to the main-thread context); two concurrent sibling `score_async` calls each self-initialize and both complete (the documented accepted limitation); a main-thread private-init workaround propagates into subsequent `anyio.run()` calls so self-init is skipped (workaround users keep exactly their old behavior). Confirmed the check-then-init sequence contains no `await`, so on inspect's single event-loop thread there is no window between the `eval_async_running()` check and initialization. Re-verified the regression test fails on `main` sources and passes with the change. Findings: 0 code changes; 1 body correction folded into this description (hook enforcement was already the status quo via `get_model()`, so it is not a new failure mode) plus the fuller enumeration of init effects above.

- Amendment after the review passes: relocated this PR's new tests verbatim from `tests/_eval/test_score.py` into their own file `tests/_eval/test_score_init.py` (no code changes) to eliminate a file-level conflict with #5120; moved tests, `ruff`, and `mypy` re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

