### PR TITLE
Fix EvalSample.store_as() silently dropping instance-scoped store data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices always score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)
 - Solver: Preserve Choice original_position across multiple shuffles in Choices.shuffle(). (#5010)
+- Eval logs: `EvalSample.store_as()` with an `instance` argument now returns that instance's stored data instead of silently returning field defaults.
 - Eval logs: An Azure storage authentication failure while listing a remote log directory now raises `AzureAuthError` with remediation guidance instead of being downgraded to a warning and an empty listing, matching how S3 surfaces auth failures. (#4914)
 - Human Agent: End-of-input (e.g. Ctrl+D) at the `task submit`/`task quit` confirmation prompt now declines cleanly instead of raising an `EOFError` traceback.
 - Agents: Long subagent reports and submitted answers are no longer clipped at the maximum tool output size (they were previously truncated, subagent reports twice over).

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -477,10 +477,11 @@ class EvalSample(BaseModel):
         Returns:
           StoreModel: model_cls bound to sample store data.
         """
-        # un-namespace names for creation
-        data = {
-            k.replace(f"{model_cls.__name__}:", "", 1): v for k, v in self.store.items()
-        }
+        # un-namespace names for creation (mirrors StoreModel._ns_name, which
+        # writes instanced fields as "ClassName:instance:field")
+        namespace = f"{instance}:" if instance is not None else ""
+        prefix = f"{model_cls.__name__}:{namespace}"
+        data = {k.replace(prefix, "", 1): v for k, v in self.store.items()}
 
         # since we are reading from the log provide a fully detached store
         data["store"] = Store()

--- a/tests/solver/test_store_model.py
+++ b/tests/solver/test_store_model.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import BaseModel, Field, ValidationError
 
 from inspect_ai import Task, eval
+from inspect_ai.log import EvalSample
 from inspect_ai.solver._solver import Solver, solver
 from inspect_ai.util import Store, StoreModel, store, store_as
 
@@ -74,6 +75,28 @@ def test_store_model_log() -> None:
     assert my_model.x == 1
     assert my_model.y == "a"
     assert isinstance(my_model.steps[0], Step)
+
+
+def test_store_model_log_instance() -> None:
+    sample = EvalSample(
+        id="s1",
+        epoch=1,
+        input="input",
+        target="target",
+        store={"MyModel:x": 1, "MyModel:i1:x": 2},
+    )
+
+    # instanced read returns the instance's data
+    instanced = sample.store_as(MyModel, instance="i1")
+    assert instanced.x == 2
+
+    # default read still ignores instanced keys
+    default = sample.store_as(MyModel)
+    assert default.x == 1
+
+    # instance with no keys in the store falls back to field defaults
+    other = sample.store_as(MyModel, instance="i2")
+    assert other.x == 5
 
 
 def test_store_model_assignment():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`EvalSample.store_as()` — the offline/post-hoc path that reconstructs a typed `StoreModel` view from a persisted sample's store — ignores its `instance` argument's namespacing. The live write path (`StoreModel._ns_name`) stores instanced fields under `"MyModel:instance:field"`, but `EvalSample.store_as()` un-namespaces keys by stripping only the bare class prefix `"MyModel:"`. An instanced key `"MyModel:1:total"` therefore reduces to `"1:total"`, matches no field, and is silently dropped — the returned model is built entirely from field defaults. Worse, if default-instance keys are also present, an instanced read returns the *default instance's* values. No error is raised in either case.

```python
from pydantic import Field
from inspect_ai.log import EvalSample
from inspect_ai.util import StoreModel

class CCRun(StoreModel):
    total: int = Field(default=0)
    done: int = Field(default=0)

sample = EvalSample(
    id="s1", epoch=1, input="x", target="",
    store={"CCRun:1:total": 8, "CCRun:1:done": 8},  # what a live run persists
)
run = sample.store_as(CCRun, instance="1")
print(run.total, run.done)  # -> 0 0 (silent data loss); expected 8 8
```

Any post-hoc log analysis of instance-scoped store models (e.g. reading state written by tools that use `store_as(..., instance=...)`, such as `bash_session` or `web_browser`, or by user solvers that keep multiple instances of a model per sample) silently reads defaults instead of the persisted data.

This was discovered during adversarial review of #5119 (noted there under "Agent review" as pre-existing and out of scope); it is pre-existing on `main` and independent of that PR.

### What is the new behavior?

`EvalSample.store_as(cls, instance="x")` strips the same prefix the writer builds (`"MyModel:x:field"`), so instanced reads return the instance's stored data. The repro above prints `8 8`.

Default-instance reads are unchanged, including the existing (correct) behavior that instanced keys are ignored when reading the default instance — and instanced reads now symmetrically ignore default-instance and other-instance keys.

The other offline reconstruction path, `store_from_events_as()` in `src/inspect_ai/util/_store.py`, already handles instance namespacing correctly and is untouched; `TaskState.store_as()` binds the live `Store` (which namespaces on access) and is also unaffected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Calls without `instance` behave byte-for-byte as before. Calls with `instance` previously returned field defaults (or the default instance's values) — they now return the data the live run actually stored, which is the documented intent of the parameter.

### Other information:

**Testing** (Linux, Python 3.13):
- New regression test `test_store_model_log_instance` in `tests/solver/test_store_model.py`: round-trips an instanced store dict through `EvalSample`, asserting the instanced read returns the data, the default read still ignores instanced keys, and an unknown instance falls back to defaults. Verified it fails on `main` (`assert 1 == 2` — the instanced read returned the default instance's value) and passes with the fix.
- `pytest tests/solver/test_store_model.py tests/util/test_store_from_events.py tests/util/test_store_nested_types.py tests/scorer/test_score_store.py` — 58 passed.
- `ruff check` / `ruff format --check` — clean; `mypy` on touched files — no issues.
- The full `make test` suite was not run locally (needs provider credentials/sandboxes); CI should be authoritative.

**Agent involvement disclosure**: implemented with Claude Code (Claude Fable 5), human-directed.

### Agent review
- Reviewer: Claude Fable 5 (fresh context, adversarial), 1 pass on the final diff — in addition to the fresh-context review pass on #5119 that originally surfaced the bug.
- Findings: 3 — 1 fixed, 2 dismissed:
  - Fixed: CHANGELOG entry was prepended to the top of `## Unreleased` instead of grouped with the existing "Eval logs:" items (moved).
  - Dismissed: `k.replace(prefix, "", 1)` matches the first occurrence anywhere, not just as a prefix — pre-existing semantics preserved exactly for the default path, and the longer instanced prefix makes false matches strictly rarer, so no new behavior.
  - Dismissed: `store_from_events_as()` in `_store.py` inverts the same namespacing with its own (already-correct) `startswith` logic, so the codebase has two implementations of "invert `_ns_name`" — consolidating into a shared helper was left out to keep this bug-fix diff minimal.
- The pass also verified empirically that the regression test fails on the parent commit (returning the default instance's value, the exact reported bug) and traced the edge cases: other classes' keys, mixed default+instanced keys, instance names containing `:` or equal to a field name — all handled correctly, with default-instance reads byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
