### PR TITLE
Contribution gate: accepted issue required for all non-qualified authors; enable enforcement

### DIFF
--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -8,22 +8,15 @@ Runs from pr-gate.yml on pull_request_target. Passes a PR if ANY of:
      total diff is < 25 lines                                     (trivial)
   5. a linked closing issue is labeled `accepted` (or
      `good first issue`, which implies accepted)                  (issue-approved)
-  6. author has a prior merged non-trivial PR in this repo        (established)
-Check 6 is additionally bounded by the open-PR cap: an established author
-with OPEN_PR_CAP or more other open PRs (drafts included) is closed until
-they are back under the cap — reopening re-runs the gate, so recovery is
-self-serve. The cap bounds only the direct-PR privilege; checks 4 and 5 are
-uncapped (trivial fixes are always welcome, an accepted issue is
-maintainer-approved demand) and checks 1-3 outrank it.
-Vetoes (checks 1-3 still pass either — a human vouching for the PR outranks):
+There is deliberately no pass for merged-PR history: contributors not on the
+qualified roster route every non-trivial change through an accepted issue,
+however many PRs they have landed. Who filed the issue doesn't matter —
+only whether a maintainer accepted it. Roster status is earned through a
+sustained record (CONTRIBUTING.md "Becoming a qualified contributor").
+Veto (checks 1-3 still pass — a human vouching for the PR outranks):
   - a linked closing issue labeled `deferred` closes the PR regardless of
-    checks 4-6 — the project has declined to prioritize that work, and the
+    checks 4-5 — the project has declined to prioritize that work, and the
     issue (not a new PR) is where re-prioritization happens.
-  - a linked closing issue FILED BY THE PR AUTHOR closes the PR unless some
-    linked issue is `accepted` (check 5) or the PR is trivial (check 4) —
-    self-filed issues don't establish demand, whatever the author's tier
-    (CONTRIBUTING.md). Once a maintainer accepts the issue, reopening the
-    PR re-runs the gate and it passes.
 Otherwise: comment + close (DRY_RUN: apply the `gate-dry-run` label only).
 PRs created before POLICY_START are never gated — the policy applies going
 forward; the pre-existing queue is dispositioned by hand.
@@ -52,17 +45,17 @@ from typing import Any, NamedTuple
 
 TEAM_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 TRIVIAL_MAX_LINES = 25
-OPEN_PR_CAP = 5  # max open PRs per established author (CONTRIBUTING.md)
-POLICY_START = "2026-07-29T00:00:00Z"  # PRs created before this are never gated
-PRIOR_MERGE_SEARCH_CAP = 30  # merged PRs by author to consider
-PRIOR_MERGE_FILECHECK_CAP = 10  # of those, how many to file-inspect
+# PRs created before this are never gated. Set to the qualified-or-accepted
+# policy's adoption date (2026-09-01) so PRs opened under the earlier rules
+# are judged by them (i.e. not at all — enforcement was off until then).
+POLICY_START = "2026-09-01T00:00:00Z"
 COMMENT_MARKER = "<!-- inspect-pr-gate -->"
 EXTENSIONS_URL = "https://inspect.aisi.org.uk/extensions.html"
 
 
 class Verdict(NamedTuple):
     verdict: str  # "pass" | "close"
-    tier: str  # qualified | trivial | issue-approved | established | new | deferred | capped | self-filed
+    tier: str  # qualified | trivial | issue-approved | needs-issue | deferred
     reason: str
 
 
@@ -129,21 +122,11 @@ def decide(ctx: dict) -> Verdict:
         return Verdict("pass", "trivial", "trivial docs fix (carve-out)")
     if "accepted" in labels or "good first issue" in labels:
         return Verdict("pass", "issue-approved", "linked issue is accepted")
-    if any(i["author"] == ctx["author"] for i in issues):
-        return Verdict(
-            "close",
-            "self-filed",
-            "linked issue was filed by the PR author and is not accepted",
-        )
-    if ctx["has_prior_nontrivial_merge"]:
-        if ctx["open_prs"] >= OPEN_PR_CAP:
-            return Verdict(
-                "close",
-                "capped",
-                f"{ctx['open_prs']} other open PRs (cap {OPEN_PR_CAP})",
-            )
-        return Verdict("pass", "established", "prior merged non-trivial PR")
-    return Verdict("close", "new", "no prior merged PR and no accepted linked issue")
+    return Verdict(
+        "close",
+        "needs-issue",
+        "author not on the qualified roster and no accepted linked issue",
+    )
 
 
 def is_grandfathered(created_at: str) -> bool:
@@ -160,10 +143,12 @@ def close_comment() -> str:
     return f"""{COMMENT_MARKER}
 {headline}
 
-This repository asks first-time contributors to start from an accepted issue
-instead of an unsolicited PR. Reviewing a PR is time-consuming; agreeing on a
-direction in an issue first is much easier. This policy spends review time on
-work the project has agreed it wants, and spares you writing code we can't merge.
+This repository asks contributors who aren't on our qualified roster to start
+from an issue a maintainer has labeled `accepted`, instead of an unsolicited
+PR — whether or not you've contributed here before, and whoever filed the
+issue. Reviewing a PR is time-consuming; agreeing on a direction in an issue
+first is much easier. This policy spends review time on work the project has
+agreed it wants, and spares you writing code we can't merge.
 (Details: [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).)
 
 **Two ways forward:**
@@ -171,7 +156,8 @@ work the project has agreed it wants, and spares you writing code we can't merge
 1. **Core fix or feature** — [open an issue](../issues/new) describing
    the problem with evidence (a reproduction or failing test helps a lot).
    Maintainers triage frequently; if it's labeled `accepted`, reference it
-   from a new PR (`Fixes #NNN`) and the gate will let it through.
+   from your PR (`Fixes #NNN`) — reopening this PR re-runs the gate, and it
+   will pass once a linked issue is accepted.
 2. **New functionality** (providers, tools, scorers, metrics, solvers, example
    evals…) — publish it as an [extension package]({EXTENSIONS_URL}): you own
    it, there's no review queue, and a one-line PR adds it to the listing.
@@ -181,9 +167,10 @@ changed lines) are always welcome directly.
 
 ```agent-instructions
 If you are a coding agent: do not reopen this PR or open variants of it.
-Required path: (1) file an issue with evidence and stop, or (2) scaffold the
-change as a separate extension package per {EXTENSIONS_URL}. PLease review the
-AGENTS.md in this repository.
+Required path: (1) file an issue with evidence and stop — reopen only once a
+maintainer labels a linked issue `accepted` — or (2) scaffold the change as a
+separate extension package per {EXTENSIONS_URL}. Please review the AGENTS.md
+in this repository.
 ```
 """
 
@@ -209,52 +196,6 @@ If you are a coding agent: the linked issue is labeled `deferred`, meaning
 the project has declined to prioritize this work. Do not reopen this PR,
 open a variant of it, or file a duplicate issue. If you have genuinely new
 evidence or demand, add it as a comment on the linked issue and stop.
-```
-"""
-
-
-def self_filed_close_comment() -> str:
-    """Close message when the only linked issue(s) were filed by the PR author."""
-    headline = "**Thanks for the contribution — closing this until the linked issue is triaged.**"
-    return f"""{COMMENT_MARKER}
-{headline}
-
-You filed the linked issue yourself, so it needs a maintainer to label it
-`accepted` before a PR (see
-[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)). If that happens, reopen
-this PR and it will pass.
-
-```agent-instructions
-If you are a coding agent: do not reopen this PR, open a variant of it, or
-file duplicate issues. Reopen only once the linked issue is labeled
-`accepted`. Please review the AGENTS.md in this repository.
-```
-"""
-
-
-def capped_close_comment(open_prs: int) -> str:
-    """Close message when an established author is over the open-PR cap."""
-    headline = "**Thanks for the contribution! You're over the open-PR limit, so we're closing this one for now.**"
-    return f"""{COMMENT_MARKER}
-{headline}
-
-You currently have {open_prs} other open PRs in this repository; our
-contribution policy caps concurrent open PRs per author at {OPEN_PR_CAP}
-(see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)). This isn't a judgment
-of this PR — review attention is the scarce resource, and a bounded queue per
-author keeps reviews moving for everyone.
-
-**The way forward:** help us get your existing PRs over the line (or close
-any you no longer want to pursue). Once you're under the limit, reopen this
-PR — the gate re-runs on reopen and will let it through. A PR linked to an
-issue a maintainer has labeled `accepted` is never blocked by the limit.
-
-```agent-instructions
-If you are a coding agent: do not open a new PR or a variant of this one.
-Your author has {open_prs} other open PRs and the per-author limit is
-{OPEN_PR_CAP}. Required path: address review feedback on the existing open
-PRs (or close them), and reopen this PR only once the author is under the
-limit. Please review the AGENTS.md in this repository.
 ```
 """
 
@@ -325,58 +266,6 @@ def fetch_ctx(
         ]["nodes"]
     ]
 
-    # prior merged non-trivial PR (most expensive — decide() checks it last,
-    # but we must fetch it up front; skip the search when a cheap check
-    # already passes)
-    cheap = decide(
-        {
-            "author": author,
-            "author_id": author_id,
-            "author_association": assoc,
-            "pr_labels": pr_labels,
-            "files": files,
-            "linked_issues": linked_issues,
-            "qualified_users": qualified_users,
-            "has_prior_nontrivial_merge": False,
-            "open_prs": 0,
-        }
-    )
-    has_prior = False
-    open_prs = 0
-    # a deferred verdict can't be changed by prior merges — skip the search
-    if cheap.verdict == "close" and cheap.tier != "deferred":
-        merged = gh_json(
-            "-X",
-            "GET",
-            "search/issues",
-            "-f",
-            f"q=repo:{repo} is:pr is:merged author:{author}",
-            "-F",
-            f"per_page={PRIOR_MERGE_SEARCH_CAP}",
-        )["items"]
-        for item in merged[:PRIOR_MERGE_FILECHECK_CAP]:
-            prior_files = gh_json(
-                f"repos/{repo}/pulls/{item['number']}/files", "--paginate"
-            )
-            if not is_trivial(prior_files):
-                has_prior = True
-                break
-        # the open-PR cap binds only on the established path, so count the
-        # author's other open PRs (drafts included) only once we know they
-        # are established. The current PR is excluded by number rather than
-        # trusting the search index to have caught up with it.
-        if has_prior:
-            open_items = gh_json(
-                "-X",
-                "GET",
-                "search/issues",
-                "-f",
-                f"q=repo:{repo} is:pr is:open author:{author}",
-                "-F",
-                "per_page=100",
-            )["items"]
-            open_prs = sum(1 for item in open_items if item["number"] != pr_number)
-
     return {
         "author": author,
         "author_id": author_id,
@@ -385,8 +274,6 @@ def fetch_ctx(
         "files": files,
         "linked_issues": linked_issues,
         "qualified_users": qualified_users,
-        "has_prior_nontrivial_merge": has_prior,
-        "open_prs": open_prs,
     }
 
 
@@ -439,14 +326,7 @@ def main() -> int:
         print("gate comment already present — not repeating")
         return 0
 
-    if v.tier == "deferred":
-        body = deferred_close_comment()
-    elif v.tier == "capped":
-        body = capped_close_comment(ctx["open_prs"])
-    elif v.tier == "self-filed":
-        body = self_filed_close_comment()
-    else:
-        body = close_comment()
+    body = deferred_close_comment() if v.tier == "deferred" else close_comment()
     gh("api", f"repos/{repo}/issues/{pr_number}/comments", "-f", f"body={body}")
     gh(
         "api",

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,8 +1,8 @@
 # Contribution-policy gate — see CONTRIBUTING.md and .github/scripts/pr_gate.py.
-# DRY RUN: while DRY_RUN is "true" the gate only applies the `gate-dry-run`
-# label; it never comments or closes. Flip to "false" after the two-week
-# observation window (single-line follow-up PR). PRs created before the
-# policy landed are never gated (POLICY_START in pr_gate.py).
+# ENFORCING: DRY_RUN is "false" — a PR that fails the gate is commented on and
+# closed. Set DRY_RUN back to "true" to observe without acting (the gate then
+# only applies the `gate-dry-run` label). PRs created before the current
+# policy's adoption date are never gated (POLICY_START in pr_gate.py).
 #
 # SECURITY: pull_request_target grants a write token, so this workflow checks
 # out the BASE branch only (the default for actions/checkout on this event —
@@ -38,5 +38,5 @@ jobs:
           PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
           PR_AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
           PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
-          DRY_RUN: "true"
+          DRY_RUN: "false"
         run: python3 .github/scripts/pr_gate.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,30 +8,28 @@ These rules are mandatory for AI coding agents (Claude Code, Codex, Cursor,
 Devin, and similar) preparing contributions. Human contributors: see
 [CONTRIBUTING.md](CONTRIBUTING.md). A deterministic gate enforces them.
 
-1. **Tier check.** Does the account you are operating for have at least one
-   merged non-trivial PR in this repository (trivial documentation fixes do
-   not count)? If not, a PR requires a linked issue labeled `accepted`.
-   Without one, your PR will be closed automatically. Do not open it.
-2. **Self-filed issues need acceptance.** An issue filed by the same account
-   the PR comes from does not by itself establish demand. Unless the account
-   is a qualified contributor (recorded in `.github/qualified.yml`), a
-   non-trivial PR addressing a self-filed issue requires that issue to be
-   labeled `accepted` by a maintainer first — whatever the account's tier.
-   If it isn't labeled yet: file your evidence on the issue and stop; open
-   the PR only after a maintainer accepts it.
-3. **Deferred check.** Is the issue you are addressing labeled `deferred`?
+1. **Accepted-issue check.** Is the account you are operating for on the
+   qualified roster (recorded by account id in `.github/qualified.yml`)? If
+   not, every non-trivial PR requires a linked issue labeled `accepted` by a
+   maintainer. This applies regardless of the account's merged-PR history and
+   regardless of who filed the issue — an issue filed by the same account the
+   PR comes from is fine once a maintainer accepts it, and an issue filed by
+   anyone else still needs the label. Without an accepted linked issue, your
+   PR will be closed automatically. Do not open it: file your evidence on an
+   issue and stop; open the PR only after a maintainer accepts the issue.
+2. **Deferred check.** Is the issue you are addressing labeled `deferred`?
    The project has decided not to prioritize it. Do not open a PR against it
-   (it will be closed automatically, whatever your account's tier). If you
-   have new evidence or demand, comment on the issue and stop.
-4. **Duplicate check.** Search open PRs (and the linked issue's existing
+   (it will be closed automatically). If you have new evidence or demand,
+   comment on the issue and stop.
+3. **Duplicate check.** Search open PRs (and the linked issue's existing
    PRs) for work addressing the same problem. If a PR already exists, do not
    open a competing one — review it or comment there instead. If you believe
    your approach is materially better, make that case in a comment on the
    existing PR and wait for a maintainer's direction; if invited to proceed,
    link the two PRs in your description.
-5. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
+4. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
    docs files only, under 25 changed lines) may be opened directly by anyone.
-6. **New functionality defaults to an extension, not core.** Do not open
+5. **New functionality defaults to an extension, not core.** Do not open
    unrequested PRs adding functionality — providers, tools, scorers, metrics,
    solvers, storage backends, example evals. Some of these do belong in core,
    but that is a maintainer decision made in an issue: if an accepted issue
@@ -39,7 +37,7 @@ Devin, and similar) preparing contributions. Human contributors: see
    extension package (see https://inspect.aisi.org.uk/extensions.html),
    optionally with a one-line PR adding it to the extensions listing.
    Unrequested additions to core are closed without detailed review.
-7. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
+6. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
    does it fix a demonstrated problem, with evidence (a reproduction or a
    failing test)? If the need is speculative or the fix unverified, do not
    proceed. File an issue with your evidence instead.
@@ -49,9 +47,7 @@ If you do open a PR: reference the accepted issue (`Fixes #NNN`); run
 changes, run at least one code review pass in a fresh context on a strong
 (frontier-class) model (see "Authoring pull requests" below); disclose
 agent involvement in the PR description; one issue per PR — no bundled
-drive-by changes; respect the open-PR limit (5 per account without write
-access, drafts included — enforced automatically; a PR over the limit is
-closed and can be reopened once the account is back under it).
+drive-by changes.
 
 As part of disclosing agent involvement, include an `### Agent review`
 section in the PR description. What to disclose, and how it's read:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,34 @@
 # Contributing to Inspect AI
 
-Thanks for your interest in contributing to Inspect! We regularly accept contributions from the community and we're glad you want to help. To keep review capacity focused on work the project has agreed it wants, contributions follow a tiered policy. Please read this section first.
+Thanks for your interest in contributing to Inspect! We regularly accept contributions from the community and we're glad you want to help. To keep review capacity focused on work the project has agreed it wants, contributions run through an issue-first policy. Please read this section first.
 
 ## How contributions work
 
-Your path depends on your history with the project:
+There are two paths:
 
 - **Qualified contributors**: maintainers and individuals recorded (by
   account id) in [`.github/qualified.yml`](.github/qualified.yml) — may open
   PRs directly.
 
-- **Established contributors**: anyone with at least one merged non-trivial
-  PR in this repository (trivial documentation fixes don't count toward this)
-  — may open PRs directly, subject to a limit of 5 open PRs at a time
-  (drafts count). A PR that would exceed the limit is closed automatically;
-  once you're back under it — by getting existing PRs merged or closing ones
-  you no longer want to pursue — reopen the closed PR and it will pass. A PR
-  linked to an issue a maintainer has labeled `accepted` is never blocked by
-  the limit.
-  One caveat: an issue you filed yourself doesn't establish demand. A PR
-  addressing your own issue needs that issue labeled `accepted` first, just
-  as for new contributors — self-reported problems get maintainer sign-off
-  before code, self-*discovered* fixes for problems others have reported
-  don't need it. This is enforced automatically: a PR linked to your own
-  not-yet-accepted issue is closed; if maintainers accept the issue, reopen
-  the PR and it will pass.
-- **New contributors**: if you haven't had a PR merged here yet, start from an
-  issue a maintainer has labeled `accepted` before writing code. PRs from new
-  contributors that aren't linked to an accepted issue are closed
-  automatically, with a comment explaining the available paths.
-  **Exception:** trivial documentation fixes (typos, broken links) are always
-  welcome directly.
+- **Everyone else**: start from an issue a maintainer has labeled `accepted`
+  before writing code, and reference it from your PR (`Fixes #NNN`). This
+  applies regardless of your contribution history here, and regardless of
+  who filed the issue — what matters is that a maintainer has accepted it.
+  PRs that aren't linked to an accepted issue are closed automatically, with
+  a comment explaining the available paths; if a linked issue is later
+  accepted, reopen the PR and it will pass.
+  **Exception:** trivial documentation fixes (typos, broken links — docs
+  files only, under 25 changed lines) are always welcome directly.
 
-Whatever your tier, a non-draft PR inactive for 60 days is closed with an
-invitation to reopen. And whatever your tier, check for an existing open PR
+Whatever your path, a non-draft PR inactive for 60 days is closed with an
+invitation to reopen. And whatever your path, check for an existing open PR
 addressing the same problem before opening yours: duplicates are closed in
 favor of the earlier PR unless a maintainer has asked for an alternative.
 
 Issues a maintainer has labeled `deferred` are decisions not to prioritize
-that work right now. PRs against a deferred issue are closed automatically,
-whatever your tier — comment on the issue with new evidence or demand if you
-think it should be revisited.
+that work right now. PRs against a deferred issue are closed automatically —
+comment on the issue with new evidence or demand if you think it should be
+revisited.
 
 **Why:** like most open-source projects, we now receive a large volume of
 unrequested, often agent-generated PRs. Reviewing a PR is time-consuming;
@@ -48,7 +36,7 @@ agreeing on a direction in an issue first is much easier. This policy spends
 our review time on work we've agreed we want and spares you writing code we
 can't merge.
 
-## Proposing work (new contributors)
+## Proposing work
 
 1. **Search existing issues and open PRs** to avoid duplicates.
 2. **Open an issue** describing the problem, the motivation, and (optionally)
@@ -72,7 +60,7 @@ listing.
 
 ## Using AI tools
 
-AI-assisted contributions are welcome from every tier — we use these tools
+AI-assisted contributions are welcome on both paths — we use these tools
 ourselves. The requirements:
 
 - You must understand, and be able to explain and defend, every line you
@@ -156,7 +144,9 @@ that isn't a judgment of you or your work.
 
 Qualified status is earned through a sustained record. As a rule of thumb, being added to the qualified list requires several
 months of PRs that mostly merge (~75%+) as well as responsive engagement in review.
-Maintainers periodically add such contributors to our list of qualified contributors.
+That record is built through the issue-first path above — accepted issues,
+then PRs that reference them. Maintainers periodically add such contributors
+to our list of qualified contributors.
 
 ## Thanks so much!
 

--- a/tests/test_pr_gate.py
+++ b/tests/test_pr_gate.py
@@ -29,8 +29,6 @@ def make_ctx(**overrides):
         "files": [{"filename": "src/inspect_ai/x.py", "additions": 40, "deletions": 3}],
         "linked_issues": [],  # closing issues: [{"author": login, "labels": [...]}]
         "qualified_users": {111222},  # account ids from .github/qualified.yml
-        "has_prior_nontrivial_merge": False,
-        "open_prs": 0,  # author's OTHER open PRs in this repo (excludes this one)
     }
     ctx.update(overrides)
     return ctx
@@ -105,9 +103,12 @@ def test_qualified_label_passes():
     assert v.verdict == "pass" and v.tier == "qualified"
 
 
-def test_prior_nontrivial_merge_passes_as_established():
+def test_prior_merge_history_grants_nothing():
+    # There is deliberately no "established" tier: merged-PR history does not
+    # exempt anyone from the accepted-issue requirement. (An obsolete ctx key
+    # is ignored rather than honored.)
     v = pr_gate.decide(make_ctx(has_prior_nontrivial_merge=True))
-    assert v.verdict == "pass" and v.tier == "established"
+    assert v.verdict == "close" and v.tier == "needs-issue"
 
 
 def test_trivial_docs_pr_passes():
@@ -130,22 +131,31 @@ def test_good_first_issue_implies_accepted():
 def test_unknown_author_no_issue_fails():
     v = pr_gate.decide(make_ctx())
     assert v.verdict == "close"
-    assert v.tier == "new"
+    assert v.tier == "needs-issue"
 
 
 def test_linked_issue_without_accepted_fails():
     v = pr_gate.decide(make_ctx(linked_issues=[issue(["enhancement"])]))
-    assert v.verdict == "close"
+    assert v.verdict == "close" and v.tier == "needs-issue"
+
+
+def test_self_filed_accepted_issue_passes():
+    # Who filed the issue is irrelevant — only the `accepted` label matters.
+    v = pr_gate.decide(make_ctx(linked_issues=[issue(["accepted"], author="somebody")]))
+    assert v.verdict == "pass" and v.tier == "issue-approved"
+
+
+def test_self_filed_unaccepted_issue_fails():
+    v = pr_gate.decide(make_ctx(linked_issues=[issue(author="somebody")]))
+    assert v.verdict == "close" and v.tier == "needs-issue"
 
 
 # --- deferred veto: a deferred linked issue closes the PR for every
 # automatic pass; only the human-vouched qualified tier goes through ---
 
 
-def test_deferred_linked_issue_fails_established_author():
-    v = pr_gate.decide(
-        make_ctx(has_prior_nontrivial_merge=True, linked_issues=[issue(["deferred"])])
-    )
+def test_deferred_linked_issue_closes():
+    v = pr_gate.decide(make_ctx(linked_issues=[issue(["deferred"])]))
     assert v.verdict == "close" and v.tier == "deferred"
 
 
@@ -188,33 +198,10 @@ def test_qualified_label_passes_despite_deferred():
     assert v.verdict == "pass" and v.tier == "qualified"
 
 
-# --- self-filed veto: an issue the PR author filed themselves doesn't
-# establish demand — the PR needs that issue (or another linked issue)
-# labeled `accepted`, whatever the author's tier. Trivial stays welcome,
-# qualified outranks, deferred is the more informative close ---
+# --- mixed linked issues: any accepted issue passes, whoever filed what ---
 
 
-def test_self_filed_unaccepted_issue_closes_established_author():
-    v = pr_gate.decide(
-        make_ctx(
-            has_prior_nontrivial_merge=True,
-            linked_issues=[issue(author="somebody")],
-        )
-    )
-    assert v.verdict == "close" and v.tier == "self-filed"
-
-
-def test_self_filed_unaccepted_issue_closes_new_author_as_self_filed():
-    v = pr_gate.decide(make_ctx(linked_issues=[issue(author="somebody")]))
-    assert v.verdict == "close" and v.tier == "self-filed"
-
-
-def test_self_filed_issue_with_accepted_passes():
-    v = pr_gate.decide(make_ctx(linked_issues=[issue(["accepted"], author="somebody")]))
-    assert v.verdict == "pass" and v.tier == "issue-approved"
-
-
-def test_self_filed_plus_other_accepted_issue_passes():
+def test_unaccepted_plus_other_accepted_issue_passes():
     v = pr_gate.decide(
         make_ctx(
             linked_issues=[
@@ -226,14 +213,7 @@ def test_self_filed_plus_other_accepted_issue_passes():
     assert v.verdict == "pass" and v.tier == "issue-approved"
 
 
-def test_team_passes_despite_self_filed():
-    v = pr_gate.decide(
-        make_ctx(author_association="MEMBER", linked_issues=[issue(author="somebody")])
-    )
-    assert v.verdict == "pass" and v.tier == "qualified"
-
-
-def test_trivial_passes_despite_self_filed():
+def test_trivial_passes_despite_unaccepted_issue():
     v = pr_gate.decide(
         make_ctx(
             files=[{"filename": "README.md", "additions": 2, "deletions": 0}],
@@ -241,107 +221,6 @@ def test_trivial_passes_despite_self_filed():
         )
     )
     assert v.verdict == "pass" and v.tier == "trivial"
-
-
-def test_deferred_reported_over_self_filed():
-    v = pr_gate.decide(make_ctx(linked_issues=[issue(["deferred"], author="somebody")]))
-    assert v.verdict == "close" and v.tier == "deferred"
-
-
-def test_self_filed_reported_over_capped():
-    v = pr_gate.decide(
-        make_ctx(
-            has_prior_nontrivial_merge=True,
-            open_prs=9,
-            linked_issues=[issue(author="somebody")],
-        )
-    )
-    assert v.verdict == "close" and v.tier == "self-filed"
-
-
-def test_self_filed_close_comment_is_distinct_and_marked():
-    body = pr_gate.self_filed_close_comment()
-    assert pr_gate.COMMENT_MARKER in body
-    assert "accepted" in body
-    assert "reopen" in body.lower()
-    assert body != pr_gate.close_comment()
-    assert body != pr_gate.deferred_close_comment()
-
-
-# --- open-PR cap: the Established tier's "may open PRs directly" privilege
-# is bounded at OPEN_PR_CAP open PRs; the other pass paths are not (trivial
-# stays always-welcome, an accepted issue is maintainer-approved demand, and
-# qualified is a human vouch) ---
-
-
-def test_established_at_cap_is_closed():
-    v = pr_gate.decide(
-        make_ctx(has_prior_nontrivial_merge=True, open_prs=pr_gate.OPEN_PR_CAP)
-    )
-    assert v.verdict == "close" and v.tier == "capped"
-
-
-def test_established_just_under_cap_passes():
-    v = pr_gate.decide(
-        make_ctx(has_prior_nontrivial_merge=True, open_prs=pr_gate.OPEN_PR_CAP - 1)
-    )
-    assert v.verdict == "pass" and v.tier == "established"
-
-
-def test_cap_is_five():
-    assert pr_gate.OPEN_PR_CAP == 5
-
-
-def test_team_passes_despite_cap():
-    v = pr_gate.decide(make_ctx(author_association="MEMBER", open_prs=20))
-    assert v.verdict == "pass" and v.tier == "qualified"
-
-
-def test_accepted_issue_passes_despite_cap():
-    v = pr_gate.decide(
-        make_ctx(
-            has_prior_nontrivial_merge=True,
-            linked_issues=[issue(["accepted"])],
-            open_prs=9,
-        )
-    )
-    assert v.verdict == "pass" and v.tier == "issue-approved"
-
-
-def test_trivial_passes_despite_cap():
-    v = pr_gate.decide(
-        make_ctx(
-            files=[{"filename": "README.md", "additions": 2, "deletions": 0}],
-            has_prior_nontrivial_merge=True,
-            open_prs=9,
-        )
-    )
-    assert v.verdict == "pass" and v.tier == "trivial"
-
-
-def test_deferred_reported_over_capped():
-    v = pr_gate.decide(
-        make_ctx(
-            has_prior_nontrivial_merge=True,
-            linked_issues=[issue(["deferred"])],
-            open_prs=9,
-        )
-    )
-    assert v.verdict == "close" and v.tier == "deferred"
-
-
-def test_new_author_over_cap_still_reports_new():
-    v = pr_gate.decide(make_ctx(open_prs=9))
-    assert v.verdict == "close" and v.tier == "new"
-
-
-def test_capped_close_comment_is_distinct_and_marked():
-    body = pr_gate.capped_close_comment(6)
-    assert pr_gate.COMMENT_MARKER in body
-    assert str(pr_gate.OPEN_PR_CAP) in body
-    assert "reopen" in body.lower()
-    assert body != pr_gate.close_comment()
-    assert body != pr_gate.deferred_close_comment()
 
 
 # --- close comment ---
@@ -364,11 +243,14 @@ def test_deferred_close_comment_is_distinct_and_marked():
 
 
 def test_pr_created_before_policy_is_grandfathered():
-    assert pr_gate.is_grandfathered("2026-07-28T06:43:25Z")
+    # POLICY_START is the qualified-or-accepted policy's adoption date;
+    # everything open before it (including the original 7/29 dry-run cohort)
+    # stays ungated even across stale-close/reopen cycles.
+    assert pr_gate.is_grandfathered("2026-08-31T06:43:25Z")
 
 
 def test_pr_created_after_policy_is_not_grandfathered():
-    assert not pr_gate.is_grandfathered("2026-07-30T00:00:00Z")
+    assert not pr_gate.is_grandfathered("2026-09-01T00:00:01Z")
 
 
 def test_pr_created_at_policy_start_is_not_grandfathered():


### PR DESCRIPTION
## What this changes

Contributors who aren't on the qualified roster (`.github/qualified.yml`) now need a linked issue labeled `accepted` for every non-trivial PR — regardless of their merged-PR history here, and regardless of who filed the issue. The previous "established contributor" pass (one prior merged non-trivial PR, bounded by a 5-open-PR cap) is removed, and with it the self-filed-issue veto and the cap, both of which are subsumed by the simpler rule.

Unchanged: the trivial docs carve-out (docs-only, <25 lines), the `deferred` veto, the `qualified` label as a per-PR maintainer vouch, and the two-door close message (accepted issue, or extension package).

This PR also **flips the gate from dry-run to enforcing** (owed since the observation window ended 8/12) and moves `POLICY_START` to 2026-09-01, so every PR opened before this policy stays grandfathered — including through stale-close/reopen cycles. No currently open PR is affected.

## Why

Analysis of the 159 external non-draft PRs since 7/29: 46 already pass via accepted issues, 36 via the roster, 13 via the trivial carve-out. The established path was the anomaly — it let one merged PR ever grant unbounded direct-PR rights, including for new public API. Routing everyone else through accepted issues puts maintainer sign-off on demand before code review on implementation, which is the policy's stated intent.

## Notes for reviewers

- `decide()` is now four checks; the expensive prior-merge search and open-PR count in `fetch_ctx` are gone, so the gate makes 3 API calls instead of up to 14.
- CONTRIBUTING.md "tiers" become two paths; AGENTS.md rules renumbered 7 → 6.
- Grandfathering relies solely on `POLICY_START` — no issue labeling required for existing open PRs.

### Agent review
- Reviewer: pure-logic test suite rewritten and run (33 passed), ruff check/format clean
- Authored with Claude (CASE); reviewed by Charles before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)