### PR TITLE
fix(scorer): reject non-scalar scores in scalar score reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scorer: Reject non-scalar scores in scalar score reducers. (#5168)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)
 - Concurrency: `max_sandboxes` and `max_subprocesses` now default off the processors the eval may actually use, so an eval in a CPU-limited container no longer oversubscribes its quota.

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -248,7 +248,9 @@ def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
                     list_result.append(max_value)
             return _reduced_score(list_result, scores)
         else:
-            scalar_scores = [s for s in scores if not _is_unscored(s.value)]
+            scalar_scores = _partition_scalar_scores(scores)
+            if len(scalar_scores) == 0:
+                return _nan_score(scores)
             max_score = max(
                 scalar_scores, key=lambda score: value_to_float(score.value)
             )
@@ -295,8 +297,9 @@ def _count_scalar(
         scores: a list of Scores.
         counter_fn: a function which returns a scalar value based upon the counter
     """
+    scalar_scores = _partition_scalar_scores(scores)
     score_values: list[str | int | float | bool] = []
-    for score in scores:
+    for score in scalar_scores:
         scalar_value = score._as_scalar()
         if _is_reducible(scalar_value):
             score_values.append(scalar_value)
@@ -452,10 +455,15 @@ def _compute_scalar_stat(
         value_to_float: function to convert the value to a float
         statistic: the statistic to apply
     """
+    scalar_scores = _partition_scalar_scores(scores)
+    if len(scalar_scores) == 0:
+        return _nan_score(scores)
+
     values = []
-    for score in scores:
-        if _is_reducible(value_to_float(score.value)):
-            values.append(value_to_float(score.value))
+    for score in scalar_scores:
+        val = value_to_float(score.value)
+        if _is_reducible(val):
+            values.append(val)
 
     # there are no reducible values
     if len(values) == 0:
@@ -476,6 +484,24 @@ def _first_scored(scores: list[Score]) -> Score | None:
         if not _is_unscored(score.value):
             return score
     return None
+
+
+def _partition_scalar_scores(scores: list[Score]) -> list[Score]:
+    r"""Return the subset of scores whose value is a scalar.
+
+    Skips scores with NaN-at-root (treated as unscored). Raises ValueError
+    if any score has a value that is neither a scalar nor a NaN scalar.
+    """
+    result: list[Score] = []
+    for score in scores:
+        if _is_unscored(score.value):
+            continue
+        if isinstance(score.value, (dict, list)):
+            raise ValueError(
+                "Attempting to reduce a scalar score for a non-scalar value"
+            )
+        result.append(score)
+    return result
 
 
 def _partition_dict_scores(scores: list[Score]) -> list[Score]:

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -879,5 +879,21 @@ def test_collect_preserve_metadata() -> None:
     assert reduced.metadata == {"foo": "bar"}
 
 
+def test_scalar_reducers_non_scalar_raises() -> None:
+    for non_scalar in (Score(value={"a": 1}), Score(value=[1, 2])):
+        scores = [Score(value=1), non_scalar]
+        for reducer in (
+            avg_reducer,
+            median_reducer,
+            mode_reducer,
+            max_reducer,
+            at_least_3_reducer,
+            pass_at_2_no_threshhold,
+            pass_k_2_no_threshold,
+        ):
+            with pytest.raises(ValueError):
+                reducer(scores)
+
+
 def _is_nan(x: Any) -> bool:
     return isinstance(x, float) and np.isnan(x)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5168

In `src/inspect_ai/scorer/_reducer/reducer.py`, `_partition_dict_scores` and `_partition_list_scores` validate score shapes, raising `ValueError("Attempting to reduce a dictionary score for a non-dictionary value")` or `ValueError("Attempting to reduce a list score for a non-list value")` when an epoch produces a mismatched score shape.

However, when reducing scalar scores, `_compute_scalar_stat` (used by `mean_score`, `median_score`, `pass_at`, `pass_k`) and `max_score` directly passed score values into `value_to_float()` without shape validation. Because `value_to_float()` returns `0.0` (with a warning) for dictionaries and lists, non-scalar score values in later epochs were silently converted to `0.0` rather than raising a `ValueError`.

### What is the new behavior?

`_partition_scalar_scores()` is introduced (mirroring `_partition_dict_scores` and `_partition_list_scores`) to validate that all non-NaN scores are scalars when reducing scalar scores, properly raising `ValueError("Attempting to reduce a scalar score for a non-scalar value")` when dict or list values are encountered.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified all scalar reducers reject non-scalar scores; all tests pass)