### PR TITLE
perf(store): skip store snapshot/diff for spans that never touch it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Store: Spans that neither write to the `Store` nor read a mutable value from it no longer serialise and diff the whole store at span end, removing a per-span cost proportional to store size (previously ~35 ms per tool call for a 10 MB store).
 - Scorer (breaking): Model-graded scorers with a panel of graders now require a strict majority: samples with no majority grade (even-split ties, three-way splits, or ties after a grader returns no parseable grade) come back unscored and leave the metric denominator, rather than the most common grade winning with ties broken by grader order. Pass `reducer="mode"` to `model_graded_qa()`/`model_graded_fact()` to restore the previous behavior. (#4721)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -38,7 +38,7 @@ from inspect_ai.log._condense import (
 )
 from inspect_ai.model._chat_message import ChatMessageBase
 from inspect_ai.model._model_call import ModelCall
-from inspect_ai.util._store import store, store_changes, store_jsonable
+from inspect_ai.util._store import StoreChangeTracker, store
 
 if TYPE_CHECKING:
     from inspect_ai.log._recorders.buffer.types import TranscriptEventSink
@@ -1020,11 +1020,23 @@ def record_interrupt_event(
 
 @contextlib.contextmanager
 def track_store_changes() -> Iterator[None]:
-    before = store_jsonable(store())
-    yield
-    after = store_jsonable(store())
+    """Emit a `StoreEvent` for changes made to the current store in the body.
 
-    changes = store_changes(before, after)
+    Changes are detected by comparing a snapshot of the store taken on its
+    first access inside the body against the store at exit. A container
+    obtained from the store before this body began and mutated inside it,
+    with no other store access in the body, is attributed to the nearest
+    enclosing span that did touch the store, and is not recorded at all if
+    there is none.
+    """
+    tracker = StoreChangeTracker(store())
+    tracker.begin()
+    try:
+        yield
+    finally:
+        tracker.end()
+
+    changes = tracker.changes()
     if changes:
         transcript()._event(StoreEvent(changes=changes))
 

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -3,9 +3,12 @@ import inspect
 from collections.abc import Awaitable, Callable, Iterator
 from contextvars import ContextVar, Token
 from logging import getLogger
-from typing import Any, AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator
 
 from shortuuid import uuid as shortuuid
+
+if TYPE_CHECKING:
+    from inspect_ai.util._store import StoreChangeTracker
 
 logger = getLogger(__name__)
 
@@ -172,7 +175,7 @@ class SpanRotationScope:
         self._token: Token[str | _SpanCell | None] | None = None
         self._parent_id: str | None = None
         self._span_open = False
-        self._store_before: dict[str, Any] = {}
+        self._tracker: StoreChangeTracker | None = None
 
     @property
     def is_open(self) -> bool:
@@ -246,16 +249,20 @@ class SpanRotationScope:
         )
 
     def _snapshot_store(self) -> None:
-        from inspect_ai.util._store import store, store_jsonable
+        from inspect_ai.util._store import StoreChangeTracker, store
 
-        self._store_before = store_jsonable(store())
+        assert self._tracker is None, "store tracker already open"
+        self._tracker = StoreChangeTracker(store())
+        self._tracker.begin()
 
     def _emit_store_changes(self) -> None:
         from inspect_ai.event._store import StoreEvent
         from inspect_ai.log._transcript import transcript
-        from inspect_ai.util._store import store, store_changes, store_jsonable
 
-        changes = store_changes(self._store_before, store_jsonable(store()))
+        assert self._tracker is not None, "store tracker not open"
+        self._tracker.end()
+        changes = self._tracker.changes()
+        self._tracker = None
         if changes:
             transcript()._event(StoreEvent(changes=changes))
 

--- a/src/inspect_ai/util/_store.py
+++ b/src/inspect_ai/util/_store.py
@@ -43,6 +43,21 @@ class Store:
 
     def __init__(self, data: dict[str, Any] | None = None) -> None:
         self._data = deepcopy(data) if data else {}
+        # Open change trackers (one per enclosing span). Each is snapshotted
+        # lazily the first time the store is written or a mutable value is
+        # handed out, so spans that never touch the store never serialise it.
+        self._trackers: list[StoreChangeTracker] = []
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "Store":
+        # Copy the data only. Open trackers belong to spans on the original
+        # store; carrying them over (as the default deepcopy would) leaves
+        # trackers on the copy that are never ended, so its first write would
+        # serialise it once per phantom tracker and retain those snapshots for
+        # the copy's lifetime.
+        copied = Store()
+        memo[id(self)] = copied
+        copied._data = deepcopy(self._data, memo)
+        return copied
 
     @overload
     def get(self, key: str, default: None = None) -> Any: ...
@@ -65,8 +80,13 @@ class Store:
         """
         if default is not None:
             if key not in self._data.keys():
+                self._snapshot_trackers()
                 self._data[key] = default
-        return cast(VT, self._data.get(key, default))
+        value = self._data.get(key, default)
+        # a mutable value may be modified in place by the caller
+        if not _is_immutable(value):
+            self._snapshot_trackers()
+        return cast(VT, value)
 
     def set(self, key: str, value: Any) -> None:
         """Set a value into the store.
@@ -75,6 +95,7 @@ class Store:
            key (str): Name of value to set
            value (Any): Value to set
         """
+        self._snapshot_trackers()
         self._data[key] = value
 
     def delete(self, key: str) -> None:
@@ -83,6 +104,7 @@ class Store:
         Args:
            key (str): Name of value to remove
         """
+        self._snapshot_trackers()
         del self._data[key]
 
     def keys(self) -> KeysView[str]:
@@ -91,10 +113,12 @@ class Store:
 
     def values(self) -> ValuesView[Any]:
         """View of values within the store."""
+        self._snapshot_trackers()
         return self._data.values()
 
     def items(self) -> ItemsView[str, Any]:
         """View of items within the store."""
+        self._snapshot_trackers()
         return self._data.items()
 
     def __contains__(self, key: object) -> bool:
@@ -105,6 +129,51 @@ class Store:
 
     def __ne__(self, value: object) -> bool:
         return self._data.__ne__(value)
+
+    def _snapshot_trackers(self) -> None:
+        for tracker in self._trackers:
+            tracker.snapshot()
+
+
+def _is_immutable(value: Any) -> bool:
+    return isinstance(value, str | int | float | bool | bytes | type(None))
+
+
+class StoreChangeTracker:
+    """Records the changes made to a `Store` between `begin()` and `end()`.
+
+    The "before" snapshot is deferred until the store is first written to
+    or hands out a value that could be mutated in place (any non-scalar
+    returned by `get()`, `values()` or `items()`). The store notifies every
+    open tracker before the access, so the snapshot reflects the same state
+    an eager snapshot at `begin()` would have captured. A tracker that is
+    never notified serialises nothing and reports no changes.
+
+    Limitation: a container obtained from the store before a span began and
+    mutated inside it, with no other store access in that span, is attributed
+    to the nearest enclosing span that did touch the store, and is not
+    recorded at all if there is none.
+    """
+
+    def __init__(self, store: Store) -> None:
+        self._store = store
+        self._before: dict[str, Any] | None = None
+
+    def begin(self) -> None:
+        self._store._trackers.append(self)
+
+    def end(self) -> None:
+        self._store._trackers.remove(self)
+
+    def snapshot(self) -> None:
+        if self._before is None:
+            self._before = store_jsonable(self._store)
+
+    def changes(self) -> list[JsonChange] | None:
+        """Changes since `begin()` (`None` if the store was never touched)."""
+        if self._before is None:
+            return None
+        return store_changes(self._before, self._store)
 
 
 def store() -> Store:

--- a/tests/log/test_track_store_changes.py
+++ b/tests/log/test_track_store_changes.py
@@ -1,28 +1,23 @@
 """Tests for :func:`inspect_ai.log._transcript.track_store_changes`.
 
-We compare the existing implementation:
-
-    before = store_jsonable(store())
-    ...
-    after = store_jsonable(store())
-
-with a proposed optimisation that snapshots the store via:
-
-    before = dict_jsonable(store()._data)
-    ...
-    after = dict_jsonable(store()._data)
-
-We exercise a range of Python and Pydantic value types (mirroring how the
-Store is used in practice) and assert that the emitted
-``StoreEvent(changes=...)`` sequences are identical under both strategies.
+``track_store_changes`` defers the "before" snapshot of the store until the
+store is first written or hands out a mutable value, so spans that never touch
+the store serialise nothing. These tests check that the emitted
+``StoreEvent(changes=...)`` sequences are identical to a reference
+implementation that eagerly snapshots the store at span begin and end, across
+the range of Python and Pydantic value types (and mutation styles, including
+in-place mutation of values obtained via ``store.get()``) that the Store sees
+in practice.
 """
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Callable, ContextManager
 
+import pytest
 from pydantic import BaseModel, Field
 
 from inspect_ai._util.json import JsonChange
@@ -57,6 +52,218 @@ def test_dict_jsonable_independent_copy() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Lazy snapshot: untouched spans serialise nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def jsonable_calls(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Count calls to ``dict_jsonable`` (the store serialisation primitive)."""
+    import inspect_ai.util._store as store_module
+
+    calls: list[int] = []
+    original = store_module.dict_jsonable
+
+    def counting(data: dict[str, Any]) -> dict[str, Any]:
+        calls.append(1)
+        return original(data)
+
+    monkeypatch.setattr(store_module, "dict_jsonable", counting)
+    return calls
+
+
+def test_untouched_span_does_not_serialise(jsonable_calls: list[int]) -> None:
+    store = Store()
+    store.set("payload", {"big": "x" * 1000})
+
+    events = _run_span_with(track_store_changes, store, lambda s: None)
+
+    assert events == []
+    assert jsonable_calls == []
+
+
+def test_scalar_read_does_not_serialise(jsonable_calls: list[int]) -> None:
+    store = Store()
+    store.set("answer", 42)
+    store.set("name", "abc")
+
+    def read(s: Store) -> None:
+        assert s.get("answer") == 42
+        assert s.get("name") == "abc"
+        assert s.get("missing") is None
+        assert "answer" in s
+        assert list(s.keys()) == ["answer", "name"]
+
+    events = _run_span_with(track_store_changes, store, read)
+
+    assert events == []
+    assert jsonable_calls == []
+
+
+def test_set_emits_expected_patch(jsonable_calls: list[int]) -> None:
+    store = Store()
+    store.set("count", 1)
+
+    def mutate(s: Store) -> None:
+        s.set("count", 2)
+        s.set("added", "x")
+
+    events = _run_span_with(track_store_changes, store, mutate)
+
+    store_events = [e for e in events if isinstance(e, StoreEvent)]
+    assert len(store_events) == 1
+    assert sorted(store_events[0].changes, key=lambda c: c.path) == [
+        JsonChange(op="add", path="/added", value="x"),
+        JsonChange(op="replace", path="/count", value=2, replaced=1),
+    ]
+    # exactly one before and one after snapshot
+    assert len(jsonable_calls) == 2
+
+
+def test_delete_emits_expected_patch() -> None:
+    store = Store()
+    store.set("gone", {"a": 1})
+
+    events = _run_span_with(track_store_changes, store, lambda s: s.delete("gone"))
+
+    assert [e.changes for e in events if isinstance(e, StoreEvent)] == [
+        [JsonChange(op="remove", path="/gone")]
+    ]
+
+
+def test_in_place_mutation_via_get_is_detected() -> None:
+    store = Store()
+    store.set("items", [1, 2])
+
+    events = _run_span_with(
+        track_store_changes, store, lambda s: s.get("items").append(3)
+    )
+
+    assert [e.changes for e in events if isinstance(e, StoreEvent)] == [
+        [JsonChange(op="add", path="/items/2", value=3)]
+    ]
+
+
+def test_get_with_default_inserts_and_is_detected() -> None:
+    store = Store()
+
+    def mutate(s: Store) -> None:
+        history: list[str] = s.get("history", [])
+        history.append("first")
+
+    events = _run_span_with(track_store_changes, store, mutate)
+
+    assert [e.changes for e in events if isinstance(e, StoreEvent)] == [
+        [JsonChange(op="add", path="/history", value=["first"])]
+    ]
+
+
+def test_nested_spans_only_inner_writes() -> None:
+    store = Store()
+    store.set("value", 0)
+    init_subtask_store(store)
+    transcript = Transcript()
+    init_transcript(transcript)
+
+    with track_store_changes():
+        with track_store_changes():
+            store.set("value", 1)
+
+    store_events = [e for e in transcript.events if isinstance(e, StoreEvent)]
+    expected = [JsonChange(op="replace", path="/value", value=1, replaced=0)]
+    # inner span emits first, then the enclosing span reports the same change
+    assert [e.changes for e in store_events] == [expected, expected]
+
+
+def test_untouched_span_after_touched_span_does_not_serialise(
+    jsonable_calls: list[int],
+) -> None:
+    store = Store()
+    init_subtask_store(store)
+    init_transcript(Transcript())
+
+    with track_store_changes():
+        store.set("a", 1)
+    assert len(jsonable_calls) == 2
+
+    with track_store_changes():
+        pass
+    assert len(jsonable_calls) == 2
+
+
+def test_store_model_attribute_write_and_in_place_mutation() -> None:
+    class _Agent(StoreModel):
+        turns: int = 0
+        notes: list[str] = Field(default_factory=list)
+
+    store = Store()
+    _Agent(store=store)  # populate defaults
+
+    def mutate(s: Store) -> None:
+        model = _Agent(store=s)
+        model.turns = 1
+        model.notes.append("hello")
+
+    events = _run_span_with(track_store_changes, store, mutate)
+
+    store_events = [e for e in events if isinstance(e, StoreEvent)]
+    assert len(store_events) == 1
+    # jsonpatch does not order operations deterministically
+    assert sorted(store_events[0].changes, key=lambda c: c.path) == [
+        JsonChange(op="add", path="/_Agent:notes/0", value="hello"),
+        JsonChange(op="replace", path="/_Agent:turns", value=1, replaced=0),
+    ]
+
+
+def test_concurrent_spans_share_snapshot_semantics() -> None:
+    """A write in one task is visible to a concurrently open span in another.
+
+    This matches the eager-snapshot behaviour: every open span diffs the whole
+    store, whichever task performed the write.
+    """
+    store = Store()
+    store.set("value", 0)
+    init_subtask_store(store)
+    transcript = Transcript()
+    init_transcript(transcript)
+
+    async def main() -> None:
+        writer_done = asyncio.Event()
+        reader_open = asyncio.Event()
+
+        async def reader() -> None:
+            with track_store_changes():
+                reader_open.set()
+                await writer_done.wait()
+
+        async def writer() -> None:
+            await reader_open.wait()
+            with track_store_changes():
+                store.set("value", 1)
+            writer_done.set()
+
+        await asyncio.gather(reader(), writer())
+
+    asyncio.run(main())
+
+    store_events = [e for e in transcript.events if isinstance(e, StoreEvent)]
+    expected = [JsonChange(op="replace", path="/value", value=1, replaced=0)]
+    assert [e.changes for e in store_events] == [expected, expected]
+
+
+def test_tracker_removed_when_span_raises() -> None:
+    store = Store()
+    init_subtask_store(store)
+    init_transcript(Transcript())
+
+    with pytest.raises(RuntimeError):
+        with track_store_changes():
+            raise RuntimeError("boom")
+
+    assert store._trackers == []
+
+
+# ---------------------------------------------------------------------------
 # Equivalence tests for different store shapes / mutations
 # ---------------------------------------------------------------------------
 
@@ -66,9 +273,7 @@ def test_track_store_changes_no_changes_produces_no_event() -> None:
     store = Store()
     store.set("value", 1)
 
-    baseline_events = _run_span_with(
-        _track_store_changes_with_store_jsonable, store, lambda s: None
-    )
+    baseline_events = _run_span_with(_track_store_changes_eager, store, lambda s: None)
     opt_events = _run_span_with(track_store_changes, store, lambda s: None)
 
     assert baseline_events == opt_events == []
@@ -84,11 +289,11 @@ def test_track_store_changes_scalars_and_nested_dicts() -> None:
         return s
 
     def mutate(store: Store) -> None:
-        data = store._data
-        data["new_key"] = "value"  # add
-        data["count"] = 6  # scalar replace
-        data["config"]["b"]["c"] = 10  # nested replace
-        del data["config"]["a"]  # delete
+        store.set("new_key", "value")  # add
+        store.set("count", 6)  # scalar replace
+        config = store.get("config")
+        config["b"]["c"] = 10  # nested replace
+        del config["a"]  # delete
 
     _assert_store_events_equal(build_store, mutate)
 
@@ -109,7 +314,7 @@ def test_track_store_changes_lists_of_dicts() -> None:
         return s
 
     def mutate(store: Store) -> None:
-        items: list[dict[str, object]] = store._data["items"]
+        items: list[dict[str, object]] = store.get("items")
         items.insert(1, {"id": 99, "name": "x"})  # insert
         items[0] = {"id": 100, "name": "replaced"}  # replace
         items.pop()  # remove
@@ -127,12 +332,11 @@ def test_track_store_changes_top_level_keys() -> None:
         return s
 
     def mutate(store: Store) -> None:
-        data = store._data
         # Delete a whole top-level subtree
-        del data["root"]
+        store.delete("root")
         # Re-add with a different shape and add a brand new root key
-        data["root"] = {"a": 2, "c": 3}
-        data["new_root"] = {"y": 4}
+        store.set("root", {"a": 2, "c": 3})
+        store.set("new_root", {"y": 4})
 
     _assert_store_events_equal(build_store, mutate)
 
@@ -178,21 +382,19 @@ def test_track_store_changes_message_like_store() -> None:
         return s
 
     def mutate(store: Store) -> None:
-        data = store._data
-
         # Toggle metadata flags
-        flags = data["metadata"]["flags"]
+        flags = store.get("metadata")["flags"]
         flags["debug"] = not flags["debug"]
         flags["retry"] = not flags["retry"]
 
         # Append/remove events
-        events: list[dict[str, object]] = data["events"]
+        events: list[dict[str, object]] = store.get("events")
         events.append({"type": "extra", "payload": "x"})
         if events:
             events.pop(0)
 
         # Modify nested metadata on real ChatMessage types
-        user_messages: list[ChatMessageUser] = data["user_messages"]
+        user_messages: list[ChatMessageUser] = store.get("user_messages")
         if user_messages:
             m0 = user_messages[0]
             meta = m0.metadata or {}
@@ -201,7 +403,7 @@ def test_track_store_changes_message_like_store() -> None:
             m0.metadata = meta
 
         # Add another score record
-        scores: list[_ScoreRecord] = data["scores"]
+        scores: list[_ScoreRecord] = store.get("scores")
         scores.append(_ScoreRecord(score=0.9, feedback="better"))
 
     _assert_store_events_equal(build_store, mutate)
@@ -275,14 +477,8 @@ def _run_nested_spans(
 
 
 @contextmanager
-def _track_store_changes_with_store_jsonable():
-    """Reference implementation using the *prior* ``store_jsonable`` semantics.
-
-    Historically, ``store_jsonable`` wrapped ``dict_jsonable(store._data)`` in an
-    additional ``deepcopy``. We keep that behaviour here explicitly so that the
-    tests continue to compare the new implementation against the original
-    snapshot strategy, even though ``store_jsonable`` itself is now lighter.
-    """
+def _track_store_changes_eager():
+    """Reference implementation: eagerly deep-copy the whole store at begin and end."""
     from inspect_ai.log._transcript import transcript
     from inspect_ai.util._store import store
 
@@ -298,14 +494,10 @@ def _assert_store_events_equal(
     build_store: Callable[[], Store],
     mutate: Callable[[Store], None],
 ) -> None:
-    """Compare StoreEvent.changes between baseline and optimised spans."""
-    # Baseline: reference implementation using store_jsonable(store())
+    """Compare StoreEvent.changes between the eager reference and track_store_changes."""
     baseline_store = build_store()
-    baseline_events = _run_span_with(
-        _track_store_changes_with_store_jsonable, baseline_store, mutate
-    )
+    baseline_events = _run_span_with(_track_store_changes_eager, baseline_store, mutate)
 
-    # Optimised using dict_jsonable(store()._data)
     opt_store = build_store()
     opt_events = _run_span_with(track_store_changes, opt_store, mutate)
 
@@ -317,7 +509,47 @@ def _assert_store_events_equal(
 
 def test_track_store_changes_nested_spans() -> None:
     """Compare behaviour for nested spans (outer span containing an inner span)."""
-    baseline_nested = _run_nested_spans(_track_store_changes_with_store_jsonable)
+    baseline_nested = _run_nested_spans(_track_store_changes_eager)
     opt_nested = _run_nested_spans(track_store_changes)
 
     assert baseline_nested == opt_nested
+
+
+# ---------------------------------------------------------------------------
+# deepcopy (used by fork()) does not carry open trackers over to the copy
+# ---------------------------------------------------------------------------
+
+
+def test_deepcopy_drops_open_trackers() -> None:
+    """A deep-copied Store has no trackers and independent data.
+
+    `fork()` deep-copies the TaskState (and so its Store) inside a running
+    span. Trackers open on the original must not be copied: a phantom tracker
+    on the copy would never be ended, so every first write to the copy would
+    serialise it and retain the snapshot for the copy's lifetime.
+    """
+    from inspect_ai.util._store import StoreChangeTracker
+
+    original = Store({"items": [1, 2]})
+    tracker = StoreChangeTracker(original)
+    tracker.begin()
+    try:
+        assert len(original._trackers) == 1
+
+        copied = deepcopy(original)
+
+        assert copied._trackers == []
+        assert len(original._trackers) == 1
+        assert copied.get("items") == [1, 2]
+
+        # a write to the copy neither reaches the original's data nor
+        # snapshots the original's tracker
+        copied.get("items").append(3)
+        assert original._data["items"] == [1, 2]
+        assert tracker._before is None
+
+        # and a write to the original does not reach the copy
+        original.set("other", "x")
+        assert "other" not in copied
+    finally:
+        tracker.end()


### PR DESCRIPTION
## Problem

`track_store_changes()` JSON-serialises the entire sample `Store` at span begin and again at span end, then diffs the two with `jsonpatch`. Every `span()` wraps it, and inspect opens a span per tool call (`model/_call_tools.py`) and per agent run (`agent/_run.py`), so a sample whose store holds a large object pays O(store bytes) of main-thread CPU on every span even when nothing was written. With a 10 MB store (400 x 25 KB values) an idle span costs ~36 ms; a sample with hundreds of tool calls spends minutes on no-op diffs. Real case: a harness that records every produced transcript into the store as the sample runs.

## Change

`Store` keeps a list of open `StoreChangeTracker`s (one per enclosing span). A tracker takes its "before" snapshot lazily, on first touch:

- `Store.set()` / `Store.delete()` notify open trackers before mutating.
- `Store.get()` (including the default-insert path), `values()` and `items()` notify before handing out a value that could be mutated in place (anything that is not `str`/`int`/`float`/`bool`/`bytes`/`None`).

Because the snapshot is taken *before* the access, it equals what the eager begin-snapshot would have captured, so the emitted `StoreEvent` patches are identical to before. In-place mutation of containers obtained via `get()` (which `StoreModel` and the built-in memory tool rely on, e.g. `store.dirs.append(...)`) is still detected. Nested spans and concurrently open spans in sibling asyncio tasks each snapshot independently; trackers live on the `Store` instance (not a `ContextVar`) so a write in one task is still visible to a span open in another task sharing the store, exactly as today. A tracker that is never notified serialises nothing and emits nothing. Scalar reads, `keys()` and `in` do not trigger a snapshot.

`SpanRotationScope` (checkpointer spans) is switched to the same tracker. `track_store_changes()` now unregisters its tracker in a `finally`, and as before emits no `StoreEvent` when the body raises.

`Store.__deepcopy__` copies only the data. `fork()` deep-copies the `TaskState` (and so its `Store`) inside a running span; the default deepcopy would also copy the open trackers, leaving phantom trackers on the copy that are never ended, so the copy's first write would serialise it once per phantom and retain those snapshots for the copy's lifetime.

## Known limitation

A container obtained from the store before a span began and mutated inside it, with no other store access in that span, is attributed to the nearest enclosing span that did touch the store, and is not recorded at all if there is none. `main`'s eager begin/end snapshot did record this case against the span itself. The sentence above is in the `track_store_changes` and `StoreChangeTracker` docstrings. I found no such usage in inspect, its tests, docs or examples; every in-place mutation pattern goes through `store.get()` / a `StoreModel` attribute read inside the span.

## Test

New/updated tests in `tests/log/test_track_store_changes.py` (20 tests):

- untouched span and scalar-read-only span emit no `StoreEvent` and make zero `dict_jsonable` calls (counted via monkeypatch)
- `set` / `delete` emit the expected patches with exactly one before + one after serialisation
- in-place `append` on a list from `get()`, and `get(key, [])` default-insert followed by `append`, are detected
- nested spans where only the inner span writes: both emit the correct patch
- `StoreModel` attribute write plus in-place list mutation through a `StoreModel` field
- concurrent spans in two asyncio tasks sharing a store: a write in one is seen by both (previous semantics preserved)
- tracker is unregistered when the span body raises
- existing equivalence tests against an eager deep-copy reference implementation retained; their mutation helpers now go through the public `get`/`set`/`delete` API instead of the private `_data` dict
- `deepcopy` of a store with an open tracker yields a copy with zero trackers and independent data; a write to the copy does not snapshot the original's tracker

Full test suite: 10981 passed, 4634 skipped. `ruff` and `mypy` clean on the changed files.

Benchmark (`origin/main` vs this branch, store of 400 x 25 KB strings, 200 spans each, ms per `span()`):

| Span body | Before | After |
|---|---|---|
| no store access | 36.6 ms | 0.05 ms |
| `store().get("answer")` (scalar read) | 36.4 ms | 0.05 ms |
| `store().set("counter", i)` (one small write) | 37.0 ms | 37.0 ms |

## Compatibility

No public API changes. `StoreEvent` content is unchanged for every access made through the `Store` API. Direct mutation of the private `Store._data` dict inside a span is no longer detected (the only in-repo instance was the test helper updated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

