### PR TITLE
Fix Moonshot logprobs test failing against a retired kimi-k2.5 model id

### DIFF
--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 import pytest
 from test_helpers.utils import (
@@ -15,15 +16,22 @@ from test_helpers.utils import (
 from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput, get_model
 
 
-async def generate_with_logprobs(model_name, **model_kwargs) -> ModelOutput:
+async def generate_with_logprobs(
+    model_name: str,
+    *,
+    temperature: float | None = 0.001,
+    extra_body: dict[str, Any] | None = None,
+    **model_kwargs: Any,
+) -> ModelOutput:
     model = get_model(
         model_name,
         config=GenerateConfig(
             logprobs=True,
             top_logprobs=2,
-            temperature=0.001,
+            temperature=temperature,
             max_tokens=50,
             max_retries=0,
+            extra_body=extra_body,
         ),
         **model_kwargs,
     )
@@ -51,10 +59,16 @@ async def test_openai_responses_logprobs() -> None:
 @pytest.mark.anyio
 @skip_if_no_moonshot
 async def test_moonshot_logprobs() -> None:
-    # kimi-k2.5 rather than k3: K3's thinking (on by default) would consume
-    # the small max_tokens budget before any completion tokens (and their
-    # logprobs) are emitted
-    response = await generate_with_logprobs("moonshot/kimi-k2.5")
+    # K3 rejects logprobs outright ("only false is allowed for this model"),
+    # so use K2.6 with thinking disabled -- with thinking on (the default) the
+    # small max_tokens budget is spent on reasoning tokens and no completion
+    # logprobs are emitted. K2.6 pins temperature to 0.6 even with thinking
+    # disabled, so send no temperature at all.
+    response = await generate_with_logprobs(
+        "moonshot/kimi-k2.6",
+        temperature=None,
+        extra_body={"thinking": {"type": "disabled"}},
+    )
     assert response.choices[0].logprobs is not None
     assert response.choices[0].logprobs.content[0].top_logprobs is not None
     assert len(response.choices[0].logprobs.content[0].top_logprobs) == 2


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Test-only change. Fixes meridianlabs-ai/inspect_ai#378.

### What is the current behavior? (You can also link to an open issue here)

`tests/model/test_logprobs.py::test_moonshot_logprobs` fails in both the asyncio and trio slow-test jobs:

```
openai.NotFoundError: Error code: 404 - {'error': {'message': 'Not found the model kimi-k2.5 or Permission denied', 'type': 'resource_not_found_error'}}
```

The test pinned `moonshot/kimi-k2.5`, which Moonshot has retired from its first-party API. Confirmed with a live key — `GET /v1/models` returns only:

```
kimi-k2.6
kimi-k2.7-code
kimi-k2.7-code-highspeed
kimi-k3
```

The key authenticates and lists models, so the "or Permission denied" half of Moonshot's conflated error message does not apply: this is a retired model id, not an account/entitlement problem. No inspect_ai change is involved — the same test passed 16 hours before the first red run, and the diff in that window touches no model or provider code (details in #378).

There is no user-facing behavior change; only the model this test exercises.

### What is the new behavior?

The test uses `moonshot/kimi-k2.6` with thinking disabled.

Two things were checked against the live API before choosing that, both of which rule out the simpler-looking options:

- **`kimi-k3` cannot be used at all.** It rejects the request outright with `400 invalid logprobs: only false is allowed for this model`, independent of thinking mode or token budget.
- **A bare id swap to `kimi-k2.6` would be a false green.** It passes, but with thinking on (the default) the test's 50-token budget is spent on reasoning tokens and the completion comes back empty — so the assertions would hold against *reasoning*-token logprobs rather than completion ones. That is exactly the failure mode the previous comment in the test was written to avoid.

With thinking disabled, K2.6 returns 9 completion-token logprobs with `top_logprobs=2` and real completion text. Reaching that required a small change to the shared `generate_with_logprobs` helper, which had no way to pass `extra_body` and hardcoded `temperature=0.001`:

```python
async def generate_with_logprobs(
    model_name: str,
    *,
    temperature: float | None = 0.001,
    extra_body: dict[str, Any] | None = None,
    **model_kwargs: Any,
) -> ModelOutput:
```

The temperature parameter is needed because K2.6 pins temperature to `0.6` even with thinking disabled — sending `0.001` returns `400 invalid temperature: only 0.6 is allowed for this model`. The default is unchanged, so the other callers of the helper are unaffected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test-only; no CHANGELOG entry (no product-functionality change).

### Other information:

Verified live against the Moonshot API: the test passes on both the asyncio and trio variants. The other tests in the file that have keys available locally (`test_openai_logprobs`, `test_openai_responses_logprobs`, `test_together_logprobs_openai_format`) still pass, confirming the helper change does not disturb its other callers. `ruff format`, `ruff check` and `mypy` are clean.

Deliberately left alone: the `kimi-k2.5` entry in `src/inspect_ai/model/_model_data/moonshotai.yml`. It exists to win case-normalized lookups against the auto-generated `together.yml`, and gateway providers may still serve K2.5 even though the first-party API does not — removing it is a separate judgment call.

Three separate bugs surfaced while investigating this one and were filed rather than folded in here:

- #381 — Moonshot 400s when a sampling param is set with Kimi thinking disabled. `completion_params()` only strips the fixed-sampling params while thinking is enabled, but probing shows the pin applies in both modes.
- #382 — Forcing a tool on Kimi K2.6 fails with a 400 instead of falling back. The named-`tool_choice` coercion targets `"any"`, which K2.6 and K2.7-code also reject with thinking on.
- #383 — Together logprobs requests 400 on newer models and silently cap `top_logprobs` at 1. This is why `test_together_logprobs` in the same file is also currently red; that failure is unrelated to this PR and is not addressed here.

### Agent review

- Reviewer: none. No separate review pass was run on this change.
- Author: Claude Opus 5 (1M context) via Claude Code. Verification was empirical rather than review-based: the failure was reproduced locally, the model list and every candidate replacement were probed against the live Moonshot API, and the fixed test was run on both anyio backends.