### PR TITLE
fix(eval_set): track only logs directly in log_dir, not subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Eval Set: `eval_set()` now tracks only the logs directly in its `log_dir`. Logs in subdirectories (a bundle, logs written by a child eval, another run) no longer trip the dirty log directory check or get cleaned up as older attempts.
 - Scorer (breaking): Model-graded scorers with a panel of graders now require a strict majority: samples with no majority grade (even-split ties, three-way splits, or ties after a grader returns no parseable grade) come back unscored and leave the metric denominator, rather than the most common grade winning with ties broken by grader order. Pass `reducer="mode"` to `model_graded_qa()`/`model_graded_fact()` to restore the previous behavior. (#4721)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)

--- a/docs/eval-sets.qmd
+++ b/docs/eval-sets.qmd
@@ -172,6 +172,8 @@ We mentioned above that each eval set you run wants a dedicated log directory. T
 
 2.  This enables you to enumerate and analyse all of the eval logs in the suite as a cohesive whole (rather than having them intermixed with the results of other runs).
 
+Only the logs directly in the log directory are tracked: `eval_set()` writes its logs flat, so logs in subdirectories are ignored.
+
 Once all of the tasks in an eval set are complete, re-running `inspect eval-set` or `eval_set()` on the same log directory will be a no-op as there is no more work to do. At this point you can use the `list_eval_logs()` function to collect up logs for analysis:
 
 ``` python

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -998,8 +998,12 @@ def eval_set(
                 "Error: No inspect tasks were found at the specified paths."
             )
 
-        # list all logs currently in the log directory (update manifest if there are some)
-        all_logs = list_all_eval_logs(log_dir)
+        # list the logs this eval set owns: the ones directly in log_dir. eval_set
+        # only ever writes flat into log_dir, so a log in a subdirectory (a
+        # bundle, a child eval's logs, another run's directory) belongs to
+        # something else and must not trip the dirty-log-dir check below
+        # (update manifest if there are some)
+        all_logs = list_all_eval_logs(log_dir, recursive=False)
         if len(all_logs) > 0:
             write_log_dir_manifest(log_dir)
 
@@ -1772,11 +1776,12 @@ def epochs_changed(epochs: Epochs | None, config: EvalConfig) -> bool:
     return canonical(requested) != canonical(config.epochs_reducer)
 
 
-# cleanup logs that aren't the latest
+# cleanup logs that aren't the latest (only the eval set's own logs, which
+# live directly in log_dir -- never anything in a subdirectory)
 def cleanup_older_eval_logs(log_dir: str, task_ids: set[str]) -> None:
     logs = [
         log
-        for log in list_all_eval_logs(log_dir)
+        for log in list_all_eval_logs(log_dir, recursive=False)
         if log.header.eval.task_id in task_ids
     ]
     latest_completed_task_eval_logs(logs=logs, cleanup_older=True)

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -275,6 +275,30 @@ def test_validate_eval_set_prerequisites_mismatch_log_dir_allow_dirty() -> None:
     assert len(all_logs) == 0
 
 
+def test_eval_set_ignores_logs_in_subdirectories() -> None:
+    # eval_set writes its logs flat into log_dir, so a log in a subdirectory
+    # belongs to something else (a child eval, a bundle) and must neither read
+    # as a dirty log dir nor count towards the eval set's completed work
+    with tempfile.TemporaryDirectory() as log_dir:
+        nested_dir = os.path.join(log_dir, "nested")
+        eval(tasks="examples/hello_world.py", model="mockllm/model", log_dir=nested_dir)
+        assert len(list_eval_logs(nested_dir)) == 1
+        assert len(list_all_eval_logs(log_dir, recursive=False)) == 0
+
+        success, logs = eval_set(
+            tasks="examples/popularity.py",
+            log_dir=log_dir,
+            limit=1,
+            model="mockllm/model",
+            log_dir_allow_dirty=False,
+        )
+        assert success
+        assert len(logs) == 1
+        assert len(list_all_eval_logs(log_dir, recursive=False)) == 1
+        # the nested log is neither adopted nor cleaned up
+        assert len(list_eval_logs(nested_dir)) == 1
+
+
 @pytest.mark.slow
 @skip_if_trio
 def test_eval_set_s3(mock_s3) -> None:


### PR DESCRIPTION
## Problem

`eval_set()` lists its log directory recursively, so a log in *any* subdirectory of `log_dir` is treated as part of the eval set:

- it trips the dirty-log-dir prerequisite check (`log_dir_allow_dirty=False`) with `Existing log file '…' in log_dir is not associated with a task passed to eval_set`, refusing to resume;
- it is considered by the older-attempt cleanup.

`eval_set` only ever writes flat into `log_dir`, so nothing it owns can be in a subdirectory. Anything there belongs to something else: a viewer bundle, logs written by a child eval launched from a task while the set runs, another run's directory.

The recursion was never a deliberate choice. It is the default of `list_eval_logs()`, inherited when `eval_set` was written in 2024. `inspect_flow` already calls `list_all_eval_logs(..., recursive=False)`, and bundling into a subdirectory of the log dir is already a `PrerequisiteError` (#3135), so subdirectories under `log_dir` are already treated as foreign.

## Change

- The two `eval_set` call sites of `list_all_eval_logs()` (the prerequisite listing in `eval_set` and `cleanup_older_eval_logs`) pass `recursive=False` explicitly. The helper's default is unchanged.
- The viewer listing / manifest writers (`write_log_listing`, `write_log_dir_manifest`) are unchanged and still list nested logs, so `inspect view` behaviour is the same.
- Docs: a sentence in the "Logging Context" section of eval-sets stating that only logs directly in the log directory are tracked.
- Changelog entry.

## Test

`test_eval_set_ignores_logs_in_subdirectories`: runs `eval()` into `log_dir/nested/`, then `eval_set()` over `log_dir` with `log_dir_allow_dirty=False`. Against `main` it fails with the `PrerequisiteError` above; with this change it passes and the nested log is neither adopted nor cleaned up. Full `tests/test_eval_set.py` including `--runslow` passes; ruff and mypy clean.

## Compatibility

The only behaviour that could change for an existing user is resuming an eval set whose logs sit in subfolders of `log_dir`, which `eval_set` never produces itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
