### PR TITLE
Add Inspect LogitTilt to the extensions listing

### DIFF
--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -193,3 +193,10 @@
     Open standard for portable LLM evaluation datasets. Convert between Inspect AI and other eval frameworks (DeepEval, Promptfoo, LangSmith, etc.) using a portable JSON format.
   author: "[Sahi Katukojula](https://github.com/adhabnr-ux)"
   categories: ["Frameworks"]
+
+- name: "[Inspect LogitTilt](https://adrskapars.github.io/inspect_logittilt/)"
+  description: |
+    Steers a model's sampling towards any target behaviour, surfacing on-policy
+    examples in fewer samples, accessing only the model's logits.
+  author: "[Adrians Skapars](https://scholar.google.com/citations?user=9Vf0mWkAAAAJ&hl=en)"
+  categories: ["Tooling"]


### PR DESCRIPTION
Adds [Inspect LogitTilt](https://adrskapars.github.io/inspect_logittilt/) to
`docs/extensions/extensions.yml` under Tooling.

It is a model provider (`hf-logittilt`) that steers a model's sampling toward a
described behaviour while a naturalness floor keeps sampling within what the
unmodified model already found probable, so an eval surfaces on-policy examples
of a rare behaviour in fewer samples. It subclasses the `hf` provider and needs
only output logits — no weights, activations or gradients.

Because it registers through the `inspect_ai` entry point, it works with any
eval that resolves its model via `get_model()`; it has been run against
`inspect_evals` tasks, Petri and Petri Bloom without integration code.

The paper introducing the method is due to appear on arXiv this week, with an
Alignment Forum post to follow.

- Docs: https://adrskapars.github.io/inspect_logittilt/
- Repo: https://github.com/AdrSkapars/inspect_logittilt
- PyPI: https://pypi.org/project/inspect-logittilt/

Only `extensions.yml` is edited; `extensions.json` is generated at build time.
