### PR TITLE
ci: assert the timeline fixture corpus is present in viewer-tests

### DIFF
--- a/.github/workflows/log_viewer.yml
+++ b/.github/workflows/log_viewer.yml
@@ -152,6 +152,10 @@ jobs:
 
       - name: Run inspect-components tests
         working-directory: src/inspect_ai/_view/ts-mono
+        # The variable asserts that this repo's corpus is present, so the suite
+        # fails rather than skipping if it can no longer find the fixtures.
+        env:
+          TSMONO_REQUIRE_FIXTURES: "1"
         run: pnpm --filter @tsmono/inspect-components test
 
   dist-validation:


### PR DESCRIPTION
`viewer-tests` runs `packages/inspect-components`' fixture timeline suite against `tests/timeline/fixtures/events/`. That suite locates the corpus by climbing nine directories out of ts-mono, and skips itself when it finds nothing. Skipping is right for a bare ts-mono clone and wrong here: if the climb ever breaks, because a directory level is added inside ts-mono, the fixtures move, or a candidate path is renamed, the job keeps reporting green over zero tests.

meridianlabs-ai/ts-mono#612 lets the caller say the corpus must be there. With `TSMONO_REQUIRE_FIXTURES=1` the suite throws and names the directories it searched instead of skipping. This sets that variable on the existing step. Nothing changes while the fixtures are found.

```
$ TSMONO_REQUIRE_FIXTURES=1 pnpm --filter @tsmono/inspect-components test
 Test Files  96 passed (96)
      Tests  975 passed (975)
```

96 files with none skipped, so the fixture suite is found and all 8 fixtures pass.

This also bumps the ts-mono submodule pointer to current main (6727349 to 093b7743d) so the variable has a reader. The pinned commit predated meridianlabs-ai/ts-mono#612 and would have ignored it. The bump pulls in six commits, all CI and test changes; `generated.ts` is untouched and the viewer bundle rebuilt at the new commit is byte-identical, so `dist/` does not change.

Why it is worth doing: the same gap in a sibling repo that embeds ts-mono let this suite run nowhere for 11 days. A `core.ts` change removed two defensive reads that the suite's hand-built fixture events depended on, 37 of its fixtures broke, and nothing reported it, because that repo had no job running the suite and ts-mono's own CI skips it. The Python implementation of the same algorithm stayed green on the shared corpus throughout. This repo already has the job; this closes the other half, so a corpus that goes missing fails loudly.

Prepared with Claude Code. Verified by running the gate in each of its three states: no fixtures with the variable set (throws), no fixtures without it (skips, unchanged), and fixtures present with it set (the run above).

