### PR TITLE
Fix descriptor leak when an eval log read is cancelled mid-stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Eval Log: Reading an eval log no longer leaks file descriptors when the read is cancelled partway through.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/_util/async_zip.py
+++ b/src/inspect_ai/_util/async_zip.py
@@ -5,11 +5,11 @@ stored locally or remotely (e.g., S3) using async range requests.
 """
 
 import struct
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from typing import Any
 
 import anyio
+from anyio.abc import ByteReceiveStream
 from typing_extensions import Self
 
 from inspect_ai._util.asyncfiles import AsyncFilesystem
@@ -259,6 +259,9 @@ class _ZipMemberBytes:
 
             async for chunk in member:  # second read (e.g., retry on error)
                 process_differently(chunk)
+
+    Must be used as an async context manager: an iteration abandoned before
+    exhaustion releases its stream at context exit, not when the loop ends.
     """
 
     def __init__(
@@ -273,38 +276,50 @@ class _ZipMemberBytes:
         self._filename = filename
         self._offset, self._end, self._method = range_and_method
         self._raw = raw
-        self._active_streams: set[CompressedToUncompressedStream] = set()
+        self._active_streams: set[
+            CompressedToUncompressedStream | ByteReceiveStream
+        ] = set()
 
-    async def __aiter__(self) -> AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncGenerator[bytes, None]:
         byte_stream = await self._filesystem.read_file_bytes(
             self._filename, self._offset, self._end
         )
+        stream: CompressedToUncompressedStream | ByteReceiveStream = (
+            byte_stream
+            if self._raw or self._method == ZipCompressionMethod.STORED
+            else CompressedToUncompressedStream(byte_stream, self._method)
+        )
 
-        if self._raw or self._method == ZipCompressionMethod.STORED:
-            # Pass through raw bytes directly - no decompression needed
-            try:
-                async for chunk in byte_stream:
-                    yield chunk
-            finally:
-                await byte_stream.aclose()
-        else:
-            # Decompress using the appropriate method
-            stream = CompressedToUncompressedStream(byte_stream, self._method)
-            self._active_streams.add(stream)
-            try:
-                async for chunk in stream:
-                    yield chunk
-            finally:
-                self._active_streams.discard(stream)
-                await stream.aclose()
+        # Do NOT close from a `finally` here, and do not wrap this in
+        # contextlib.aclosing: when a stranded consumer's generator is
+        # finalized *synchronously* by the collector, GeneratorExit lands in
+        # this frame and the awaited close raises "coroutine ignored
+        # GeneratorExit", leaking the stream. Close only on normal exhaustion,
+        # where awaiting is legal; __aexit__ owns every other exit.
+        self._active_streams.add(stream)
+        async for chunk in stream:
+            yield chunk
+        await stream.aclose()
+        self._active_streams.discard(stream)
 
     async def __aenter__(self) -> Self:
         return self
 
-    async def __aexit__(self, *_args: Any) -> None:
+    async def __aexit__(self, *_args: object) -> None:
+        error: Exception | None = None
         for stream in list(self._active_streams):
-            await stream.aclose()
-        self._active_streams.clear()
+            # Shielded: a close that yields to a cancelled scope would be
+            # abandoned mid-flight, and these streams cannot be closed twice
+            # (aclose() marks itself done before awaiting), so a skipped
+            # close is a permanent leak. Untrack only once the close lands.
+            with anyio.CancelScope(shield=True):
+                try:
+                    await stream.aclose()
+                    self._active_streams.discard(stream)
+                except Exception as ex:
+                    error = error if error is not None else ex
+        if error is not None:
+            raise error
 
 
 class AsyncZipReader:

--- a/tests/util/test_async_zip.py
+++ b/tests/util/test_async_zip.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 import os
 import struct
@@ -7,7 +9,9 @@ import zlib
 from collections.abc import AsyncIterator
 from pathlib import Path
 
+import anyio
 import ijson  # type: ignore
+import psutil
 import pytest
 from test_helpers.utils import skip_if_trio
 
@@ -628,3 +632,64 @@ async def test_read_multi_frame_zstd_member(
     assert data == payload, (
         f"round-trip mismatch: wrote {len(payload)} bytes, read back {len(data)} bytes"
     )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="counts open file descriptors")
+@skip_if_trio  # ijson.parse_async is asyncio-only
+@pytest.mark.parametrize(
+    "compression",
+    [zipfile.ZIP_DEFLATED, zipfile.ZIP_STORED],
+    ids=["deflated", "stored"],
+)
+@pytest.mark.parametrize("scoped", [False, True], ids=["task-cancel", "cancel-scope"])
+async def test_cancelled_parse_does_not_leak_descriptors(
+    tmp_path: Path, compression: int, scoped: bool
+) -> None:
+    """Cancelling a parse mid-read must still release the member's descriptor.
+
+    ijson reads through an adapter, so a cancellation can land with a read in
+    flight. That leaves the member generator suspended with a send pending, and
+    a generator in that state cannot be closed — so cleanup living in the
+    generator body never runs and __aexit__ has to own it.
+
+    Both cancellation shapes matter. A bare task.cancel() delivers once, so
+    cleanup awaits normally; an enclosing cancel scope stays cancelled, and an
+    unshielded close would be abandoned at its first checkpoint.
+    """
+    zip_path = tmp_path / "cancel.zip"
+    with zipfile.ZipFile(zip_path, "w", compression) as zf:
+        zf.writestr(
+            "big.json", json.dumps([{"i": i, "pad": "y" * 80} for i in range(30000)])
+        )
+
+    events = 0
+
+    async def parse() -> None:
+        nonlocal events
+        async with AsyncFilesystem() as fs:
+            reader = AsyncZipReader(fs, str(zip_path))
+            async with await reader.open_member("big.json") as member:
+                async for _ in ijson.parse_async(adapt_to_reader(member)):
+                    events += 1
+
+    await parse()  # warm up one-time allocations
+    before = psutil.Process().num_fds()
+    landed = 0
+    for i in range(40):
+        seen = events
+        if scoped:
+            with anyio.move_on_after(i * 0.0004):
+                await parse()
+        else:
+            task = asyncio.ensure_future(parse())
+            await asyncio.sleep(i * 0.0004)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        landed += events > seen
+
+    # A sweep whose cancellations all fired before their parse began would leak
+    # nothing and prove nothing, so require that most of them landed mid-parse.
+    assert landed >= 10, f"only {landed}/40 cancellations landed mid-parse"
+    after = psutil.Process().num_fds()
+    assert after <= before, f"leaked {after - before} descriptors over 40 cancellations"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Cancelling an eval log read while it streams a zip member leaks a file descriptor
per cancellation and emits `RuntimeError: coroutine ignored GeneratorExit` through
`sys.unraisablehook`. Forty cancellations against a local `.eval` leak 38
descriptors. In test runs these surface as `PytestUnraisableExceptionWarning`
blamed on whichever test the collector happens to interrupt, so the test named is
usually innocent and the warning moves around with GC timing.

`_ZipMemberBytes.__aiter__` closed its stream from a `finally`, and that close
awaits. Awaiting is safe until a consumer stranded inside `__anext__` is closed
*synchronously* by the collector: `GeneratorExit` enters the frame, the `await`
raises, and the stream is never closed. `aclose()` cannot recover it either — a
generator abandoned mid-`__anext__` reports "already running".

### What is the new behavior?

Cleanup runs only on normal exhaustion, where awaiting is legal. Every other exit
leaves the stream registered for `__aexit__`, which also covers the raw/`STORED`
path that was never registered at all. This trades prompt release on an early
break for a release that cannot be skipped.

`__aexit__` shields each close. An unshielded close yields at its first
checkpoint, so under an enclosing cancel scope (`move_on_after`, a task group) it
is abandoned mid-flight and the remaining streams are skipped — and these streams
cannot be closed twice, since `aclose()` marks itself done before awaiting, so a
skipped close leaks permanently. Measured under a cancel scope: the underlying
file was closed **0/15** times unshielded, **15/15** shielded.

Descriptors over 40 cancellations, before → after:

| | fds | outcome |
|---|---|---|
| before | 4 → 31 | 27 unraisable |
| **after** | **4 → 4** | clean |

### Does this PR introduce a breaking change?

No. `_ZipMemberBytes` must now be used as an async context manager for an
abandoned iteration to be released, which its docstring already required and its
only in-repo caller already does.

### Other information:

The test is parametrized over both cancellation shapes, because they behave
differently: a bare `task.cancel()` delivers once so cleanup awaits normally,
while a cancel scope stays cancelled and is what the shielding exists for. It
contributes no trio coverage — `ijson.parse_async` is asyncio-only, hence
`@skip_if_trio`.

`_view/common.py` has a related but distinct S3 connection leak, fixed separately
in #5212 — not bundled here.

### Agent review

- Authored by Claude Opus 5 (Claude Code). Reviewers, one pass each in fresh
  contexts on the diff: GPT-5.6 (xhigh reasoning) and five Claude Opus 5 subagents
  (type safety, bug hunt, simplification, structure, test quality).
- Findings: 9 — 8 fixed, 1 not reproduced.
  - **The shielding bug above** was the highest-severity finding, raised
    independently by two reviewers and confirmed by direct measurement. It was not
    a regression (the old `finally` was skipped at the same await) but the original
    version of this PR claimed a guarantee it did not deliver.
  - An earlier revision also routed one `adapt_to_reader` call in
    `log/_recorders/eval.py` through its context-manager form. **Dropped**:
    measured against a 40 MB member it changed nothing (identical outcomes, fds and
    live streams), while introducing a masked-cancellation failure mode that only
    the `async_zip` fix suppressed. It belongs in its own PR.
  - Also fixed: the two `__aiter__` branches collapsed to one; the rationale
    comment cut and made imperative (it now names `contextlib.aclosing`, which
    reproduces the bug and is the first thing a reader reaches for); the
    context-manager contract moved into the class docstring; `psutil` for fd
    counting so the test runs on macOS; a sharpened vacuity guard; `Any` → `object`.
  - Not reproduced: a claim that the `eval.py` hunk masked cancellation with
    `RuntimeError`. 40/40 clean `CancelledError` on the production path, and three
    other reviewers agreed; the hunk was dropped on other grounds.
- Verified: reverting the fix fails all four parametrizations 3/3; removing only
  the shield fails the cancel-scope variant; the fix passes 10/10 with no flakes.
