### PR TITLE
Reuse cached prompt prefixes on Bedrock Converse requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bedrock: Converse requests now reuse cached prompt prefixes across turns and samples, cutting input token cost, and report cache read and write tokens in usage.
 - Scorers: `match(numeric=True)` now parses numbers with attached sentence or enclosing punctuation (e.g. "42!", "(42)"); operator prefixes (`<42`, `~42`) still do not match, and `location="exact"` remains strict. (#4742)
 - Multiple choice: The choice scorer now handles multi-digit labels when tasks have 36 or more options, and raises a clear error when a target references a position beyond the task's choices (samples without choices always score incorrect rather than raising). (#4590)
 - Approval: Support comma-separated tool patterns in approval policy configs, matching the documented `tools: web_browser*, bash` syntax; policy file paths given as `file://` URLs are normalized to local paths. (#5025)

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -148,7 +148,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto"] | bool | None
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic and Bedrock Converse (Claude and Nova) only."""
 
     fallback_models: list[str] | None
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""
@@ -275,7 +275,7 @@ class GenerateConfig(BaseModel):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto"] | bool | None = Field(default=None)
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic and Bedrock Converse (Claude and Nova) only."""
 
     fallback_models: list[str] | None = Field(default=None)
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -141,6 +141,10 @@ class ConverseReasoningContent(BaseModel):
     reasoningText: ConverseReasoningText
 
 
+class ConverseCachePoint(BaseModel):
+    type: Literal["default"] = "default"
+
+
 class ConverseMessageContent(BaseModel):
     text: str | None = None
     image: ConverseImage | None = None
@@ -149,6 +153,7 @@ class ConverseMessageContent(BaseModel):
     toolResult: ConverseToolResult | None = None
     guardContent: ConverseGuardContent | None = None
     reasoningContent: ConverseReasoningContent | None = None
+    cachePoint: ConverseCachePoint | None = None
 
 
 class ConverseMessage(BaseModel):
@@ -164,6 +169,10 @@ class ConverseUsage(BaseModel):
     inputTokens: int
     outputTokens: int
     totalTokens: int
+    # absent entirely on some models (e.g. claude-haiku-4-5) when nothing was
+    # cached, and reported as 0 on others (e.g. claude-sonnet-4-6)
+    cacheReadInputTokens: int | None = None
+    cacheWriteInputTokens: int | None = None
 
 
 class ConverseMetrics(BaseModel):
@@ -208,6 +217,7 @@ class ConverseContent(BaseModel):
 class ConverseSystemContent(BaseModel):
     text: str | None = None
     guardContent: ConverseGuardContent | None = None
+    cachePoint: ConverseCachePoint | None = None
 
 
 class ConverseInferenceConfig(BaseModel):
@@ -229,6 +239,20 @@ class ConverseTool(BaseModel):
     toolSpec: ConverseToolSpec
 
 
+class ConverseToolCachePoint(BaseModel):
+    """A `cachePoint` entry in `toolConfig.tools`.
+
+    Modelled separately from `ConverseTool` rather than making `toolSpec`
+    optional, so an ordinary tool entry is still statically guaranteed to
+    carry a spec.
+    """
+
+    cachePoint: ConverseCachePoint
+
+
+ConverseToolsEntry = Union[ConverseTool, ConverseToolCachePoint]
+
+
 class ConverseToolChoice(BaseModel):
     auto: dict[str, Any] | None = None
     any: dict[str, Any] | None = None
@@ -236,7 +260,7 @@ class ConverseToolChoice(BaseModel):
 
 
 class ConverseToolConfig(BaseModel):
-    tools: list[ConverseTool] | None = None
+    tools: list[ConverseToolsEntry] | None = None
     toolChoice: ConverseToolChoice | None = None
 
 
@@ -284,6 +308,23 @@ def _lock_object_additional_properties(schema: JSONSchema) -> None:
     if schema.anyOf:
         for any_schema in schema.anyOf:
             _lock_object_additional_properties(any_schema)
+
+
+# Claude families AWS documents as not supporting Converse prompt caching.
+# Everything else is treated as supported — see `supports_prompt_cache()` for
+# why the gate is an exclusion list rather than an inclusion list.
+CACHE_UNSUPPORTED_CLAUDE = (
+    # Bedrock spells Claude 2 `claude-v2` / `claude-v2:1`; the native anthropic
+    # provider's list uses the `claude-2` form, so match both.
+    "claude-2",
+    "claude-v2",
+    "claude-instant",
+    "claude-3-sonnet",
+    "claude-3-haiku",
+    "claude-3-opus",
+    # only the 20241022 (v2) 3.5 sonnet supports caching, not the 20240620 v1
+    "claude-3-5-sonnet-20240620",
+)
 
 
 class BedrockAPI(ModelAPI):
@@ -461,6 +502,29 @@ class BedrockAPI(ModelAPI):
     def is_nova(self) -> bool:
         return "nova" in self.model_family().lower()
 
+    def supports_prompt_cache(self) -> bool:
+        """Whether this model accepts Converse `cachePoint` blocks.
+
+        Exclusion-based, mirroring the model gating in the native anthropic
+        provider: any Claude that isn't on the deny list is assumed to
+        support caching, so a new family (claude 5, and whatever follows)
+        keeps working without a code change here. An inclusion list would
+        silently drop caching every time Anthropic changes the id scheme.
+        """
+        if self.is_nova():
+            return True
+        if not self.is_claude():
+            return False
+        family = self.model_family().lower()
+        return not any(name in family for name in CACHE_UNSUPPORTED_CLAUDE)
+
+    def cache_prompt_enabled(self, config: GenerateConfig) -> bool:
+        # "auto" and None both mean enabled, matching anthropic.py
+        cache_prompt = (
+            config.cache_prompt if isinstance(config.cache_prompt, bool) else True
+        )
+        return cache_prompt and self.supports_prompt_cache()
+
     def _is_claude_4_x(self, x: int) -> bool:
         # bedrock model ids look like
         # `anthropic.claude-opus-4-7-20260101-v1:0` or
@@ -614,6 +678,14 @@ class BedrockAPI(ModelAPI):
             system, messages = await converse_messages(
                 input, emulate_reasoning=self.is_claude()
             )
+
+            if self.cache_prompt_enabled(config):
+                add_cache_points(
+                    system,
+                    messages,
+                    tool_config,
+                    tools_supported=self.is_claude(),
+                )
 
             # Claude 4.7+ runs adaptive-thinking-only and rejects sampling
             # parameters; other thinking-enabled Claude models also reject
@@ -881,6 +953,54 @@ async def converse_messages(
     return system if len(system) > 0 else None, non_system
 
 
+def add_cache_points(
+    system: list[ConverseSystemContent] | None,
+    messages: list[ConverseMessage],
+    tool_config: ConverseToolConfig | None,
+    *,
+    tools_supported: bool,
+) -> None:
+    """Mark the cacheable prefixes of a Converse request.
+
+    Emits up to three `cachePoint` blocks, against Bedrock's limit of four for
+    Claude (a fifth is a hard ValidationException):
+
+    1. End of `system` — the static prefix. Converse renders
+       `tools` -> `system` -> `messages`, so this covers the tool definitions
+       too; tools only need their own point when there is no system prompt.
+    2. End of the penultimate message — a lookback point that still hits when
+       the final message differs between otherwise-identical requests (RAG,
+       scorers, approvers, branching evals). Mirrors
+       `add_lookback_cache_control` in the native anthropic provider.
+    3. End of the final message — so the next turn of an agent loop reads the
+       whole history instead of re-paying for this turn. The native provider
+       gets this from top-level automatic caching, which Bedrock doesn't
+       support; on Converse we can place it explicitly.
+
+    Points go at message boundaries, never between content blocks, so a
+    parallel tool-call turn's `toolResult` group is never split.
+    """
+
+    def cache_point() -> ConverseMessageContent:
+        return ConverseMessageContent(cachePoint=ConverseCachePoint())
+
+    if system:
+        system.append(ConverseSystemContent(cachePoint=ConverseCachePoint()))
+    elif tools_supported and tool_config is not None and tool_config.tools:
+        # Nova rejects a cachePoint inside toolConfig.tools outright
+        # ("Malformed input request: #/toolConfig/tools/0"), hence the gate.
+        tool_config.tools.append(
+            ConverseToolCachePoint(cachePoint=ConverseCachePoint())
+        )
+
+    # With a single message there is no earlier request whose cache this could
+    # serve, and that message is the volatile part (a per-sample question or
+    # document), so caching it would pay a write premium that is never read.
+    if len(messages) >= 2:
+        messages[-2].content.append(cache_point())
+        messages[-1].content.append(cache_point())
+
+
 def model_output_from_response(
     model: str, response: ConverseResponse, tools: list[ToolInfo]
 ) -> ModelOutput:
@@ -923,10 +1043,19 @@ def model_output_from_response(
         ),
     )
 
-    # Compute usage
+    # Compute usage. Converse reports cache reads/writes separately from
+    # inputTokens, matching ModelUsage's convention that input_tokens excludes
+    # both and total_tokens sums all four.
     input_tokens = response.usage.inputTokens
+    cache_read_tokens = response.usage.cacheReadInputTokens
+    cache_write_tokens = response.usage.cacheWriteInputTokens
     output_tokens = response.usage.outputTokens
-    total_tokens = input_tokens + output_tokens
+    total_tokens = (
+        input_tokens
+        + (cache_read_tokens or 0)
+        + (cache_write_tokens or 0)
+        + output_tokens
+    )
 
     # return ModelOutput
     return ModelOutput(
@@ -934,6 +1063,8 @@ def model_output_from_response(
         choices=[choice],
         usage=ModelUsage(
             input_tokens=input_tokens,
+            input_tokens_cache_read=cache_read_tokens,
+            input_tokens_cache_write=cache_write_tokens,
             output_tokens=output_tokens,
             total_tokens=total_tokens,
         ),
@@ -1251,11 +1382,11 @@ def converse_image_type(type: str) -> ConverseImageFormat:
             )
 
 
-def converse_tools(tools: list[ToolInfo]) -> list[ConverseTool] | None:
+def converse_tools(tools: list[ToolInfo]) -> list[ConverseToolsEntry] | None:
     if len(tools) == 0:
         return None
 
-    result = []
+    result: list[ConverseToolsEntry] = []
     for tool in tools:
         tool_spec = ConverseToolSpec(
             name=tool.name,

--- a/tests/model/providers/test_bedrock_prompt_cache.py
+++ b/tests/model/providers/test_bedrock_prompt_cache.py
@@ -1,0 +1,467 @@
+"""Bedrock Converse prompt caching.
+
+Placement rules and model gating are covered with a mocked Converse client;
+the `@skip_if_no_bedrock` tests at the bottom are the ones that actually prove
+caching happens, by asserting a non-zero `cacheReadInputTokens` on a repeat
+request. Request-shape assertions alone cannot do that — botocore accepts
+shapes the service then ignores or rejects.
+"""
+
+from typing import Any, Literal, cast
+
+import pytest
+
+pytest.importorskip("aiobotocore")
+pytest.importorskip("botocore")
+
+from test_helpers.utils import skip_if_no_bedrock  # noqa: E402
+
+from inspect_ai.model import (  # noqa: E402
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    GenerateConfig,
+    get_model,
+)
+from inspect_ai.model._providers.bedrock import (  # noqa: E402
+    BedrockAPI,
+    ConverseResponse,
+    model_output_from_response,
+)
+from inspect_ai.tool import ToolInfo  # noqa: E402
+from inspect_ai.tool._tool_call import ToolCall  # noqa: E402
+from inspect_ai.tool._tool_params import ToolParam, ToolParams  # noqa: E402
+
+CACHE_POINT = {"cachePoint": {"type": "default"}}
+
+# Real Bedrock ids, as returned by `aws bedrock list-inference-profiles`.
+# Note the 5-series and the 4.6+ ids carry no date/version suffix at all.
+SUPPORTED_MODELS = [
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic.claude-sonnet-4-6",
+    "us.anthropic.claude-opus-4-7",
+    "global.anthropic.claude-opus-4-8",
+    # 5-series: the reason the gate is an exclusion list
+    "anthropic.claude-opus-5",
+    "us.anthropic.claude-sonnet-5",
+    "global.anthropic.claude-fable-5",
+    "us.amazon.nova-pro-v1:0",
+    "global.amazon.nova-2-lite-v1:0",
+]
+
+UNSUPPORTED_MODELS = [
+    "meta.llama3-1-70b-instruct-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-instant-v1",
+    "anthropic.claude-v2:1",
+]
+
+
+# --- mocked Converse client ------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.request: dict[str, Any] | None = None
+
+    async def converse(self, **request: Any) -> dict[str, Any]:
+        self.request = request
+        return _response()
+
+
+class _FakeClientContext:
+    def __init__(self, client: _FakeClient) -> None:
+        self.client = client
+
+    async def __aenter__(self) -> _FakeClient:
+        return self.client
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, client: _FakeClient) -> None:
+        self.client_instance = client
+
+    def client(self, **kwargs: Any) -> _FakeClientContext:
+        return _FakeClientContext(self.client_instance)
+
+
+class _FakeHooks:
+    def start_request(self) -> str:
+        return "request-id"
+
+    def user_agent_extra(self, request_id: str) -> str:
+        return f"test/{request_id}"
+
+    def end_request(self, request_id: str) -> float:
+        return 0.0
+
+
+def _response(
+    *, cache_read: int | None = None, cache_write: int | None = None
+) -> dict[str, Any]:
+    usage: dict[str, int] = {
+        "inputTokens": 11,
+        "outputTokens": 7,
+        "totalTokens": 18 + (cache_read or 0) + (cache_write or 0),
+    }
+    if cache_read is not None:
+        usage["cacheReadInputTokens"] = cache_read
+    if cache_write is not None:
+        usage["cacheWriteInputTokens"] = cache_write
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+        "stopReason": "end_turn",
+        "usage": usage,
+        "metrics": {"latencyMs": 1},
+    }
+
+
+def _make_api(model_name: str) -> tuple[BedrockAPI, _FakeClient]:
+    api = BedrockAPI.__new__(BedrockAPI)
+    api.model_name = model_name
+    api.base_url = None
+    api.model_args = {}
+    api.read_timeout = 60
+    api.connect_timeout = 60
+    client = _FakeClient()
+    api.session = cast(Any, _FakeSession(client))
+    api._http_hooks = cast(Any, _FakeHooks())
+    return api, client
+
+
+def _lookup_tool() -> ToolInfo:
+    return ToolInfo(
+        name="lookup",
+        description="Look up a record.",
+        parameters=ToolParams(
+            properties={"q": ToolParam(type="string", description="query")},
+            required=["q"],
+        ),
+    )
+
+
+async def _request(
+    *,
+    model_name: str = "anthropic.claude-sonnet-4-6",
+    input: list[Any],
+    config: GenerateConfig | None = None,
+    tools: list[ToolInfo] | None = None,
+) -> dict[str, Any]:
+    api, client = _make_api(model_name)
+    await api.generate(
+        cast(Any, input), tools or [], "auto", config or GenerateConfig()
+    )
+    assert client.request is not None
+    return client.request
+
+
+def _count_cache_points(request: dict[str, Any]) -> int:
+    total = sum(1 for block in request.get("system", []) or [] if "cachePoint" in block)
+    for tool in (request.get("toolConfig") or {}).get("tools", []) or []:
+        if "cachePoint" in tool:
+            total += 1
+    for message in request["messages"]:
+        total += sum(1 for block in message["content"] if "cachePoint" in block)
+    return total
+
+
+CONVERSATION = [
+    ChatMessageSystem(content="stable instructions"),
+    ChatMessageUser(content="stable context"),
+    ChatMessageAssistant(content="stable answer"),
+    ChatMessageUser(content="dynamic question"),
+]
+
+
+# --- placement -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cache_prompt", [None, "auto", True])
+async def test_marks_system_lookback_and_rolling_prefixes(
+    cache_prompt: Literal["auto"] | bool | None,
+) -> None:
+    """Three points: static system prefix, lookback, and end of conversation."""
+    request = await _request(
+        input=CONVERSATION, config=GenerateConfig(cache_prompt=cache_prompt)
+    )
+
+    assert request["system"][-1] == CACHE_POINT
+    # lookback on the penultimate message, rolling point on the final one
+    assert request["messages"][-2]["content"][-1] == CACHE_POINT
+    assert request["messages"][-1]["content"][-1] == CACHE_POINT
+    # the first message is not a boundary we mark
+    assert not any("cachePoint" in b for b in request["messages"][0]["content"])
+
+
+@pytest.mark.parametrize("model_name", SUPPORTED_MODELS)
+async def test_supported_models_are_cached(model_name: str) -> None:
+    request = await _request(model_name=model_name, input=CONVERSATION)
+    assert _count_cache_points(request) > 0
+
+
+@pytest.mark.parametrize("model_name", UNSUPPORTED_MODELS)
+async def test_unsupported_models_preserve_request_shape(model_name: str) -> None:
+    request = await _request(model_name=model_name, input=CONVERSATION)
+    assert _count_cache_points(request) == 0
+
+
+async def test_cache_prompt_false_preserves_request_shape() -> None:
+    request = await _request(
+        input=CONVERSATION, config=GenerateConfig(cache_prompt=False)
+    )
+    assert _count_cache_points(request) == 0
+
+
+async def test_single_message_marks_only_the_static_prefix() -> None:
+    """A lone message is volatile, so only the static prefix is marked.
+
+    With one message there is no prior request whose cache this could serve,
+    and that message is the per-sample question or document — caching it would
+    pay a write premium that is never read back.
+    """
+    request = await _request(
+        input=[
+            ChatMessageSystem(content="stable instructions"),
+            ChatMessageUser(content="dynamic question"),
+        ]
+    )
+
+    assert request["system"][-1] == CACHE_POINT
+    assert not any("cachePoint" in b for m in request["messages"] for b in m["content"])
+
+
+async def test_falls_back_to_tools_when_there_is_no_system_prompt() -> None:
+    request = await _request(input=CONVERSATION[1:], tools=[_lookup_tool()])
+
+    assert "system" not in request
+    assert request["toolConfig"]["tools"][-1] == CACHE_POINT
+
+
+async def test_nova_never_marks_tools() -> None:
+    """Nova never gets a cachePoint in toolConfig.tools.
+
+    Bedrock rejects one outright with
+    `Malformed input request: #/toolConfig/tools/0`.
+    """
+    request = await _request(
+        model_name="us.amazon.nova-pro-v1:0",
+        input=CONVERSATION[1:],
+        tools=[_lookup_tool()],
+    )
+
+    assert not any("cachePoint" in t for t in request["toolConfig"]["tools"])
+    assert _count_cache_points(request) > 0
+
+
+async def test_parallel_tool_results_are_not_split() -> None:
+    """A parallel tool-call turn's toolResult group is never split.
+
+    Consecutive tool messages collapse into a single user message, so a
+    cachePoint placed by block offset rather than message boundary would land
+    between the toolResult blocks.
+    """
+    request = await _request(
+        input=[
+            ChatMessageUser(content="look up a and b"),
+            ChatMessageAssistant(
+                content="",
+                tool_calls=[
+                    ToolCall(id="tooluse_a", function="lookup", arguments={"q": "a"}),
+                    ToolCall(id="tooluse_b", function="lookup", arguments={"q": "b"}),
+                ],
+            ),
+            ChatMessageTool(content="ra", tool_call_id="tooluse_a", function="lookup"),
+            ChatMessageTool(content="rb", tool_call_id="tooluse_b", function="lookup"),
+        ],
+        tools=[_lookup_tool()],
+    )
+
+    blocks = request["messages"][-1]["content"]
+    tool_results = [i for i, b in enumerate(blocks) if "toolResult" in b]
+    cache_points = [i for i, b in enumerate(blocks) if "cachePoint" in b]
+    assert len(tool_results) == 2
+    # every cachePoint sits after the whole toolResult group, never inside it
+    assert all(i > max(tool_results) for i in cache_points)
+
+
+@pytest.mark.parametrize("model_name", SUPPORTED_MODELS)
+async def test_never_exceeds_bedrock_cache_point_limit(model_name: str) -> None:
+    """Claude rejects a fifth cachePoint with a ValidationException."""
+    long_conversation: list[Any] = [ChatMessageSystem(content="stable instructions")]
+    for i in range(6):
+        long_conversation.append(ChatMessageUser(content=f"q{i}"))
+        long_conversation.append(ChatMessageAssistant(content=f"a{i}"))
+
+    request = await _request(
+        model_name=model_name, input=long_conversation, tools=[_lookup_tool()]
+    )
+    assert _count_cache_points(request) <= 4
+
+
+# --- usage accounting ------------------------------------------------------
+
+
+def test_cache_usage_is_reported_and_counted_in_total() -> None:
+    output = model_output_from_response(
+        "m", ConverseResponse(**_response(cache_read=100, cache_write=25)), []
+    )
+    usage = output.usage
+    assert usage is not None
+    # input_tokens excludes cache reads/writes; total sums all four
+    assert usage.input_tokens == 11
+    assert usage.input_tokens_cache_read == 100
+    assert usage.input_tokens_cache_write == 25
+    assert usage.total_tokens == 11 + 100 + 25 + 7
+
+
+def test_missing_cache_usage_fields_remain_compatible() -> None:
+    """Some models omit the fields entirely rather than reporting 0."""
+    output = model_output_from_response("m", ConverseResponse(**_response()), [])
+    usage = output.usage
+    assert usage is not None
+    assert usage.input_tokens_cache_read is None
+    assert usage.input_tokens_cache_write is None
+    assert usage.total_tokens == 18
+
+
+def test_zero_cache_usage_fields_are_preserved() -> None:
+    output = model_output_from_response(
+        "m", ConverseResponse(**_response(cache_read=0, cache_write=0)), []
+    )
+    usage = output.usage
+    assert usage is not None
+    assert usage.input_tokens_cache_read == 0
+    assert usage.input_tokens_cache_write == 0
+    assert usage.total_tokens == 18
+
+
+# --- live -----------------------------------------------------------------
+#
+# The only tests that can show caching actually works. Prefixes must clear the
+# model's minimum cacheable length (1024 tokens on sonnet-4-6, 4096 on
+# haiku-4-5) or Bedrock silently declines to cache with no error.
+
+LIVE_MODEL = "bedrock/us.anthropic.claude-sonnet-4-6"
+
+
+def _filler(marker: str, tokens: int) -> str:
+    line = f"Note {marker}: inventory audit line covering warehouse aisle number "
+    return " ".join(line + str(i) + "." for i in range(max(1, tokens // 15)))
+
+
+@pytest.mark.anyio
+@skip_if_no_bedrock
+async def test_bedrock_live_multi_turn_reads_cache() -> None:
+    """A second turn re-reads the history cached by the first."""
+    model = get_model(LIVE_MODEL, config=GenerateConfig(max_tokens=16))
+    messages: list[Any] = [
+        ChatMessageSystem(content="You are an auditor. " + _filler("live-sys", 1500)),
+        ChatMessageUser(content="Audit aisle 1. " + _filler("live-u0", 600)),
+    ]
+    first = await model.generate(messages, tools=[], cache=False)
+    assert first.usage is not None
+
+    messages += [
+        ChatMessageAssistant(content="Checked. " + _filler("live-a0", 400)),
+        ChatMessageUser(content="Next please."),
+    ]
+    second = await model.generate(messages, tools=[], cache=False)
+    assert second.usage is not None
+    assert (second.usage.input_tokens_cache_read or 0) > 0, (
+        "second turn did not read the prefix cached by the first"
+    )
+
+
+@pytest.mark.anyio
+@skip_if_no_bedrock
+async def test_bedrock_live_shared_system_prompt_reads_cache() -> None:
+    """The single-turn eval shape: one system prompt, many varying questions.
+
+    The question must stay uncached — caching it would pay a write premium on
+    content no later request ever reads.
+    """
+    model = get_model(LIVE_MODEL, config=GenerateConfig(max_tokens=16))
+    system = ChatMessageSystem(
+        content="You are an auditor. " + _filler("live-shared", 2000)
+    )
+    await model.generate(
+        [system, ChatMessageUser(content="Question 0. " + _filler("live-q0", 300))],
+        tools=[],
+        cache=False,
+    )
+    second = await model.generate(
+        [system, ChatMessageUser(content="Question 1. " + _filler("live-q1", 300))],
+        tools=[],
+        cache=False,
+    )
+    assert second.usage is not None
+    assert (second.usage.input_tokens_cache_read or 0) > 0, (
+        "shared system prompt was not served from cache"
+    )
+
+
+@pytest.mark.anyio
+@skip_if_no_bedrock
+async def test_bedrock_live_cache_prompt_false_does_not_cache() -> None:
+    model = get_model(
+        LIVE_MODEL, config=GenerateConfig(max_tokens=16, cache_prompt=False)
+    )
+    messages: list[Any] = [
+        ChatMessageSystem(content="You are an auditor. " + _filler("live-off", 1500)),
+        ChatMessageUser(content="Hello."),
+        ChatMessageAssistant(content="Hi."),
+        ChatMessageUser(content="Reply OK."),
+    ]
+    await model.generate(messages, tools=[], cache=False)
+    output = await model.generate(messages, tools=[], cache=False)
+    assert output.usage is not None
+    assert not output.usage.input_tokens_cache_read
+    assert not output.usage.input_tokens_cache_write
+
+
+@pytest.mark.anyio
+@skip_if_no_bedrock
+async def test_bedrock_live_parallel_tool_results_accepted() -> None:
+    """Guards the toolResult-group placement against a live ValidationException."""
+    model = get_model(LIVE_MODEL, config=GenerateConfig(max_tokens=16))
+    messages: list[Any] = [
+        ChatMessageSystem(content="You are an auditor. " + _filler("live-par", 1500)),
+        ChatMessageUser(content="Look up a and b."),
+        ChatMessageAssistant(
+            content="",
+            tool_calls=[
+                ToolCall(id="tooluse_a", function="lookup", arguments={"q": "a"}),
+                ToolCall(id="tooluse_b", function="lookup", arguments={"q": "b"}),
+            ],
+        ),
+        ChatMessageTool(content="ra", tool_call_id="tooluse_a", function="lookup"),
+        ChatMessageTool(content="rb", tool_call_id="tooluse_b", function="lookup"),
+    ]
+    output = await model.generate(messages, tools=[_lookup_tool()], cache=False)
+    assert output.usage is not None
+
+
+@pytest.mark.anyio
+@skip_if_no_bedrock
+async def test_bedrock_live_nova_accepts_cache_points() -> None:
+    """Nova rejects a cachePoint in toolConfig.tools; system/messages are fine."""
+    model = get_model(
+        "bedrock/us.amazon.nova-pro-v1:0", config=GenerateConfig(max_tokens=16)
+    )
+    messages: list[Any] = [
+        ChatMessageUser(content=_filler("live-nova", 2000)),
+        ChatMessageAssistant(content="Understood."),
+        ChatMessageUser(content="Reply OK."),
+    ]
+    output = await model.generate(messages, tools=[_lookup_tool()], cache=False)
+    assert output.usage is not None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #4961.

> **Note on #4963.** @original4422 opened #4963 against the same issue first. This is an alternate implementation, opened at maintainer request after reviewing that PR. It differs in model gating, cachePoint placement, and validation — details under *Other information*. Two criticisms from that review turned out to be **wrong** once measured against live Bedrock; they're retracted below.

### What is the current behavior? (You can also link to an open issue here)

Bedrock Converse ignores `cache_prompt` entirely, so no prompt prefix is ever cached — every turn of an agent loop and every sample sharing a system prompt re-pays full price for the identical prefix. Converse response parsing also drops `cacheReadInputTokens` / `cacheWriteInputTokens`, so on the rare cache hit (there are none today) input would be under-counted.

### What is the new behavior?

Converse requests now mark their cacheable prefixes, and cache token counts land in `ModelUsage`.

**Placement.** Up to three `cachePoint` blocks per request, against Bedrock's limit of four:

```
tools   ─┐
system  ─┴─ [cachePoint]   static prefix, shared across samples
...
msg[-2] ─── [cachePoint]   lookback — survives churn in the final message
msg[-1] ─── [cachePoint]   rolling — next turn reads the whole history
```

Converse renders `tools` → `system` → `messages`, so the system point covers the tool definitions too; tools only get their own point when there is no system prompt. The lookback point mirrors `add_lookback_cache_control` in the native anthropic provider. The rolling point is what that provider gets from top-level automatic caching, which Bedrock doesn't support — on Converse we can place it explicitly.

Points sit at **message boundaries**, never between content blocks, so a parallel tool-call turn's `toolResult` group is never split.

A request with a single message gets only the static prefix. There is no earlier request whose cache it could serve, and that message is the volatile part — caching it pays a write premium nothing reads back. This matters: see the measurement below.

**Model gating** is an exclusion list mirroring the native anthropic provider, so a new Claude family keeps caching without a code change here. An inclusion list silently drops caching every time Anthropic changes the id scheme — and it already has: the current 5-series Bedrock ids carry no date or version suffix at all (`anthropic.claude-opus-5`, `us.anthropic.claude-sonnet-5`, `global.anthropic.claude-fable-5`).

Nova gets system and message points but never a `toolConfig.tools` point, which Bedrock rejects outright.

**Usage.** `input_tokens` excludes cache reads/writes and `total_tokens` sums all four, matching `ModelUsage`'s documented convention and `anthropic.py`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No API change. Caching is **on by default** for supported models, matching the native anthropic provider's treatment of `cache_prompt` (`None` and `"auto"` both mean enabled). Set `cache_prompt=False` to opt out.

Bedrock bills cache writes at a premium (1.25× for Anthropic models), so the default is a spend change, not just a saving. The measurements below cover both workload shapes; the single-message carve-out exists specifically so the classic single-turn eval doesn't regress.

### Other information:

#### Measured against live Bedrock

`us.anthropic.claude-sonnet-4-6`, billed-equivalent input tokens (uncached + 1.25×write + 0.1×read), lower is better:

| Strategy | 6-turn agent loop | 5-sample shared system prompt |
|---|---|---|
| no caching (today) | 29,766 | 14,730 |
| system point only | 21,478 | **6,234** |
| rolling point only | 12,831 | 17,452 ← **worse than no caching** |
| **this PR** | **12,656** | 6,399 |

The rolling-point-only column is why the single-message carve-out exists: on a single-turn eval it writes ~14k tokens of cache nobody ever reads.

#### Bedrock behaviour established empirically

Documented here because none of it is inferable from request-shape assertions, and some of it contradicts what the docs imply:

| Question | Answer |
|---|---|
| Does a cachePoint at the end of an *assistant* message work? | Yes — 1810 write → 1810 read |
| Does a *moved* cachePoint read a cache written at an earlier position? | **Yes** — prefix matching is position-independent |
| cachePoint interleaved between `toolResult` blocks | Accepted, not rejected — suboptimal, not a validation error |
| Below the minimum cacheable prefix | Silent no-op, no error → no gating needed |
| Minimum prefix | sonnet-4-6 ≈1024, haiku-4-5 ≈4096 (matches Anthropic's published table) |
| Max cachePoints, Claude | **4** — a 5th is a hard `ValidationException` |
| Max cachePoints, Nova | ≥5 across system + messages |
| cachePoint in `toolConfig.tools`, Nova | **Rejected** — `Malformed input request: #/toolConfig/tools/0` |
| cachePoint in `toolConfig.tools`, Claude | Accepted |

Note the third and fourth rows: `botocore`'s `ParamValidator` accepts shapes the service then ignores or rejects, so structural validation is not evidence that caching works.

#### Testing

`tests/model/providers/test_bedrock_prompt_cache.py` — 81 mocked cases (placement, gating across 12 supported and 7 unsupported real Bedrock ids, the 4-point cap, parallel tool results, usage accounting) plus 5 `@skip_if_no_bedrock` live tests that assert a real `cacheReadInputTokens > 0` on a repeat request.

The live tests are the only ones that can catch a caching regression, and they are **not vacuous** — with cache-point insertion disabled, both cache-read tests fail on their real assertions:

```
FAILED test_bedrock_live_multi_turn_reads_cache[asyncio]
  - AssertionError: second turn did not read the prefix cached by the first
FAILED test_bedrock_live_shared_system_prompt_reads_cache[asyncio]
  - AssertionError: shared system prompt was not served from cache
```

Results:

- `pytest tests/model/providers/ -k bedrock --runapi` with `ENABLE_BEDROCK_TESTS=1`: **133 passed, 58 skipped, 0 failed** (skips are `--runtrio` variants and models this account lacks access to)
- `ruff format` / `ruff check`: clean
- `mypy --exclude tests/test_package src tests`: clean, 1428 source files

**Coverage gap:** live tests ran against `us.anthropic.claude-sonnet-4-6` and `us.amazon.nova-pro-v1:0`. Claude 5-series is **mocked-only** — those inference profiles list as ACTIVE but return `AccessDenied` on the test account, so the forward-compatibility of the gating for 5-series ids is asserted but not live-verified.

`skip_if_no_bedrock` already existed in `tests/test_helpers/utils.py` but was unused; these are its first consumers.

#### Differences from #4963

| | #4963 | This PR |
|---|---|---|
| Gating | New regex `claude-[a-z]+-[45](?:-\|$)` | Exclusion list mirroring `anthropic.py` |
| 5-series covered | Yes, but untested (matrix tops out at 4-6) | Yes, in the mocked matrix |
| Placement | One point, 2nd content block from the end | Three points at message boundaries |
| Parallel tool results | cachePoint lands between `toolResult` blocks | Never split |
| Cap enforcement | n/a (single point) | Asserted ≤ 4 |
| Validation | Mocked request shapes only | Mocked + live cache-read assertions |

#4963's regex is a third copy of Claude version detection in a file that already has two, and diverges from the existing 5-series branch in `is_claude_4_7_or_later` (`claude-[a-zA-Z]+-5`, no anchor). The exclusion list removes the duplication.

Writing the gating test caught a bug I'd otherwise have shipped: `anthropic.py`'s list uses `claude-2`, but Bedrock spells it `claude-v2` / `claude-v2:1`, so Claude 2 would have had caching enabled. Both forms are matched now.

**Two criticisms from the review that prompted this PR were wrong**, and the live probes are what showed it — #4963's moving cachePoint does produce cache reads, and its interleaved `toolResult` placement is accepted rather than rejected (suboptimal, not a validation error). Its Nova `tools_supported=is_claude()` gate was also correct. Retracting all three here; the remaining differences above stand on the measurements, not on those points.

### Agent review

- **Reviewer: none.** No separate fresh-context review pass was run on this branch before opening. Stating that explicitly rather than implying coverage that doesn't exist.
- What was done instead: the design was chosen from live Bedrock measurements rather than from the docs (tables above), and the load-bearing live tests were mutation-checked by disabling cache-point insertion and confirming they fail on their real assertions.
- Authored with Claude Opus 5 via Claude Code. Happy to run a fresh-context review pass and update this section if useful before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
