### PR TITLE
fix(solver): use format_template in chain_of_thought solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Solver: Use format_template in chain_of_thought solver. (#5166)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)
 - Concurrency: `max_sandboxes` and `max_subprocesses` now default off the processors the eval may actually use, so an eval in a CPU-limited container no longer oversubscribes its quota.

--- a/src/inspect_ai/solver/_prompt.py
+++ b/src/inspect_ai/solver/_prompt.py
@@ -151,7 +151,9 @@ def chain_of_thought(template: str = DEFAULT_COT_TEMPLATE) -> Solver:
     cot_template = resource(template)
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
-        state.user_prompt.text = cot_template.format(prompt=state.user_prompt.text)
+        state.user_prompt.text = format_template(
+            cot_template, {"prompt": state.user_prompt.text}
+        )
         return state
 
     return solve

--- a/tests/solver/test_prompt.py
+++ b/tests/solver/test_prompt.py
@@ -105,8 +105,23 @@ def test_chain_of_thought_resource(tmp_path):
         solver=[chain_of_thought(str(template_file)), generate()],
     )
     log = eval(task, model="mockllm/model")[0]
-    assert log.samples
     assert (
         "Reason carefully:\nWhat is 20 + 22?\nANSWER: 42"
+        in log.samples[0].messages[0].text
+    )
+
+
+def test_chain_of_thought_with_braces():
+    custom_template = (
+        "{prompt}\nReason step by step. Return JSON with {custom_field} key."
+    )
+    task = Task(
+        dataset=[Sample(input="Solve problem", target="42")],
+        solver=[chain_of_thought(custom_template), generate()],
+    )
+    log = eval(task, model="mockllm/model")[0]
+    assert log.samples
+    assert (
+        "Solve problem\nReason step by step. Return JSON with {custom_field} key."
         in log.samples[0].messages[0].text
     )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5166

In `src/inspect_ai/solver/_prompt.py`, `chain_of_thought` used standard Python `str.format(prompt=...)` to interpolate the prompt into `cot_template`. When a custom CoT template contained literal braces or additional placeholders (e.g. JSON schema instructions, math notation, or code blocks), `cot_template.format()` crashed with `KeyError`.

### What is the new behavior?

`chain_of_thought` now uses `format_template(cot_template, {"prompt": state.user_prompt.text})` consistent with all other prompt solvers (`prompt_template`, `system_message`, `user_message`, `assistant_message`), safely preserving unescaped braces and extra placeholders without error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified chain_of_thought with custom templates containing braces/placeholders; all checks passed)