### PR TITLE
Record cascade_values in cascade() score metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Scorers: `cascade()` now records `cascade_values` in score metadata, the per-stage float verdicts, so earlier stages overridden on fall-through stay visible for auditing.
 - Scorer (breaking): Model-graded scorers with a panel of graders now require a strict majority: samples with no majority grade (even-split ties, three-way splits, or ties after a grader returns no parseable grade) come back unscored and leave the metric denominator, rather than the most common grade winning with ties broken by grader order. Pass `reducer="mode"` to `model_graded_qa()`/`model_graded_fact()` to restore the previous behavior. (#4721)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)

--- a/docs/multiple-scorers.qmd
+++ b/docs/multiple-scorers.qmd
@@ -214,7 +214,7 @@ cascade(
 )
 ```
 
-A stage settles the sample when `value_to_float()` of its score is at least `threshold` (default `1.0`, i.e. CORRECT). Stages that decline (return `None`) or are unscored are skipped; if no stage settles, the last real score is returned, and if nothing scored the sample is unscored. The returned score records which stage decided under `decided_by` in its metadata.
+A stage settles the sample when `value_to_float()` of its score is at least `threshold` (default `1.0`, i.e. CORRECT). Stages that decline (return `None`) or are unscored are skipped; if no stage settles, the last real score is returned, and if nothing scored the sample is unscored. The returned score records which stage decided under `decided_by` in its metadata, alongside `cascade_values`: the `value_to_float()` verdict of every stage that ran and scored, in order. `cascade_values` preserves the verdicts of earlier stages that a later stage overrode, so a cheap stage disagreeing with the deciding stage stays visible for offline auditing.
 
 A cascade trusts a settling verdict from an earlier stage, so earlier scorers should not be prone to false positives (exact match qualifies; a lenient heuristic does not).
 

--- a/src/inspect_ai/scorer/_cascade.py
+++ b/src/inspect_ai/scorer/_cascade.py
@@ -36,6 +36,15 @@ def cascade(threshold: float = 1.0, **scorers: Scorer) -> Scorer:
     settling stage, or the last scored stage on fall-through); the sub-scorer's
     own `Score` object is not mutated.
 
+    The returned metadata also carries `cascade_values`, a mapping from each
+    stage that ran and produced a real score to its `value_to_float` verdict,
+    in run order. This preserves the verdicts of earlier stages that a later
+    stage overrode on fall-through, so a cheap stage disagreeing with the
+    deciding stage stays visible for offline auditing. Stages that declined
+    (`None`) or were unscored (`nan`) are omitted, and stages after the settling
+    one never ran, so they do not appear. When no stage scored (the unscored
+    fall-back), the `cascade_values` key is absent rather than empty.
+
     The cascade assumes earlier (cheaper) scorers do not produce false
     positives, so a `CORRECT` from exact match or symbolic equivalence can be
     trusted without running the grader model. That assumption is the caller's
@@ -58,6 +67,7 @@ def cascade(threshold: float = 1.0, **scorers: Scorer) -> Scorer:
 
     async def score(state: TaskState, target: Target) -> Score:
         last_scored: tuple[str, Score] | None = None
+        cascade_values: dict[str, float] = {}
         for name, sub_scorer in scorers.items():
             result = await sub_scorer(state, target)
             if result is None:
@@ -65,6 +75,7 @@ def cascade(threshold: float = 1.0, **scorers: Scorer) -> Scorer:
             value = to_float(result.value)
             if isnan(value):
                 continue
+            cascade_values[name] = value
             last_scored = (name, result)
             if value >= threshold:
                 break
@@ -74,7 +85,10 @@ def cascade(threshold: float = 1.0, **scorers: Scorer) -> Scorer:
 
         decided_by, result = last_scored
         return result.model_copy(
-            update={"metadata": (result.metadata or {}) | {"decided_by": decided_by}}
+            update={
+                "metadata": (result.metadata or {})
+                | {"decided_by": decided_by, "cascade_values": cascade_values}
+            }
         )
 
     return score

--- a/tests/scorer/test_cascade.py
+++ b/tests/scorer/test_cascade.py
@@ -152,6 +152,62 @@ def test_sub_scorer_score_not_mutated():
     assert "decided_by" not in (original.metadata or {})
 
 
+def test_cascade_values_records_only_settling_stage_on_short_circuit():
+    calls: list[str] = []
+    fn = cascade(
+        exact=_stage("exact", Score(value=CORRECT), calls),
+        grader=_stage("grader", Score(value=CORRECT), calls),
+    )
+    result = _run(fn)
+    # grader never ran, so only exact's verdict is recorded
+    assert result.metadata["cascade_values"] == {"exact": 1.0}
+
+
+def test_cascade_values_preserves_fall_through_disagreement():
+    calls: list[str] = []
+    fn = cascade(
+        exact=_stage("exact", Score(value=INCORRECT), calls),
+        grader=_stage("grader", Score(value=CORRECT), calls),
+    )
+    result = _run(fn)
+    # the overridden cheap-stage verdict stays visible next to the decider
+    assert result.metadata["decided_by"] == "grader"
+    assert result.metadata["cascade_values"] == {"exact": 0.0, "grader": 1.0}
+
+
+def test_cascade_values_records_all_stages_when_none_settle():
+    calls: list[str] = []
+    fn = cascade(
+        a=_stage("a", Score(value=INCORRECT), calls),
+        b=_stage("b", Score(value=INCORRECT), calls),
+    )
+    result = _run(fn)
+    # nothing settles: last real score decides, every ran stage is recorded
+    assert result.metadata["decided_by"] == "b"
+    assert result.metadata["cascade_values"] == {"a": 0.0, "b": 0.0}
+
+
+def test_cascade_values_absent_when_nothing_scored():
+    calls: list[str] = []
+    fn = cascade(
+        a=_stage("a", None, calls),
+        b=_stage("b", Score.unscored(), calls),
+    )
+    result = _run(fn)
+    assert "cascade_values" not in (result.metadata or {})
+
+
+def test_cascade_values_omits_declined_and_unscored_stages():
+    calls: list[str] = []
+    fn = cascade(
+        declined=_stage("declined", None, calls),
+        unscored=_stage("unscored", Score.unscored(), calls),
+        grader=_stage("grader", Score(value=CORRECT), calls),
+    )
+    result = _run(fn)
+    assert result.metadata["cascade_values"] == {"grader": 1.0}
+
+
 @scorer(metrics=[accuracy(), stderr()])
 def _fixed(value):
     async def score(state: TaskState, target: Target) -> Score:


### PR DESCRIPTION
## What

Follow-up to #5118. `cascade()` now records `cascade_values` in the returned score's metadata: a mapping from each stage that ran and produced a real score to its `value_to_float()` verdict, in run order.

This preserves the verdicts of earlier stages that a later stage overrode on fall-through, so a cheap stage disagreeing with the deciding stage stays visible for offline auditing (the use case @dragonstyle raised while reviewing #5118). It sits alongside the existing `decided_by` entry.

Behavior:

- Short-circuit: only the settling stage is recorded (later stages never ran), e.g. `{"exact": 1.0}`.
- Fall-through: every stage that ran and scored is recorded, e.g. `{"exact": 0.0, "grader": 1.0}`, so the overridden cheap-stage verdict stays visible next to `decided_by`.
- Stages that declined (`None`) or were unscored (`nan`) are omitted, keeping the value a JSON-clean `dict[str, float]` with no `NaN` token in the log.
- When no stage scored, the sample is still `Score.unscored(reason="scoring_failed")` and the `cascade_values` key is absent.

No change to the settling logic, `decided_by`, or the default `accuracy()`/`stderr()` metrics.

## Test plan

- `pytest tests/scorer/test_cascade.py` (16 passed). New cases cover short-circuit (only settling stage recorded), fall-through disagreement, all-stages-below-threshold, declined/unscored omission, and key-absent-when-nothing-scored.
- Docs and CHANGELOG updated.

### AI tooling

Authored with Cursor.

### Agent review

Reviewed by Claude Opus 4.8 in a fresh context (1 pass) before opening. Findings, all resolved in this PR:

- Missing test for the pure fall-through case where no stage settles but multiple stages are recorded: added `test_cascade_values_records_all_stages_when_none_settle`.
- The docstring said declined/unscored stages "are omitted", implying the key still exists on the all-declined path where it is actually absent: clarified the docstring and added `test_cascade_values_absent_when_nothing_scored`.
- CHANGELOG entry exceeded the ~25-word guidance: trimmed to 23 words.
