### PR TITLE
Report Azure credential failures when opening a remote eval set instead of showing it as missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Agent bridge: Anthropic responses now report thinking tokens in `usage.output_tokens_details`, so bridged clients can distinguish a reasoning response from a plain one.
 - Eval Log: Buffer manifest segment entries are now `TypedDict`s rather than pydantic models, cutting manifest parse time and GC pressure on the sync thread for runs with many segments.
 - Eval Log: Buffer manifests are no longer written with indentation, which accounted for ~41% of their bytes on every `log_shared` sync.
+- Eval Set: Inspect View now reports a storage authentication failure when opening a remote eval set, with remediation guidance for Azure, rather than showing the eval set as missing.
 
 ## 0.3.261 (30 August 2026)
 

--- a/src/inspect_ai/_view/common.py
+++ b/src/inspect_ai/_view/common.py
@@ -20,7 +20,7 @@ from s3fs.core import _error_wrapper, version_id_kw  # type: ignore
 from inspect_ai._eval.evalset import EvalSet
 from inspect_ai._util._async import tg_collect
 from inspect_ai._util.asyncfiles import _READ_FULLY_CHUNK_SIZE, AsyncFilesystem
-from inspect_ai._util.azure import is_azure_auth_error
+from inspect_ai._util.azure import AzureAuthError, is_azure_listing_auth_error
 from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.file import default_fs_options, dirname, filesystem, size_in_mb
 from inspect_ai._view.azure import normalize_azure_listing_name
@@ -132,8 +132,9 @@ async def read_eval_set_info_async(
     Async counterpart to `read_eval_set_info`. Reads the manifest through
     `AsyncFilesystem` (riding the shared client) rather than bouncing sync fsspec
     through a threadpool — see the fsspec/`to_thread` warning in AGENTS.md.
-    Returns None when the manifest is absent, or (matching `read_eval_set_info`)
-    when the check/read fails with an Azure auth error.
+    Returns None when the manifest is absent. An Azure auth failure raises
+    `AzureAuthError`, matching how listing surfaces one; note that the sync
+    `read_eval_set_info` still degrades such a failure to None.
     """
     sep = filesystem(eval_set_dir).sep
     manifest = f"{eval_set_dir.rstrip('/').rstrip(sep)}{sep}eval-set.json"
@@ -142,8 +143,10 @@ async def read_eval_set_info_async(
             return None
         return EvalSet.model_validate_json(await afs.read_file(manifest))
     except Exception as ex:
-        if is_azure_auth_error(ex):
-            return None
+        # An auth failure is not a missing manifest: surface it with
+        # remediation guidance instead of reporting no eval set.
+        if is_azure_listing_auth_error(manifest, ex):
+            raise AzureAuthError(manifest, ex) from ex
         raise
 
 

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -27,6 +27,7 @@ import inspect_ai.log
 import inspect_ai.log._recorders.buffer.filestore
 import inspect_ai.model
 from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_ai._util.azure import AzureAuthError
 from inspect_ai._util.event_loop_monitor import event_loop_monitor
 from inspect_ai._util.json import to_json_safe
 from inspect_ai._view import fastapi_server
@@ -1104,19 +1105,48 @@ def _patch_flat_filesystem(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(common, "filesystem", fake_filesystem)
 
 
-async def test_read_eval_set_info_async_suppresses_azure_auth_error(
+class _AzureAuthErrorFilesystem:
+    async def exists(self, filename: str) -> bool:
+        raise Exception("Server failed to authenticate the request")
+
+
+async def test_read_eval_set_info_async_raises_azure_auth_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_flat_filesystem(monkeypatch)
 
-    class AzureAuthErrorFilesystem:
-        async def exists(self, filename: str) -> bool:
-            raise Exception("Server failed to authenticate the request")
+    with pytest.raises(AzureAuthError, match="Azure storage authentication failed"):
+        await read_eval_set_info_async(
+            "az://container/logs", cast(AsyncFilesystem, _AzureAuthErrorFilesystem())
+        )
 
-    result = await read_eval_set_info_async(
-        "az://container/logs", cast(AsyncFilesystem, AzureAuthErrorFilesystem())
-    )
-    assert result is None
+
+async def test_read_eval_set_info_async_azure_auth_error_keeps_cause(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_flat_filesystem(monkeypatch)
+
+    with pytest.raises(AzureAuthError) as exc_info:
+        await read_eval_set_info_async(
+            "az://container/logs", cast(AsyncFilesystem, _AzureAuthErrorFilesystem())
+        )
+
+    assert str(exc_info.value.__cause__) == "Server failed to authenticate the request"
+
+
+async def test_read_eval_set_info_async_ignores_azure_text_on_non_azure_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_flat_filesystem(monkeypatch)
+
+    with pytest.raises(Exception) as exc_info:
+        await read_eval_set_info_async(
+            "s3://bucket/logs", cast(AsyncFilesystem, _AzureAuthErrorFilesystem())
+        )
+
+    # the raw error propagates unchanged rather than being read as an Azure one
+    assert type(exc_info.value) is Exception
+    assert str(exc_info.value) == "Server failed to authenticate the request"
 
 
 async def test_read_eval_set_info_async_raises_non_auth_errors(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Refs #5050.

`read_eval_set_info_async` wraps the `eval-set.json` probe in a `try` that catches `is_azure_auth_error` and returns `None`. `None` is also what the function returns when the manifest is genuinely absent, so an expired SAS token, a missing role assignment, or a wrong account key is indistinguishable from a directory that holds no eval set. Inspect View shows "no eval set" and the user has nothing to act on.

The guard matches on message text only, with no path check, unlike `should_suppress_azure_error` in `_util/azure.py` which required both. So it fires on any backend. Measured against this branch's base with a stub filesystem whose existence probe raises, varying only the path scheme:

```
azure auth text, az:// path    -> returned None
azure auth text, s3:// path    -> returned None
non-auth error,  az:// path    -> raised
```

The second line is a non-Azure path taking the Azure suppression.

This suppression is deliberate, not an oversight. `a49d54ce5` added it with the message "read_eval_set_info_async let Azure auth errors propagate (500 from /eval-set) where sync read_eval_set_info degraded them to None via call_with_azure_auth_fallback. Match that". What changed since is the direction ruled on in #4914: an auth failure should surface as an exception, and #5068 has landed that for log listing.

### What is the new behavior?

An Azure auth failure reading the manifest raises `AzureAuthError` carrying the remediation guidance, with the original error on `__cause__`. This uses `is_azure_listing_auth_error` and `AzureAuthError` from #5068 rather than adding a second copy of the pattern, which also fixes the path blindness: the helper requires an Azure scheme, so an Azure-shaped message on `s3://` now propagates unchanged instead of being swallowed.

Non-auth errors are unaffected.

Two things this deliberately does not do:

- The sync `read_eval_set_info` still degrades an Azure auth failure to `None` through `call_with_azure_auth_fallback`, and `/eval-set` routes to it whenever `fs_options` is non-empty. So a user passing Azure credentials that way keeps the old behavior. I left it because `_resolve_log_dir` is shared with the eval-set write path, so changing it is a wider blast radius than this issue justifies. Happy to do it here or in a follow-up, whichever you prefer.
- `AzureAuthError` is a `PermissionError` and the view server registers a handler only for `FileNotFoundError`, so it surfaces as a 500 and the guidance lands in the server log rather than the browser. That is equally true of the listing path since #5068, so it looked like one mapping decision for both rather than something to change here.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, in the failure case only. A call that previously returned `None` on an Azure auth error now raises `AzureAuthError`. Successful reads and genuinely missing manifests are unchanged. This restores the pre-`a49d54ce5` behavior for that path, which is the direction #4914 asked for.

### Other information:

Verification:

- Three tests added to `tests/_view/test_view_server.py` (the raise, the preserved `__cause__`, and the non-Azure path). All three fail on the base commit with the production hunk reverted and the test file byte-identical, and pass on this branch.
- `tests/_view/test_view_server.py` is green on both matrix versions, 3.10 and 3.11, on the default run (117 passed) and the `--runtrio` leg (13 passed).
- `make check` passes: ruff 0.9.6, `mypy --exclude tests/test_package src tests` clean across 1438 files, suppressions ledger unchanged. `pre-commit run --files` passes on the three changed files.
- Not run: the full `make test` suite, and no Azure account was involved, so the auth error is simulated by a stub filesystem rather than a real credential failure. Line coverage of `_view/common.py` was checked directly since there is no coverage job in CI; every changed line is exercised.

### Agent review
- Reviewer: Claude Opus 5 via `/code-review` at high effort, fresh context (had not seen the authoring conversation), 1 pass
- Findings: 2 - 1 acted on (the sync `read_eval_set_info` branch still degrades, which is now stated in the function docstring and in this description instead of silently left), 1 dismissed (`AzureAuthError` surfacing as a bare 500, which predates this change and applies equally to the merged listing path)
