### PR TITLE
Add filter_scorer() to run a scorer only on samples a predicate selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Inspect CTL: New `inspect ctl sample score` interim-scores a single running sample's work-so-far on demand (briefly held while scored; the sample keeps running).
 - Score: `inspect score` now reports samples that errored or were stopped early, so a re-scored partial run is no longer displayed as if it were complete.
 - Scorers: New `cascade()` scorer runs scorers in order and reports the first that settles a sample, so an expensive grader only runs on samples cheaper scorers left unsettled.
+- Scorers: New `filter_scorer()` runs a scorer only on samples a predicate selects; skipped samples are left unscored by it and excluded from its metrics.
 - Agent bridge: Anthropic responses now report thinking tokens in `usage.output_tokens_details`, so bridged clients can distinguish a reasoning response from a plain one.
 - Agent bridge: A bridged request asking for Anthropic `output_config.format`, OpenAI `text.verbosity`, or any of Gemini's `thinkingConfig.thinkingBudget`, `presencePenalty`, `frequencyPenalty`, `responseLogprobs` and `logprobs` now gets it, instead of silently receiving the model default.
 - Agent bridge: A bridged Gemini response now reports `thoughtsTokenCount`, so a client can see how many thinking tokens a request used.

--- a/docs/multiple-scorers.qmd
+++ b/docs/multiple-scorers.qmd
@@ -218,6 +218,41 @@ A stage settles the sample when `value_to_float()` of its score is at least `thr
 
 A cascade trusts a settling verdict from an earlier stage, so earlier scorers should not be prone to false positives (exact match qualifies; a lenient heuristic does not).
 
+## Filtering Scorers
+
+Some samples do not need a given scorer at all: a transcript the solver marked as degenerate does not need a grader model to tell you it failed, and a dataset that mixes kinds of samples may need a different scorer for each kind. `filter_scorer()` wraps a scorer with a predicate so the scorer only runs on the samples the predicate selects. The point is to not spend grader calls on samples that do not need them; the predicate-false samples simply have no score from that scorer.
+
+For example, to skip the model-graded scorer for samples a solver flagged in `state.metadata`:
+
+``` python
+from inspect_ai.scorer import filter_scorer, match, model_graded_qa
+
+def not_degenerate(state: TaskState, target: Target) -> bool:
+    return not state.metadata.get("degenerate", False)
+
+Task(
+    dataset=dataset,
+    solver=[generate(), flag_degenerate()],
+    scorer=[
+        match(),
+        filter_scorer(model_graded_qa(), not_degenerate),
+    ],
+)
+```
+
+Or to route two kinds of samples to different scorers in one task:
+
+``` python
+scorer=[
+    filter_scorer(math(), lambda state, target: state.metadata["kind"] == "numeric"),
+    filter_scorer(model_graded_fact(), lambda state, target: state.metadata["kind"] == "free_text"),
+]
+```
+
+The predicate receives the sample's `TaskState` and `Target` and may be `async`. The filtered scorer keeps the inner scorer's name, options and metrics, so it appears in the log as `model_graded_qa` (not `filter_scorer`) and its metrics are computed over the samples it scored — skipped samples are excluded from that scorer's metrics rather than counted as zero. The scorer's metadata in the log header records the predicate's name under `filter` (a named function gives a readable entry; a lambda records as `<lambda>`).
+
+The predicate is not stored in the log, so re-scoring with `inspect score` re-creates the inner scorer from its recorded name and options and runs it on every sample, including ones the filter skipped at eval time.
+
 ## Sandbox Access
 
 If your Solver is an [Agent](agents.qmd) with tool use, you might want to inspect the contents of the tool sandbox to score the task.

--- a/docs/reference/inspect_ai.scorer.qmd
+++ b/docs/reference/inspect_ai.scorer.qmd
@@ -19,6 +19,7 @@ description: Task scoring and metrics.
 ### target_perplexity
 ### multi_scorer
 ### cascade
+### filter_scorer
 ### precomputed_scores
 
 ## Metrics

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -4,6 +4,7 @@ from ._answer import AnswerPattern, answer
 from ._cascade import cascade
 from ._choice import choice
 from ._classification import exact, f1
+from ._filter import filter_scorer
 from ._match import includes, match
 from ._math import math
 from ._metric import (
@@ -89,6 +90,7 @@ __all__ = [
     "collect_score",
     "exact",
     "f1",
+    "filter_scorer",
     "frequency",
     "grouped",
     "includes",

--- a/src/inspect_ai/scorer/_filter.py
+++ b/src/inspect_ai/scorer/_filter.py
@@ -1,0 +1,82 @@
+import inspect
+from typing import Awaitable, Callable
+
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.registry import (
+    is_registry_object,
+    registry_info,
+    registry_params,
+    set_registry_info,
+    set_registry_params,
+)
+from inspect_ai.solver._task_state import TaskState
+
+from ._metric import Score
+from ._scorer import Scorer
+from ._target import Target
+
+
+def filter_scorer(
+    scorer: Scorer,
+    predicate: Callable[[TaskState, Target], bool | Awaitable[bool]],
+) -> Scorer:
+    r"""Restrict a scorer to the samples a predicate selects.
+
+    Calls `predicate(state, target)` for each sample; when it returns `False`
+    the sample is left unscored by this scorer (the scorer returns `None` and
+    the inner scorer is not called), otherwise scoring is delegated to the
+    inner scorer. Use this to avoid spending grader-model calls on samples
+    that do not need them — e.g. transcripts the solver marked as degenerate,
+    or a kind of sample this scorer does not apply to.
+
+    The returned scorer keeps the inner scorer's identity: it is recorded in
+    the log under the inner scorer's name with the inner scorer's options and
+    metrics, so persisted scores and metrics aggregation are unchanged. The
+    only trace of the filter is a `filter` key in the scorer's metadata naming
+    the predicate (use a named function rather than a lambda for a readable
+    entry). Two filtered scorers with different inner scorers therefore coexist
+    under their own names, and a filtered scorer alongside an unfiltered one of
+    the same kind is disambiguated exactly as two unfiltered ones would be.
+
+    The predicate itself is not persisted: re-scoring the log with
+    `inspect score` re-creates the inner scorer from its recorded name and
+    options and runs it on every sample.
+
+    Filtered-out samples have no score from this scorer, so they are excluded
+    from this scorer's metrics rather than counted as zero (metrics are
+    computed over the samples that have a score for the scorer). Other
+    scorers in the task still score them as usual.
+
+    Args:
+        scorer: Scorer to run on the selected samples. Must be a registry
+            object (created by a function decorated with `@scorer`).
+        predicate: Called with the sample's `TaskState` and `Target`; return
+            `True` to score the sample, `False` to skip it. May be `async`.
+
+    Returns:
+        A Scorer that scores only the samples the predicate selects.
+    """
+    if not is_registry_object(scorer, type="scorer"):
+        raise PrerequisiteError(
+            f"The scorer {getattr(scorer, '__name__', '<unknown>')} was not created "
+            "by a function decorated with @scorer so cannot be filtered."
+        )
+
+    async def score(state: TaskState, target: Target) -> Score | None:
+        selected = predicate(state, target)
+        if inspect.isawaitable(selected):
+            selected = await selected
+        if not selected:
+            return None
+        return await scorer(state, target)
+
+    predicate_name = getattr(predicate, "__name__", type(predicate).__name__)
+    info = registry_info(scorer)
+    set_registry_info(
+        score,
+        info.model_copy(
+            update={"metadata": info.metadata | {"filter": predicate_name}}
+        ),
+    )
+    set_registry_params(score, registry_params(scorer))
+    return score

--- a/tests/scorer/test_filter_scorer.py
+++ b/tests/scorer/test_filter_scorer.py
@@ -1,0 +1,251 @@
+from typing import cast
+
+import pytest
+
+from inspect_ai import Task, eval, score
+from inspect_ai._eval.score import resolve_scorers
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.dataset import Sample
+from inspect_ai.event import ScoreEvent
+from inspect_ai.log import EvalLog
+from inspect_ai.log._log import EvalMetricDefinition
+from inspect_ai.scorer import (
+    CORRECT,
+    INCORRECT,
+    Score,
+    Target,
+    accuracy,
+    filter_scorer,
+    mean,
+    scorer,
+    stderr,
+)
+from inspect_ai.solver import TaskState
+
+_STATE = cast(TaskState, None)  # scorers below ignore state
+_TARGET = Target(["x"])
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def counting_grade(value: str = CORRECT, calls: list[str] | None = None):
+    """Return a fixed grade and record each call in `calls`."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        if calls is not None:
+            calls.append(target.text)
+        return Score(value=value)
+
+    return score
+
+
+@scorer(metrics=[mean()])
+def length_score():
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=len(target.text))
+
+    return score
+
+
+def _run_eval(task: Task) -> EvalLog:
+    log = eval(tasks=task, model="mockllm/model")[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    assert log.results is not None
+    assert log.eval.scorers is not None
+    return log
+
+
+def _select_even_target(state: TaskState, target: Target) -> bool:
+    return int(target.text) % 2 == 0
+
+
+async def test_predicate_false_returns_none_without_calling_inner():
+    calls: list[str] = []
+    filtered = filter_scorer(counting_grade(calls=calls), lambda s, t: False)
+    assert await filtered(_STATE, _TARGET) is None
+    assert calls == []
+
+
+async def test_predicate_true_delegates_to_inner():
+    calls: list[str] = []
+    filtered = filter_scorer(counting_grade(calls=calls), lambda s, t: True)
+    result = await filtered(_STATE, _TARGET)
+    assert result is not None
+    assert result.value == CORRECT
+    assert calls == ["x"]
+
+
+async def test_async_predicate():
+    calls: list[str] = []
+
+    async def select(state: TaskState, target: Target) -> bool:
+        return target.text == "x"
+
+    filtered = filter_scorer(counting_grade(calls=calls), select)
+    assert (await filtered(_STATE, _TARGET)) is not None
+    assert await filtered(_STATE, Target(["y"])) is None
+    assert calls == ["x"]
+
+
+def test_inner_must_be_registry_scorer():
+    async def plain(state: TaskState, target: Target) -> Score:
+        return Score(value=CORRECT)
+
+    with pytest.raises(PrerequisiteError):
+        filter_scorer(plain, lambda s, t: True)
+
+
+def test_filtered_scorer_persists_under_inner_name_and_options():
+    calls: list[str] = []
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 5)],
+        scorer=filter_scorer(
+            counting_grade(value=INCORRECT, calls=calls), _select_even_target
+        ),
+    )
+    log = _run_eval(task)
+
+    # the inner scorer only ran on the selected samples (targets 2 and 4)
+    assert sorted(calls) == ["2", "4"]
+
+    # per-sample scores are keyed on the inner scorer's name and absent for
+    # filtered-out samples
+    assert log.samples is not None
+    for sample in log.samples:
+        scores = sample.scores or {}
+        if int(str(sample.target)) % 2 == 0:
+            assert set(scores) == {"counting_grade"}
+            assert scores["counting_grade"].value == INCORRECT
+        else:
+            assert scores == {}
+
+    # score events are emitted (with the inner's args) only for scored samples
+    score_events = [
+        event
+        for sample in log.samples
+        for event in sample.events
+        if isinstance(event, ScoreEvent)
+    ]
+    assert len(score_events) == 2
+    assert all(event.scorer == "counting_grade" for event in score_events)
+    assert all(
+        event.scorer_args == {"value": INCORRECT, "calls": []} for event in score_events
+    )
+
+    # the log header records the inner scorer's name, options and metrics; the
+    # options must be exactly the inner's so `inspect score` can re-create it
+    assert log.eval.scorers is not None
+    assert len(log.eval.scorers) == 1
+    eval_scorer = log.eval.scorers[0]
+    assert eval_scorer.name == "counting_grade"
+    assert eval_scorer.options == {"value": INCORRECT, "calls": []}
+    assert eval_scorer.metadata == {"filter": "_select_even_target"}
+    assert isinstance(eval_scorer.metrics, list)
+    metric_names = [
+        m.name.removeprefix("inspect_ai/")
+        for m in eval_scorer.metrics
+        if isinstance(m, EvalMetricDefinition)
+    ]
+    assert metric_names == ["accuracy", "stderr"]
+
+
+def test_metrics_computed_over_scored_samples_only():
+    # even-target samples are scored CORRECT; odd ones are filtered out. If the
+    # filtered-out samples were counted as zero, accuracy would be 0.5.
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 5)],
+        scorer=filter_scorer(counting_grade(value=CORRECT), _select_even_target),
+    )
+    log = _run_eval(task)
+    assert log.results is not None
+    assert len(log.results.scores) == 1
+    eval_score = log.results.scores[0]
+    assert eval_score.name == "counting_grade"
+    assert eval_score.scorer == "counting_grade"
+    assert eval_score.metrics["accuracy"].value == 1.0
+
+
+def test_two_filtered_scorers_coexist_under_their_own_names():
+    grade_calls: list[str] = []
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 5)],
+        scorer=[
+            filter_scorer(counting_grade(calls=grade_calls), _select_even_target),
+            filter_scorer(length_score(), lambda s, t: not _select_even_target(s, t)),
+        ],
+    )
+    log = _run_eval(task)
+
+    assert log.eval.scorers is not None
+    assert [s.name for s in log.eval.scorers] == ["counting_grade", "length_score"]
+    assert log.results is not None
+    assert [s.name for s in log.results.scores] == ["counting_grade", "length_score"]
+    assert log.results.scores[1].metrics["mean"].value == 1.0
+
+    assert log.samples is not None
+    for sample in log.samples:
+        scores = sample.scores or {}
+        expected = (
+            "counting_grade" if int(str(sample.target)) % 2 == 0 else "length_score"
+        )
+        assert set(scores) == {expected}
+
+
+def test_filtered_and_unfiltered_same_scorer_disambiguate_like_two_unfiltered():
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 3)],
+        scorer=[
+            counting_grade(),
+            filter_scorer(counting_grade(value=INCORRECT), _select_even_target),
+        ],
+    )
+    log = _run_eval(task)
+    assert log.results is not None
+    assert [s.name for s in log.results.scores] == [
+        "counting_grade",
+        "counting_grade1",
+    ]
+    assert log.samples is not None
+    by_target = {str(s.target): s.scores or {} for s in log.samples}
+    assert set(by_target["1"]) == {"counting_grade"}
+    assert set(by_target["2"]) == {"counting_grade", "counting_grade1"}
+    assert by_target["2"]["counting_grade1"].value == INCORRECT
+
+
+def test_task_metrics_override_keeps_filter_metadata():
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 5)],
+        scorer=filter_scorer(counting_grade(), _select_even_target),
+        metrics=[mean()],
+    )
+    log = _run_eval(task)
+    assert log.eval.scorers is not None
+    eval_scorer = log.eval.scorers[0]
+    assert eval_scorer.metadata == {"filter": "_select_even_target"}
+    assert isinstance(eval_scorer.metrics, list)
+    metric_names = [
+        m.name.removeprefix("inspect_ai/")
+        for m in eval_scorer.metrics
+        if isinstance(m, EvalMetricDefinition)
+    ]
+    assert metric_names == ["mean"]
+    assert log.results is not None
+    assert set(log.results.scores[0].metrics) == {"mean"}
+
+
+def test_rescoring_recreates_inner_scorer_without_filter():
+    # the predicate is not persisted: `inspect score` re-creates the inner
+    # scorer from the recorded name/options and runs it on every sample
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target=str(i)) for i in range(1, 5)],
+        scorer=filter_scorer(counting_grade(), _select_even_target),
+    )
+    log = _run_eval(task)
+    assert log.samples is not None
+    assert sum("counting_grade" in (s.scores or {}) for s in log.samples) == 2
+
+    rescored = score(log, resolve_scorers(log), action="overwrite")
+    assert rescored.samples is not None
+    assert all("counting_grade" in (s.scores or {}) for s in rescored.samples)
+    assert rescored.eval.scorers is not None
+    assert rescored.eval.scorers[0].name == "counting_grade"


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

**Problem.** A task's scorers run on every sample. When a grader model is one of them, that spends judge calls on samples that do not need grading: transcripts the solver already flagged as degenerate or failed, or samples of a kind a given scorer does not apply to (e.g. a dataset mixing numeric and free-text questions where `math()` and `model_graded_fact()` each apply to half). Today the only options are to bake the skip logic into a custom scorer (losing the built-in scorer's identity in the log) or to split the dataset into separate tasks. `cascade()` covers the "cheap scorer settled it" case but still runs the first stage on every sample, and cannot express "this scorer is not applicable to this sample".

### What is the new behavior?

**Change.** New `inspect_ai.scorer.filter_scorer(scorer, predicate)` wraps a scorer so it only runs on the samples `predicate(state, target)` selects. When the predicate is false the wrapper returns `None` — Inspect's existing "no score for this sample" — and the inner scorer is not called. The predicate may be sync or async.

The wrapper adopts the inner scorer's registry identity rather than introducing its own: it copies the inner's `RegistryInfo` (name, metrics, metadata) and registry params onto the returned scorer via the existing `set_registry_info` / `set_registry_params` helpers, adding a single `filter` key to the metadata naming the predicate. Consequences, all following from existing machinery with no changes to the eval loop or registry:

- Per-sample scores, `ScoreEvent.scorer`, `log.eval.scorers[i].name` and `log.results.scores[i].name` all use the inner's name (`model_graded_qa`, not `filter_scorer`), and two filtered scorers wrapping different inners coexist under their own names. A filtered and an unfiltered scorer of the same kind are disambiguated exactly as two unfiltered ones are (`name`, `name1`) by `unique_scorer_name`.
- `log.eval.scorers[i].options` is exactly the inner's params. This matters because `inspect score` re-creates scorers as `scorer_from_spec(ScorerSpec(scorer=name), **options)`; a `filter` marker in `options` would have broken re-scoring with an unexpected-kwarg error. The marker goes in `metadata` instead, which is informational only and never fed back into creation.
- Metrics are the inner's, and `eval_results` computes each scorer's metrics over the samples that have a score for that scorer, so filtered-out samples are excluded from the scorer's metrics rather than counted as zero. This is documented in the docstring and user docs.

**Name.** `filter_scorer` mirrors `multi_scorer`'s `<modifier>_scorer` shape and reads as an operation applied to a scorer ("filter this scorer to these samples"), which matches what it is: because the result keeps the inner scorer's identity, it is a transformation of a scorer rather than a scorer in its own right, so a noun-style name (`scorer_filter`) or a standalone-scorer name (like `cascade`) would misdescribe it.

This is an efficiency/convenience feature about not spending judge calls; it does not change rescoring semantics or how `None` scores are treated.

Docs: new "Filtering Scorers" section in `docs/multiple-scorers.qmd` (after "Cascading Scorers") with the degenerate-transcript and two-kinds-of-samples examples, plus a reference entry. CHANGELOG entry under Unreleased.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Purely additive: one new public function and one new `metadata` key that only appears on scorers created through it. No existing code paths change.

### Other information:

**Test.** `tests/scorer/test_filter_scorer.py` (all run against `mockllm/model`, no network):

- predicate false → `None` and the inner scorer is not called; predicate true → inner score returned
- async predicate works
- inner that is not a registry scorer → `PrerequisiteError`
- end-to-end eval: per-sample `scores` keyed on the inner name and absent for filtered samples; `ScoreEvent`s only for scored samples with the inner's `scorer_args`; `log.eval.scorers[0]` records the inner's name, options and metrics plus `metadata == {"filter": "<predicate>"}`
- `accuracy` over 4 samples with 2 filtered out is 1.0 (would be 0.5 if filtered samples counted as zero)
- two filtered scorers with different inners coexist under their own names, each scoring its own subset
- filtered + unfiltered same-kind scorers become `counting_grade` / `counting_grade1`

`tests/scorer/` passes on asyncio (669 passed) and with `--runtrio` (193 passed). `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

**Compatibility.** No registry or eval-loop changes; `inspect score` on a log produced with a filtered scorer re-creates the inner scorer from the recorded name/options as before (and will then score all samples, since the predicate is not serialisable — consistent with this being about avoiding judge calls at eval time, not rescoring semantics).

**Tooling.** Authored with Claude Code (Claude Fable 5.1).

### Agent review
- Reviewer: Claude Fable 5.1 (general-purpose subagent, fresh context, same model family as the author), 1 pass. The reviewer independently ran ruff, mypy, the new tests on asyncio and trio, and an empirical probe of `inspect score` re-creation.
- Findings: 8 — 4 fixed, 4 dismissed/deferred:
  - fixed: docs/docstring claimed `inspect score` re-scoring "works as usual"; it re-creates the *unfiltered* inner scorer (the predicate is not serialisable), so with `--action overwrite` every sample is scored. Reworded docs and docstring, and added `test_rescoring_recreates_inner_scorer_without_filter` to pin that as the documented contract.
  - fixed: no test for `Task(metrics=...)` on a filtered scorer (`resolve_scorer_metrics` rebuilds the RegistryInfo). Added `test_task_metrics_override_keeps_filter_metadata`.
  - fixed: `ScorerPredicate` alias appeared in the public signature but was not exported; inlined the `Callable[...]` type instead of adding a public type.
  - fixed: lambdas record as `filter: "<lambda>"`; docs and docstring now say a named function gives a readable entry. CHANGELOG entry shortened to ~25 words.
  - dismissed: the `filter` metadata key would overwrite an inner `@scorer(filter=...)` metadata key — vanishingly unlikely collision, not worth a less readable key name.
  - deferred: `score_async` could warn when a header scorer carries a `filter` key it cannot honour; and the viewer does not surface `EvalScorer.metadata`, so `inspect view` shows fewer scored samples for the scorer without saying why. Both are reasonable follow-ups but out of scope for this PR.
  - process flag: AGENTS.md rule 5 (new scorers default to an extension) — raised here as a maintainer decision.
- Reviewer found no correctness, shared-mutable-state, or async-backend issues in the wrapper itself, and confirmed `None` is handled as "no score" on all four scoring paths (`run.py`, `score.py`, `_score.py`, `_control/scoring.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
