### PR TITLE
Rescore only selected samples with inspect score --sample-id / score(sample_ids=...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Eval Log: JSON values in logged events nested deeper than 240 levels are now truncated with a placeholder marker (previously depths up to ~254 were preserved and deeper crashed the eval).
 - Inspect CTL: New `inspect ctl sample score` interim-scores a single running sample's work-so-far on demand (briefly held while scored; the sample keeps running).
 - Score: `inspect score` now reports samples that errored or were stopped early, so a re-scored partial run is no longer displayed as if it were complete.
+- Score: `inspect score --sample-id` and `score(sample_ids=...)` rescore only the named samples, leaving every other sample's scores untouched.
 - Scorers: New `cascade()` scorer runs scorers in order and reports the first that settles a sample, so an expensive grader only runs on samples cheaper scorers left unsettled.
 - Agent bridge: Anthropic responses now report thinking tokens in `usage.output_tokens_details`, so bridged clients can distinguish a reasoning response from a plain one.
 - Agent bridge: A bridged request asking for Anthropic `output_config.format`, OpenAI `text.verbosity`, or any of Gemini's `thinkingConfig.thinkingBudget`, `presencePenalty`, `frequencyPenalty`, `responseLogprobs` and `logprobs` now gets it, instead of silently receiving the model default.

--- a/docs/scoring-workflow.qmd
+++ b/docs/scoring-workflow.qmd
@@ -83,6 +83,15 @@ inspect score ./logs/2024-02-23_task_gpt-4_TUhnCn473c6.eval --scorer custom_scor
 inspect score ./logs/2024-02-23_task_gpt-4_TUhnCn473c6.eval --scorer custom_scorer.py --action overwrite
 ```
 
+### Scoring Specific Samples
+
+To rescore only some of the samples, pass their ids with `--sample-id` (comma separated). Every other sample keeps its existing scores in both append and overwrite mode, and an id that matches no sample is an error:
+
+``` bash
+# regrade samples 7 and 12 only, replacing their previous scores
+inspect score ./logs/2024-02-23_task_gpt-4_TUhnCn473c6.eval --sample-id 7,12 --action overwrite
+```
+
 ## Score Function
 
 You can also use the `score()` function in your Python code to score evaluation logs. For example, if you are exploring the performance of different scorers, you might find it more useful to call the `score()` function using varying scorers or scorer options. For example:

--- a/src/inspect_ai/_cli/score.py
+++ b/src/inspect_ai/_cli/score.py
@@ -23,6 +23,7 @@ from inspect_ai._eval.context import init_eval_context
 from inspect_ai._eval.loader import metric_from_spec
 from inspect_ai._eval.score import (
     ScoreAction,
+    check_sample_ids,
     resolve_scorers,
     score_async,
 )
@@ -30,6 +31,7 @@ from inspect_ai._util._async import configured_async_backend
 from inspect_ai._util.config import parse_cli_args
 from inspect_ai._util.file import filesystem
 from inspect_ai._util.platform import platform_init
+from inspect_ai._util.samples import parse_sample_id
 from inspect_ai.log._log import EvalLog, EvalResults, EvalSample
 from inspect_ai.log._recorders import create_recorder_for_location
 from inspect_ai.model._model import Model, get_model
@@ -92,6 +94,12 @@ from .common import CommonOptions, common_options, process_common_options
     help="Whether to append or overwrite the existing scores.",
 )
 @click.option(
+    "--sample-id",
+    type=str,
+    envvar="INSPECT_SCORE_SAMPLE_ID",
+    help="Score specific sample(s) (comma separated list of ids); every other sample keeps its existing scores.",
+)
+@click.option(
     "--overwrite",
     type=bool,
     is_flag=True,
@@ -127,6 +135,7 @@ def score_command(
     s: tuple[str, ...] | None,
     metric: tuple[str, ...] | None,
     action: ScoreAction | None,
+    sample_id: str | None,
     stream: int | bool = False,
     **common: Unpack[CommonOptions],
 ) -> None:
@@ -149,6 +158,7 @@ def score_command(
             action=action,
             log_level=common["log_level"],
             stream=stream,
+            sample_id=sample_id,
         )
 
     anyio.run(run_score, backend=configured_async_backend())
@@ -169,6 +179,7 @@ async def score(
     m: tuple[str, ...] | None = None,
     model_role: tuple[str, ...] | None = None,
     stream: int | bool = False,
+    sample_id: str | None = None,
 ) -> None:
     platform_init()
 
@@ -176,6 +187,7 @@ async def score(
     scorer_args = parse_cli_config(args=s, config=None)
     model_args = parse_cli_args(m)
     model_roles = parse_model_role_cli_args(model_role) if model_role else None
+    sample_ids = parse_sample_id(sample_id)
     override_model: Model | None = (
         get_model(model, base_url=model_base_url, **model_args)
         if model is not None
@@ -195,6 +207,16 @@ async def score(
         raise ValueError(
             f"Cannot determine the number of samples to score for {log_file}"
         )
+
+    # check the filter before the interactive prompts below and, when
+    # streaming, before any sample has been written to the output
+    if sample_ids is not None:
+        present = (
+            [sample.id for sample in eval_log.samples]
+            if eval_log.samples
+            else [id for id, _ in await recorder.read_log_sample_ids(log_file)]
+        )
+        check_sample_ids(sample_ids, present)
 
     # Sample coverage describes the original run, not this scoring pass, and
     # `--action overwrite` replaces `results` with counts taken over the samples
@@ -251,6 +273,7 @@ async def score(
         action=action,
         copy=False,
         samples=read_sample,
+        sample_ids=sample_ids,
     )
 
     if stream:

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -10,6 +10,7 @@ from typing import (
     AsyncContextManager,
     AsyncGenerator,
     Callable,
+    Iterable,
     Literal,
     NamedTuple,
     Sequence,
@@ -25,6 +26,7 @@ from inspect_ai._display import display as display_manager
 from inspect_ai._eval.context import init_task_context
 from inspect_ai._eval.loader import load_file_tasks, scorer_from_spec
 from inspect_ai._eval.task.task import resolve_scorer, resolve_scorer_metrics
+from inspect_ai._eval.task.util import sample_id_filter
 from inspect_ai._util._async import configured_async_backend, run_coroutine, tg_collect
 from inspect_ai._util.platform import platform_init, running_in_notebook
 from inspect_ai._util.registry import (
@@ -46,7 +48,7 @@ from inspect_ai.log import (
 )
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._headline import headline_metric_ref, resolve_headline_metric
-from inspect_ai.log._log import EvalMetricDefinition, EvalSample
+from inspect_ai.log._log import EvalMetricDefinition, EvalSample, EvalScorer
 from inspect_ai.log._resolve import rebind_sample_timelines
 from inspect_ai.log._score import _find_scorers_span
 from inspect_ai.log._transcript import Transcript, init_transcript, transcript
@@ -90,6 +92,7 @@ def score(
     action: ScoreAction | None = None,
     display: DisplayType | None = None,
     copy: bool = True,
+    sample_ids: str | int | list[str] | list[int] | list[str | int] | None = None,
 ) -> EvalLog:
     """Score an evaluation log.
 
@@ -109,6 +112,9 @@ def score(
        action: Whether to append or overwrite this score
        display: Progress/status display
        copy: Whether to deepcopy the log before scoring.
+       sample_ids: Score only the sample(s) with these ids (glob patterns
+         are matched as for `eval(sample_id=...)`); every other sample
+         keeps its existing scores. An id that matches no sample is an error.
 
     Returns:
        Log with scores yielded by scorer.
@@ -133,6 +139,7 @@ def score(
                 model_roles=model_roles,
                 action=action,
                 copy=copy,
+                sample_ids=sample_ids,
             )
         )
     else:
@@ -143,6 +150,7 @@ def score(
                 model_roles=model_roles,
                 action=action,
                 copy=copy,
+                sample_ids=sample_ids,
             ),
             log,
             scorers,
@@ -210,6 +218,29 @@ def _get_updated_events(
     return list(event_sequence(sample_event_tree))
 
 
+def check_sample_ids(
+    sample_ids: str | int | list[str] | list[int] | list[str | int],
+    present: Iterable[str | int],
+) -> None:
+    """Raise `ValueError` if any requested id (or pattern) matches none of `present`.
+
+    A filter with no hits would otherwise make a pass that scored nothing
+    look like a success.
+    """
+    requested = sample_ids if isinstance(sample_ids, list) else [sample_ids]
+    if not requested:
+        raise ValueError("sample_ids is empty")
+    present = list(present)
+    matchers = [(str(id), sample_id_filter(id)) for id in requested]
+    unmatched = [
+        text
+        for text, matcher in matchers
+        if not any(matcher.matches(sid) for sid in present)
+    ]
+    if unmatched:
+        raise ValueError(f"sample_ids not found in log: {', '.join(unmatched)}")
+
+
 async def score_async(
     log: EvalLog,
     scorers: "Scorers",
@@ -223,6 +254,7 @@ async def score_async(
     display: DisplayType | None = None,
     copy: bool = True,
     samples: Callable[[int], AsyncContextManager[EvalSample]] | None = None,
+    sample_ids: str | int | list[str] | list[int] | list[str | int] | None = None,
 ) -> EvalLog:
     """Score an evaluation log.
 
@@ -248,12 +280,20 @@ async def score_async(
          Function to read samples from the log, which accepts the
          sample index and async yields an EvalSample. Can be used to
          stream samples without loading the entire log into memory.
+       sample_ids:
+         Score only the sample(s) with these ids (glob patterns are matched
+         as for `eval(sample_id=...)`); every other sample keeps its existing
+         scores. An id that matches no sample is an error.
 
     Returns:
        Log with scores yielded by scorer.
     """
     if samples is None and log.samples is None:
         raise ValueError("There are no samples to score in the log.")
+
+    matcher = sample_id_filter(sample_ids) if sample_ids is not None else None
+    if sample_ids is not None and log.samples is not None:
+        check_sample_ids(sample_ids, [sample.id for sample in log.samples])
 
     # resolve scorers
     resolved_scorers = resolve_scorer(scorers)
@@ -307,30 +347,52 @@ async def score_async(
         # tally the per-sample error state as we go so an overwrite can restate
         # completed_samples exactly rather than falling back to len(scores)
         sample_completed: list[bool] = [False] * total_samples
+        scored_ids: list[str | int] = []
+        untouched_names: set[str] = set()
 
         async def _score_sample(idx_sample: int) -> None:
             nonlocal scorer_names
             sample_score: dict[str, SampleScore] = {}
 
             async with samples(idx_sample) as sample:
-                # run the task, capturing the resulting sample scores
-                # and sample names for later use. The sample scores
-                # returned here are only the _newly created_ scores
-                # which means that metrics below are being computed
-                # only for the new scores (not all scores on the sample)
-                #
-                # We need to capture the the full sample score here
-                # since the sample score carries the scorer name that generated
-                # it (so using sample.scores directly isn't enough)
-                sample_score, names = await _run_score_task(
-                    log, sample, resolved_scorers, active_model, active_roles, action
-                )
+                if matcher is None or matcher.matches(sample.id):
+                    # run the task, capturing the resulting sample scores
+                    # and sample names for later use. The sample scores
+                    # returned here are only the _newly created_ scores
+                    # which means that metrics below are being computed
+                    # only for the new scores (not all scores on the sample)
+                    #
+                    # We need to capture the the full sample score here
+                    # since the sample score carries the scorer name that generated
+                    # it (so using sample.scores directly isn't enough)
+                    sample_score, names = await _run_score_task(
+                        log,
+                        sample,
+                        resolved_scorers,
+                        active_model,
+                        active_roles,
+                        action,
+                    )
+                    scored_ids.append(sample.id)
+                    if scorer_names is None:
+                        scorer_names = names
+                elif action == "overwrite":
+                    # an overwrite rebuilds results from the scores gathered in
+                    # this pass, so a sample the filter left alone contributes
+                    # the scores it already has (an append only extends results
+                    # with the new scorer, which this sample did not receive)
+                    sample_score = {
+                        name: SampleScore(
+                            score=score,
+                            sample_id=sample.id,
+                            sample_metadata=sample.metadata,
+                        )
+                        for name, score in (sample.scores or {}).items()
+                    }
+                    untouched_names.update(sample_score)
 
-            assert sample.scores is not None
             scores[idx_sample] = sample_score
             sample_completed[idx_sample] = sample.error is None
-            if scorer_names is None:
-                scorer_names = names
             p.update(1)
 
         await tg_collect(
@@ -339,6 +401,27 @@ async def score_async(
                 for idx_sample in range(total_samples)
             )
         )
+
+        # streamed samples (header-only log) could only be checked as they
+        # were read (an in-memory log was checked before any scoring above)
+        if sample_ids is not None and log.samples is None:
+            check_sample_ids(sample_ids, scored_ids)
+
+        # an overwrite rebuilds results and the header's scorer list from this
+        # pass. Scorers whose scores survive on samples the filter left alone
+        # must stay described (metrics, params), or results would fall back to
+        # registry defaults and a later recompute_metrics() / `inspect score`
+        # would no longer know about them
+        retained_names = untouched_names - set(scorer_names or [])
+        retained_scorers: list[EvalScorer] = []
+        retained_info: list[ScorerInfo] = []
+        if retained_names:
+            retained_scorers = [
+                s for s in (log.eval.scorers or []) if s.name in retained_names
+            ]
+            retained_info = [
+                i for i in resolve_scorers_info(log) if i.name in retained_names
+            ]
 
         # collect metrics from EvalLog (they may overlap w/ the scorer metrics,
         # that will be taken care of in eval_results). For append, the new scorer
@@ -359,11 +442,16 @@ async def score_async(
             epochs_reducer = reducers_from_log_header(log)
 
         # compute metrics
+        scorers_info: list[Scorer] | list[ScorerInfo] = (
+            [ScorerInfo.from_scorer(s) for s in resolved_scorers] + retained_info
+            if retained_info
+            else resolved_scorers
+        )
         results, reductions = eval_results(
             total_samples,
             list(filter(None, scores)),
             epochs_reducer,
-            resolved_scorers,
+            scorers_info,
             log_metrics,
             scorer_names,
             early_stopping=log.results.early_stopping if log.results else None,
@@ -389,7 +477,7 @@ async def score_async(
             # Completely replace the results (and reductions) with the new ones
             log.reductions = reductions
             log.results = results
-            log.eval.scorers = applied_eval_scorers
+            log.eval.scorers = applied_eval_scorers + retained_scorers
         else:
             # Only update the results with the new scores, leaving the rest
             # of the results as they were. The reductions computed here cover

--- a/tests/_cli/test_score.py
+++ b/tests/_cli/test_score.py
@@ -155,7 +155,7 @@ async def test_score_stream_preserves_log_updates(
     )
 
     async def fake_score_async(
-        *, log, scorers, metrics, model, model_roles, action, copy, samples
+        *, log, scorers, metrics, model, model_roles, action, copy, samples, sample_ids
     ):
         assert samples is not None
         return log
@@ -217,7 +217,7 @@ async def test_score_stream_flushes_periodically(
     )
 
     async def fake_score_async(
-        *, log, scorers, metrics, model, model_roles, action, copy, samples
+        *, log, scorers, metrics, model, model_roles, action, copy, samples, sample_ids
     ):
         assert samples is not None
         for idx in range(10):
@@ -241,6 +241,116 @@ async def test_score_stream_flushes_periodically(
     )
 
     assert flush_counts == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_score_forwards_parsed_sample_ids(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(score_cli, "init_eval_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(score_cli, "print_results", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        score_cli, "resolve_scorers", lambda *args, **kwargs: [object()]
+    )
+    received: list[object] = []
+
+    async def fake_score_async(*, log, sample_ids, **kwargs):
+        received.append(sample_ids)
+        return log
+
+    monkeypatch.setattr(score_cli, "score_async", fake_score_async)
+
+    await score(
+        log_dir="",
+        log_file=str(LOG_SCORED),
+        action="overwrite",
+        log_level=None,
+        output_file=str(tmp_path / "rescored.eval"),
+        overwrite=True,
+        scorer="match",
+        s=(),
+        metric=None,
+        stream=False,
+        sample_id="1, 3",
+    )
+
+    assert received == [["1", "3"]]
+
+
+@pytest.mark.anyio
+async def test_score_stream_rejects_unknown_sample_ids_before_writing(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A streamed pass writes samples as it reads them, so the check comes first."""
+    output_file = tmp_path / "rescored.eval"
+    monkeypatch.setattr(score_cli, "init_eval_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(score_cli, "print_results", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        score_cli, "resolve_scorers", lambda *args, **kwargs: [object()]
+    )
+
+    async def fake_score_async(**kwargs):
+        raise AssertionError("scoring must not start with an unknown sample id")
+
+    monkeypatch.setattr(score_cli, "score_async", fake_score_async)
+
+    with pytest.raises(ValueError, match="42"):
+        await score(
+            log_dir="",
+            log_file=str(LOG_SCORED),
+            action="overwrite",
+            log_level=None,
+            output_file=str(output_file),
+            overwrite=True,
+            scorer="match",
+            s=(),
+            metric=None,
+            stream=True,
+            sample_id="1,42",
+        )
+    assert not output_file.exists()
+
+
+@pytest.mark.anyio
+async def test_score_stream_writes_untouched_samples_through(
+    tmp_path: pathlib.Path,
+) -> None:
+    output_file = tmp_path / "rescored.eval"
+    before = await read_eval_log_async(str(LOG_SCORED))
+    assert before.samples is not None
+
+    await score(
+        log_dir="",
+        log_file=str(LOG_SCORED),
+        action="overwrite",
+        log_level=None,
+        output_file=str(output_file),
+        overwrite=True,
+        scorer="match",
+        s=(),
+        metric=None,
+        model="mockllm/model",
+        stream=True,
+        sample_id="3",
+    )
+
+    after = await read_eval_log_async(output_file)
+    assert after.samples is not None
+    assert [s.id for s in after.samples] == [s.id for s in before.samples]
+    for old, new in zip(before.samples, after.samples):
+        if old.id == 3:
+            assert new.scores is not None and [*new.scores] == ["match"]
+            assert new.events != old.events
+        else:
+            # the streaming writer re-derives `working_start` on every sample
+            # it writes, so compare events by shape rather than by value
+            assert new.model_dump(exclude={"events"}) == old.model_dump(
+                exclude={"events"}
+            )
+            assert [type(e) for e in new.events] == [type(e) for e in old.events]
+    assert after.results is not None
+    assert after.results.total_samples == 10
+    assert [s.name for s in after.results.scores] == ["match"]
 
 
 def early_stops(count: int) -> EarlyStoppingSummary:

--- a/tests/scorer/test_scorer.py
+++ b/tests/scorer/test_scorer.py
@@ -1,11 +1,14 @@
 # type: ignore
 
+from copy import deepcopy
+
 import pytest
 from test_helpers.utils import ensure_test_package_installed, run_example
 
 from inspect_ai import Task, eval, score
+from inspect_ai._eval.score import ScoreAction
 from inspect_ai.dataset import Sample
-from inspect_ai.log import recompute_metrics
+from inspect_ai.log import EvalLog, recompute_metrics
 from inspect_ai.scorer import Score, Scorer, Target, accuracy, includes, scorer
 from inspect_ai.scorer._scorer import scorer_create
 from inspect_ai.solver import TaskState
@@ -137,3 +140,100 @@ def test_recompute_duplicate_scorer_names():
 
     recompute_metrics(eval_log)
     assert [score.name for score in eval_log.results.scores] == before
+
+
+@scorer(metrics=[accuracy()])
+def first_scorer(threshold: float = 0.5) -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=1.0, answer="first")
+
+    return score
+
+
+@scorer(metrics=[accuracy()])
+def second_scorer() -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=0.0, answer="second")
+
+    return score
+
+
+def _three_sample_log() -> EvalLog:
+    task = Task(
+        dataset=[Sample(input=f"Question {id}", target="x", id=id) for id in (1, 2, 3)],
+        scorer=first_scorer(threshold=0.9),
+    )
+    return eval(tasks=task, model="mockllm/model", display="none")[0]
+
+
+@pytest.mark.parametrize("action", ["overwrite", "append"])
+def test_score_sample_ids_leaves_other_samples_untouched(action: ScoreAction) -> None:
+    log = _three_sample_log()
+    assert log.samples is not None
+    before = {sample.id: deepcopy(sample.scores) for sample in log.samples}
+
+    rescored = score(log, second_scorer(), action=action, sample_ids=[2])
+
+    assert rescored.samples is not None
+    by_id = {sample.id: sample for sample in rescored.samples}
+    assert by_id[1].scores == before[1]
+    assert by_id[3].scores == before[3]
+    assert by_id[2].scores is not None
+    if action == "overwrite":
+        assert [*by_id[2].scores] == ["second_scorer"]
+    else:
+        assert [*by_id[2].scores] == ["first_scorer", "second_scorer"]
+    assert by_id[2].scores["second_scorer"].answer == "second"
+
+    # results describe the whole log, not only the rescored sample, and the
+    # header still describes the scorer whose scores survive on the others
+    assert rescored.results is not None
+    results = {score.name: score for score in rescored.results.scores}
+    assert results["second_scorer"].metrics["accuracy"].value == 0.0
+    assert results["first_scorer"].metrics["accuracy"].value == 1.0
+    assert results["first_scorer"].params == {"threshold": 0.9}
+    assert rescored.results.total_samples == 3
+    assert rescored.results.completed_samples == 3
+    assert rescored.eval.scorers is not None
+    header = {s.name: s for s in rescored.eval.scorers}
+    assert set(header) == {"first_scorer", "second_scorer"}
+    assert header["first_scorer"].options == {"threshold": 0.9}
+
+
+def test_score_sample_ids_same_scorer_keeps_one_result() -> None:
+    """Regrading a few samples with the task's own scorer is the common case."""
+    log = _three_sample_log()
+    rescored = score(
+        log, first_scorer(threshold=0.9), action="overwrite", sample_ids=[2]
+    )
+    assert rescored.results is not None
+    assert [s.name for s in rescored.results.scores] == ["first_scorer"]
+    assert rescored.results.scores[0].metrics["accuracy"].value == 1.0
+    assert rescored.reductions is not None
+    assert len(rescored.reductions[0].samples) == 3
+    assert rescored.eval.scorers is not None
+    assert [s.name for s in rescored.eval.scorers] == ["first_scorer"]
+
+
+def test_score_sample_ids_glob_pattern() -> None:
+    task = Task(
+        dataset=[Sample(input="q", target="x", id=id) for id in ("a-1", "a-2", "b-1")],
+        scorer=first_scorer(),
+    )
+    log = eval(tasks=task, model="mockllm/model", display="none")[0]
+    rescored = score(log, second_scorer(), action="overwrite", sample_ids="a-*")
+    assert rescored.samples is not None
+    by_id = {sample.id: [*sample.scores] for sample in rescored.samples}
+    assert by_id == {
+        "a-1": ["second_scorer"],
+        "a-2": ["second_scorer"],
+        "b-1": ["first_scorer"],
+    }
+
+
+def test_score_sample_ids_unknown_id_raises() -> None:
+    log = _three_sample_log()
+    with pytest.raises(ValueError, match="42"):
+        score(log, second_scorer(), action="overwrite", sample_ids=[2, 42])
+    with pytest.raises(ValueError, match="empty"):
+        score(log, second_scorer(), action="overwrite", sample_ids=[])


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

**Problem.** `score_async(log, scorers, action="overwrite")` scores every sample in the log and replaces each sample's `scores` dict with exactly what the pass produced. In a task whose samples are of different kinds (e.g. one "orchestrator" sample whose scorer grades a selection, plus many "rollout" samples whose classifier scores were written by their solver), rescoring the orchestrator with `overwrite` erases every rollout's scores, because the pass's scorer returns `None` for them. `append` avoids the erasure but renames the new score to `<name>1` and duplicates the header's scorer entry. There is no way to say "regrade these samples and leave the rest alone".

### What is the new behavior?

**Change.**
- `score_async(..., sample_ids=...)` and `score(..., sample_ids=...)` (same type as `eval()`'s `sample_id`; matching reuses `sample_id_filter`, so ids are normalised the same way and globs work). Only matching samples are scored; every other sample keeps its `scores` exactly as they were, in both `overwrite` and `append` mode.
- `inspect score --sample-id 7,12` (comma separated, `INSPECT_SCORE_SAMPLE_ID` env var), mirroring `inspect eval --sample-id`.
- An id (or pattern) that matches no sample raises `ValueError` listing it, and an empty list is rejected, rather than a silent no-op. The CLI checks this before the action/output prompts, and in `--stream` mode before any sample has been written to the output file.
- Results in `overwrite` mode: an overwrite rebuilds `log.results` from the scores gathered in the pass, so with a filter the untouched samples contribute the scores they already have (built as `SampleScore`s the way `recompute_metrics()` does). `total_samples`/`completed_samples` still cover the whole log. The header (`log.eval.scorers`) keeps the entries of scorers whose scores survive on untouched samples, and their `ScorerInfo` (metrics/params) is passed to `eval_results`, so a later `recompute_metrics()` or `inspect score` without `--scorer` still knows about them and `results.scores[...].params` is preserved. Without this, rescoring one sample would leave `log.results` describing that one sample only. `append` mode is unchanged: results are only extended with the new scorer, which untouched samples did not receive.

Usage:
```bash
inspect score logs/run.eval --sample-id 7,12 --action overwrite
```
```python
score(log, my_scorer(), action="overwrite", sample_ids=[7, 12])
```

**Test.**
- `tests/scorer/test_scorer.py`: three-sample log rescored with `sample_ids=[2]` in overwrite and append mode; the other two samples' `scores` dicts compare equal to deep copies taken before, the rescored sample has the expected keys, `results` covers all three samples, and the header/params of the retained scorer survive; same-scorer regrade yields one `EvalScore` over three samples; glob pattern `"a-*"`; unknown id and empty list raise.
- `tests/_cli/test_score.py`: `--sample-id "1, 3"` is parsed and forwarded as `["1", "3"]`; in `--stream` mode an unknown id raises before any output file exists; an end-to-end `--stream` run with a filter over the fixture log writes the untouched samples through unchanged (compared excluding `events`, whose `working_start` the streaming writer already re-derives on `main`) and rescores only the filtered one.
- Confirmed the new tests fail on `origin/main` source on their assertions (with an ignored `sample_ids` parameter added so they get past the signature): both mode variants fail on the scores comparison and the unknown-id test with `DID NOT RAISE`.
- `ruff check`, `ruff format --check` and `mypy` clean on the four changed Python files. `pytest tests/scorer tests/log tests/test_eval_no_samples.py tests/_cli/test_score.py`: 1678 passed. Async CLI tests also pass under `--runtrio`.

### Does this PR introduce a breaking change?

**Compatibility.** No. `sample_ids` / `--sample-id` default to `None`, in which case behaviour is byte-for-byte what it was. The only signature changes are new optional keyword parameters on `score()`, `score_async()`, and the CLI's `score()` coroutine (test fakes that stub `score_async` with an explicit keyword-only signature need `sample_ids` added; the two in `tests/_cli/test_score.py` are updated). `check_sample_ids` is a new module-level helper in `_eval/score.py` used by the CLI.

### Other information:

Written with Claude Code (Claude Fable 5.1) driven by a maintainer's brief.

### Agent review
- Reviewer: Claude Fable 5.1 subagent (fresh context, same model as the author), 1 pass over the full diff plus surrounding code, with a probe script against the in-memory path.
- Findings: 7 — 6 fixed, 1 partially adopted.
  - Fixed: filtered overwrite dropped retained scorers from `log.eval.scorers` and lost their `params`/metrics (now retained, with a parameterised-scorer test); `sample_ids=[]` passed the check and produced a NaN result entry (now raises); unknown ids were only reported after the interactive prompts (now checked right after the log header is read); redundant post-loop id check narrowed to the header-only path; matcher construction hoisted out of the inner loop; a no-op `assert sample.scores is not None` removed.
  - Partially adopted (coverage): added same-scorer, glob, and end-to-end `--stream` tests; skipped a dedicated epochs > 1 test since matching is by id and every epoch of a matched id goes through the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
