### PR TITLE
Preserve multimodal input in model-graded scorers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
+- Scorer: Model-graded scorers now include media from the original sample input in grader requests.
 - Approval: Policy files given as percent-encoded `file://` URIs (e.g. paths with spaces, as `Path.as_uri()` produces) are now accepted by `eval()`, `Task()`, and `--approval`.
 - Checkpoints: Invalidating a sample now re-runs it from scratch on retry (its checkpoints are discarded) instead of resuming from its last checkpoint.
 - Bugfix: Interrupting a checkpointed eval's retry (Ctrl-C, crash, OOM) no longer loses checkpointed progress, including for samples the retry never reached.

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -1,9 +1,17 @@
 import logging
 import re
+from collections.abc import Sequence
 from functools import partial
 from typing import Any, Callable
 
-from inspect_ai._util.content import Content, ContentText
+from inspect_ai._util.content import (
+    Content,
+    ContentAudio,
+    ContentDocument,
+    ContentImage,
+    ContentText,
+    ContentVideo,
+)
 from inspect_ai._util.dict import omit
 from inspect_ai._util.format import format_function_call
 from inspect_ai._util.list import remove_last_match_and_after
@@ -29,6 +37,8 @@ from ._scorer import Scorer, scorer
 from ._target import Target
 
 logger = logging.getLogger(__name__)
+
+_ModelGraderMedia = ContentImage | ContentAudio | ContentVideo | ContentDocument
 
 
 @scorer(metrics=[accuracy(), stderr()])
@@ -290,13 +300,38 @@ def _model_graded_qa_single(
             state.metadata, ["question", "answer", "criterion", "instructions"]
         )
 
+        input_media = _model_grader_input_media(state.input)
+        input_media_text = " ".join(f"[{media.type}]" for media in input_media)
+
         # present the question
         if include_history is True:
             question = chat_history(state)
+            if (
+                input_media_text
+                and isinstance(state.input, list)
+                and not any(
+                    isinstance(message, ChatMessageUser) and message.text
+                    for message in state.input
+                )
+            ):
+                question = f"{input_media_text}{question}"
         elif callable(include_history):
             question = include_history(state)
         else:
-            question = state.input_text
+            try:
+                question = state.input_text
+            except ValueError:
+                if (
+                    not input_media
+                    or not isinstance(state.input, list)
+                    or not any(
+                        isinstance(message, ChatMessageUser) for message in state.input
+                    )
+                ):
+                    raise
+                question = ""
+        if not question and input_media_text and not callable(include_history):
+            question = input_media_text
 
         # format the scoring template
         scoring_prompt = model_scoring_prompt(
@@ -306,10 +341,13 @@ def _model_graded_qa_single(
             criterion=target.text,
             instructions=instructions,
             metadata=metadata,
+            input_media=input_media,
         )
 
         # query the model for the score
         result = await model.generate([scoring_prompt])
+        metadata_prompt = _model_grading_metadata_message(scoring_prompt)
+        metadata_response = _model_grading_metadata_message(result.message)
 
         # extract the grade
         match = re.search(resolved_grade_pattern, result.completion)
@@ -340,8 +378,8 @@ def _model_graded_qa_single(
                 explanation=result.completion,
                 metadata=dict(
                     grading=[
-                        scoring_prompt,
-                        result.message,
+                        metadata_prompt,
+                        metadata_response,
                     ]
                 ),
             )
@@ -353,8 +391,8 @@ def _model_graded_qa_single(
                 + f"{result.completion}",
                 metadata=dict(
                     grading=[
-                        scoring_prompt,
-                        result.message,
+                        metadata_prompt,
+                        metadata_response,
                     ],
                 ),
             )
@@ -544,6 +582,7 @@ def model_scoring_prompt(
     criterion: str,
     instructions: str,
     metadata: dict[str, Any],
+    input_media: Sequence[_ModelGraderMedia] = (),
 ) -> ChatMessageUser:
     # Neutralize structural delimiters in all dataset-controlled inputs so a model
     # cannot inject fake [END DATA] / [BEGIN DATA] markers into the judge prompt.
@@ -555,8 +594,15 @@ def model_scoring_prompt(
         k: _sanitize_metadata_value(v) for k, v in metadata.items()
     }
 
+    if len(input_media) > 0:
+        question = (
+            f"{question} (see [Task media])"
+            if len(question) > 0
+            else "See [Task media]"
+        )
+
     # we need to remove media objects from output and reference them as attachements in the answer
-    media: list[Content] = (
+    output_media: list[Content] = (
         [
             content
             for content in output.message.content
@@ -565,11 +611,11 @@ def model_scoring_prompt(
         if len(output.choices) > 0 and isinstance(output.message.content, list)
         else []
     )
-    if len(media) > 0:
+    if len(output_media) > 0:
         if len(answer) > 0:
-            answer = f"{answer} (see also attached media)"
+            answer = f"{answer} (see [Submission media])"
         else:
-            answer = "See attached media"
+            answer = "See [Submission media]"
 
     # format the prompt
     prompt = template.format(
@@ -581,7 +627,36 @@ def model_scoring_prompt(
     )
 
     # return with media if necessary
-    if len(media) > 0:
-        return ChatMessageUser(content=[ContentText(text=prompt)] + media)
+    if len(input_media) > 0 or len(output_media) > 0:
+        content: list[Content] = [ContentText(text=prompt)]
+        if len(input_media) > 0:
+            content.extend([ContentText(text="[Task media]"), *input_media])
+        if len(output_media) > 0:
+            content.extend([ContentText(text="[Submission media]"), *output_media])
+        return ChatMessageUser(content=content)
     else:
         return ChatMessageUser(content=prompt)
+
+
+def _model_grading_metadata_message(message: ChatMessage) -> ChatMessage:
+    if isinstance(message.content, list) and any(
+        isinstance(content, _ModelGraderMedia) for content in message.content
+    ):
+        return message.model_copy(update={"content": message.text})
+    return message
+
+
+def _model_grader_input_media(
+    sample_input: str | list[ChatMessage],
+) -> list[_ModelGraderMedia]:
+    if isinstance(sample_input, str):
+        return []
+    return [
+        content
+        for message in sample_input
+        if isinstance(message.content, list)
+        for content in message.content
+        if isinstance(
+            content, ContentImage | ContentAudio | ContentVideo | ContentDocument
+        )
+    ]

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -2,15 +2,24 @@ import asyncio
 import math
 import os
 import re
-from typing import Any, Callable
+from pathlib import Path
+from typing import Any, Callable, Literal
 
 import pytest
 
-from inspect_ai import Task, eval, score
+from inspect_ai import Task, eval, eval_async, score
 from inspect_ai._eval.score import resolve_scorers
-from inspect_ai._util.content import ContentImage, ContentText
+from inspect_ai._util.content import (
+    Content,
+    ContentAudio,
+    ContentDocument,
+    ContentImage,
+    ContentText,
+    ContentVideo,
+)
 from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.json import json_dataset
+from inspect_ai.log import read_eval_log
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.model import (
     ChatMessageAssistant,
@@ -32,6 +41,8 @@ from inspect_ai.scorer import (
 )
 from inspect_ai.scorer._model import (
     DEFAULT_GRADE_PATTERN,
+    _model_grader_input_media,
+    model_scoring_prompt,
     neutralize_structural_delimiters,
 )
 from inspect_ai.solver._task_state import TaskState
@@ -89,7 +100,15 @@ def test_chat_history_without_assistant_turn():
     assert "The 39 Steps" in history
 
 
-def test_model_graded_multimodal():
+@pytest.mark.parametrize(
+    ["scorer_factory", "scorer_name"],
+    [
+        pytest.param(model_graded_fact, "model_graded_fact", id="fact"),
+        pytest.param(model_graded_qa, "model_graded_qa", id="qa"),
+    ],
+)
+@pytest.mark.anyio
+async def test_model_graded_multimodal(scorer_factory, scorer_name):
     # grab the ballons image from the images tests dataset
     dataset = json_dataset(
         os.path.join("tests", "util", "test_images", "images.jsonl")
@@ -101,33 +120,294 @@ def test_model_graded_multimodal():
     assert isinstance(user_message.content, list)
     target_image = user_message.content[1]
     assert isinstance(target_image, ContentImage)
+    output_image = target_image.model_copy(update={"detail": "low"})
     assistant_output = ModelOutput.from_content(
         "mockllm/model",
         content=[
             ContentText(text="I believe there are 3 ballons in the picture."),
-            target_image,
+            output_image,
         ],
     )
-    model = get_model("mockllm/model", custom_outputs=[assistant_output])
+    subject_model = get_model("mockllm/model", custom_outputs=[assistant_output])
+    grader_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "GRADE: C")],
+    )
 
     # run the task
     task = Task(
         dataset=dataset,
-        scorer=model_graded_fact(model="mockllm/model"),
+        scorer=scorer_factory(model=grader_model),
     )
-    log = eval(task, model=model)[0]
+    log = (await eval_async(task, model=subject_model))[0]
 
     # confirm that the image was presented to the model for scoring
     sample = resolve_sample_attachments(log.samples[0], "full")
+    grading_prompt = log.samples[0].scores[scorer_name].metadata["grading"][0]
     model_event = next(
-        (event for event in reversed(sample.events) if event.event == "model")
+        event
+        for event in reversed(sample.events)
+        if event.event == "model"
+        and event.input
+        and event.input[0].id == grading_prompt["id"]
     )
     content = model_event.input[0].content
     assert isinstance(content, list)
-    assert len(content) > 1
+    assert len(content) == 5
     assert isinstance(content[0], ContentText)
-    assert "attached" in content[0].text
-    assert isinstance(content[1], ContentImage)
+    assert "[Task media]" in content[0].text
+    assert "[Submission media]" in content[0].text
+    assert content[1] == ContentText(text="[Task media]")
+    assert isinstance(content[2], ContentImage)
+    assert content[2].detail == "auto"
+    assert content[3] == ContentText(text="[Submission media]")
+    assert isinstance(content[4], ContentImage)
+    assert content[4].detail == "low"
+
+
+@pytest.mark.parametrize("include_history", [False, True], ids=["input", "history"])
+@pytest.mark.anyio
+async def test_model_graded_image_only_input(include_history):
+    dataset = json_dataset(
+        os.path.join("tests", "util", "test_images", "images.jsonl")
+    )[0:1]
+    assert isinstance(dataset[0].input, list)
+    user_message = dataset[0].input[0]
+    assert isinstance(user_message.content, list)
+    image = user_message.content[1]
+    assert isinstance(image, ContentImage)
+    dataset[0].input = [ChatMessageUser(content=[image])]
+
+    grader_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "GRADE: C")],
+    )
+    subject_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "Three balloons")],
+    )
+    log = (
+        await eval_async(
+            Task(
+                dataset=dataset,
+                scorer=model_graded_qa(
+                    model=grader_model, include_history=include_history
+                ),
+            ),
+            model=subject_model,
+        )
+    )[0]
+
+    assert log.samples
+    grading_prompt = log.samples[0].scores["model_graded_qa"].metadata["grading"][0]
+    sample = resolve_sample_attachments(log.samples[0], "full")
+    model_event = next(
+        event
+        for event in reversed(sample.events)
+        if event.event == "model"
+        and event.input
+        and event.input[0].id == grading_prompt["id"]
+    )
+    content = model_event.input[0].content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentText)
+    assert "[Task]: [image]" in content[0].text
+    assert content[1] == ContentText(text="[Task media]")
+    assert len([item for item in content if isinstance(item, ContentImage)]) == 1
+
+
+@pytest.mark.parametrize(
+    "include_history",
+    [
+        pytest.param(True, id="history"),
+        pytest.param(lambda state: f"Custom: {state.messages[0].text}", id="callable"),
+    ],
+)
+@pytest.mark.anyio
+async def test_model_graded_input_media_attached_once_with_history(include_history):
+    dataset = json_dataset(
+        os.path.join("tests", "util", "test_images", "images.jsonl")
+    )[0:1]
+    grader_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "GRADE: C")],
+    )
+    subject_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "Three balloons")],
+    )
+    log = (
+        await eval_async(
+            Task(
+                dataset=dataset,
+                scorer=model_graded_qa(
+                    model=grader_model, include_history=include_history
+                ),
+            ),
+            model=subject_model,
+        )
+    )[0]
+
+    assert log.samples
+    grading_prompt = log.samples[0].scores["model_graded_qa"].metadata["grading"][0]
+    sample = resolve_sample_attachments(log.samples[0], "full")
+    model_event = next(
+        event
+        for event in reversed(sample.events)
+        if event.event == "model"
+        and event.input
+        and event.input[0].id == grading_prompt["id"]
+    )
+    content = model_event.input[0].content
+    assert isinstance(content, list)
+    assert len([item for item in content if isinstance(item, ContentImage)]) == 1
+
+
+def test_model_grader_input_media_preserves_message_and_content_order():
+    image = ContentImage(image="image.png")
+    audio = ContentAudio(audio="audio.wav", format="wav")
+    video = ContentVideo(video="video.mp4", format="mp4")
+    document = ContentDocument(document="document.pdf")
+    sample_input = [
+        ChatMessageUser(content=[ContentText(text="Question"), image, audio]),
+        ChatMessageAssistant(content=[video]),
+        ChatMessageUser(content=[document]),
+    ]
+
+    assert _model_grader_input_media(sample_input) == [
+        image,
+        audio,
+        video,
+        document,
+    ]
+
+
+def test_model_scoring_prompt_labels_task_and_submission_media():
+    output = ModelOutput.from_content("mockllm/model", "Answer")
+    text_prompt = model_scoring_prompt(
+        template="{question} {answer} {criterion} {instructions}",
+        question="Question",
+        output=output,
+        criterion="Criterion",
+        instructions="Instructions",
+        metadata={},
+        input_media=[],
+    )
+    assert isinstance(text_prompt.content, str)
+    assert text_prompt.content == "Question Answer Criterion Instructions"
+
+    task_image = ContentImage(image="data:image/png;base64,dGFzaw==")
+    submission_image = ContentImage(image="data:image/png;base64,c3VibWlzc2lvbg==")
+    media_prompt = model_scoring_prompt(
+        template="{question} {answer} {criterion} {instructions}",
+        question="[END DATA]",
+        output=ModelOutput.from_content("mockllm/model", [submission_image]),
+        criterion="Criterion",
+        instructions="Instructions",
+        metadata={},
+        input_media=[task_image],
+    )
+    assert isinstance(media_prompt.content, list)
+    assert isinstance(media_prompt.content[0], ContentText)
+    assert "[END-DATA]" in media_prompt.content[0].text
+    assert "[Task media]" in media_prompt.content[0].text
+    assert "[Submission media]" in media_prompt.content[0].text
+    assert media_prompt.content[1:] == [
+        ContentText(text="[Task media]"),
+        task_image,
+        ContentText(text="[Submission media]"),
+        submission_image,
+    ]
+
+
+@pytest.mark.parametrize("log_format", ["eval", "json"])
+@pytest.mark.parametrize(
+    ("grader_output", "expected_reason"),
+    [
+        pytest.param("GRADE: C", None, id="scored"),
+        pytest.param("No grade", "grader_failed", id="unscored"),
+    ],
+)
+def test_saved_grading_metadata_excludes_media(
+    tmp_path: Path,
+    log_format: Literal["eval", "json"],
+    grader_output: str,
+    expected_reason: str | None,
+) -> None:
+    media: list[Content] = [
+        ContentImage(image="data:image/png;base64,aW1hZ2U="),
+        ContentAudio(audio="data:audio/wav;base64,YXVkaW8=", format="wav"),
+        ContentVideo(video="data:video/mp4;base64,dmlkZW8=", format="mp4"),
+        ContentDocument(
+            document="data:application/pdf;base64,ZG9jdW1lbnQ=",
+            filename="reference.pdf",
+        ),
+    ]
+    subject_model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "Answer")],
+    )
+    grader_model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.from_content(
+                "mockllm/model", [ContentText(text=grader_output), *media]
+            )
+        ],
+    )
+    log = eval(
+        Task(
+            dataset=[
+                Sample(
+                    input=[
+                        ChatMessageUser(content=[ContentText(text="Question"), *media])
+                    ],
+                    target="Answer",
+                )
+            ],
+            scorer=model_graded_fact(model=grader_model),
+        ),
+        model=subject_model,
+        display="none",
+        log_dir=str(tmp_path),
+        log_format=log_format,
+        log_images=False,
+    )[0]
+
+    saved_log = read_eval_log(log.location)
+    assert saved_log.samples
+    sample = saved_log.samples[0]
+    assert sample.scores
+    score = sample.scores["model_graded_fact"]
+    assert score.reason == expected_reason
+    assert score.metadata
+    grading_prompt = score.metadata["grading"][0]
+    assert isinstance(grading_prompt, dict)
+    assert grading_prompt["id"]
+    assert isinstance(grading_prompt["content"], str)
+    assert "Question" in grading_prompt["content"]
+    assert "attachment://" not in grading_prompt["content"]
+    grading_response = score.metadata["grading"][1]
+    assert isinstance(grading_response, dict)
+    assert grading_response["id"]
+    assert isinstance(grading_response["content"], str)
+    assert grader_output in grading_response["content"]
+    assert "base64" not in score.model_dump_json()
+
+    grading_event = next(
+        event
+        for event in sample.events
+        if event.event == "model"
+        and event.input
+        and event.input[0].id == grading_prompt["id"]
+    )
+    event_content = grading_event.input[0].content
+    assert isinstance(event_content, list)
+    assert [
+        type(item)
+        for item in event_content
+        if isinstance(item, (ContentImage, ContentAudio, ContentVideo, ContentDocument))
+    ] == [ContentImage, ContentAudio, ContentVideo, ContentDocument]
 
 
 @pytest.mark.parametrize(

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -1,7 +1,9 @@
 import asyncio
+import base64
 import math
 import os
 import re
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, Literal
 
@@ -19,11 +21,13 @@ from inspect_ai._util.content import (
 )
 from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.json import json_dataset
-from inspect_ai.log import read_eval_log
+from inspect_ai.log import read_eval_log_async
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.model import (
+    ChatMessage,
     ChatMessageAssistant,
     ChatMessageUser,
+    GenerateConfig,
     Model,
     ModelName,
     ModelRole,
@@ -46,6 +50,7 @@ from inspect_ai.scorer._model import (
     neutralize_structural_delimiters,
 )
 from inspect_ai.solver._task_state import TaskState
+from inspect_ai.tool import ToolChoice, ToolInfo
 
 
 def include_history_task(include_history: bool | Callable[[TaskState], str]) -> Task:
@@ -216,6 +221,7 @@ async def test_model_graded_image_only_input(include_history):
     assert len([item for item in content if isinstance(item, ContentImage)]) == 1
 
 
+@pytest.mark.parametrize("scorer_factory", [model_graded_fact, model_graded_qa])
 @pytest.mark.parametrize(
     "include_history",
     [
@@ -224,43 +230,48 @@ async def test_model_graded_image_only_input(include_history):
     ],
 )
 @pytest.mark.anyio
-async def test_model_graded_input_media_attached_once_with_history(include_history):
-    dataset = json_dataset(
-        os.path.join("tests", "util", "test_images", "images.jsonl")
-    )[0:1]
-    grader_model = get_model(
-        "mockllm/model",
-        custom_outputs=[ModelOutput.from_content("mockllm/model", "GRADE: C")],
+async def test_model_graded_input_media_attached_once_with_history(
+    scorer_factory: Callable[..., Scorer],
+    include_history: bool | Callable[[TaskState], str],
+) -> None:
+    image = ContentImage(image="data:image/png;base64,dGFzaw==")
+    sample_input: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="Question"), image])
+    ]
+    state = TaskState(
+        model=ModelName("mockllm/subject"),
+        sample_id=1,
+        epoch=1,
+        input=sample_input,
+        messages=[*sample_input, ChatMessageAssistant(content="Answer")],
     )
-    subject_model = get_model(
-        "mockllm/model",
-        custom_outputs=[ModelOutput.from_content("mockllm/model", "Three balloons")],
-    )
-    log = (
-        await eval_async(
-            Task(
-                dataset=dataset,
-                scorer=model_graded_qa(
-                    model=grader_model, include_history=include_history
-                ),
-            ),
-            model=subject_model,
-        )
-    )[0]
+    state.output = ModelOutput.from_content("mockllm/subject", "Answer")
+    original_input = deepcopy(state.input)
+    requests: list[list[ChatMessage]] = []
 
-    assert log.samples
-    grading_prompt = log.samples[0].scores["model_graded_qa"].metadata["grading"][0]
-    sample = resolve_sample_attachments(log.samples[0], "full")
-    model_event = next(
-        event
-        for event in reversed(sample.events)
-        if event.event == "model"
-        and event.input
-        and event.input[0].id == grading_prompt["id"]
-    )
-    content = model_event.input[0].content
+    def capture(
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        requests.append(deepcopy(messages))
+        return ModelOutput.from_content("mockllm/grader", "GRADE: C")
+
+    result = await scorer_factory(
+        model=get_model("mockllm/grader", custom_outputs=capture),
+        include_history=include_history,
+    )(state, Target("Answer"))
+
+    assert result is not None and result.value == CORRECT
+    assert state.input == original_input
+    assert len(requests) == 1
+    content = requests[0][0].content
     assert isinstance(content, list)
-    assert len([item for item in content if isinstance(item, ContentImage)]) == 1
+    assert isinstance(content[0], ContentText)
+    if callable(include_history):
+        assert "Custom: Question (see [Task media])" in content[0].text
+    assert content[1:] == [ContentText(text="[Task media]"), image]
 
 
 def test_model_grader_input_media_preserves_message_and_content_order():
@@ -320,6 +331,7 @@ def test_model_scoring_prompt_labels_task_and_submission_media():
     ]
 
 
+@pytest.mark.parametrize("scorer_factory", [model_graded_fact, model_graded_qa])
 @pytest.mark.parametrize("log_format", ["eval", "json"])
 @pytest.mark.parametrize(
     ("grader_output", "expected_reason"),
@@ -328,86 +340,152 @@ def test_model_scoring_prompt_labels_task_and_submission_media():
         pytest.param("No grade", "grader_failed", id="unscored"),
     ],
 )
-def test_saved_grading_metadata_excludes_media(
+async def test_saved_grading_metadata_excludes_media(
     tmp_path: Path,
+    scorer_factory: Callable[..., Scorer],
     log_format: Literal["eval", "json"],
     grader_output: str,
     expected_reason: str | None,
 ) -> None:
-    media: list[Content] = [
-        ContentImage(image="data:image/png;base64,aW1hZ2U="),
-        ContentAudio(audio="data:audio/wav;base64,YXVkaW8=", format="wav"),
-        ContentVideo(video="data:video/mp4;base64,dmlkZW8=", format="mp4"),
-        ContentDocument(
-            document="data:application/pdf;base64,ZG9jdW1lbnQ=",
-            filename="reference.pdf",
-        ),
+    # Inert transport fixtures distinguish task, submission, and grader media.
+    # Only the mock provider receives them; no decoding or fetching is tested.
+    def media(label: str) -> list[Content]:
+        payload = base64.b64encode(label.encode()).decode()
+        return [
+            ContentImage(image=f"data:image/png;base64,{payload}"),
+            ContentAudio(audio=f"data:audio/wav;base64,{payload}", format="wav"),
+            ContentVideo(video=f"data:video/mp4;base64,{payload}", format="mp4"),
+            ContentDocument(
+                document=f"data:application/pdf;base64,{payload}",
+                filename=f"{label}.pdf",
+            ),
+        ]
+
+    task_media = media("task")
+    response_media = media("grader")
+    submission_image = ContentImage(image="data:image/png;base64,c3VibWlzc2lvbg==")
+    sample_input: list[ChatMessage] = [
+        ChatMessageUser(content=[ContentText(text="Question"), *task_media])
     ]
     subject_model = get_model(
-        "mockllm/model",
-        custom_outputs=[ModelOutput.from_content("mockllm/model", "Answer")],
-    )
-    grader_model = get_model(
-        "mockllm/model",
+        "mockllm/subject",
         custom_outputs=[
-            ModelOutput.from_content(
-                "mockllm/model", [ContentText(text=grader_output), *media]
-            )
+            ModelOutput.from_content("mockllm/subject", [submission_image])
         ],
     )
-    log = eval(
-        Task(
-            dataset=[
-                Sample(
-                    input=[
-                        ChatMessageUser(content=[ContentText(text="Question"), *media])
-                    ],
-                    target="Answer",
-                )
-            ],
-            scorer=model_graded_fact(model=grader_model),
-        ),
-        model=subject_model,
-        display="none",
-        log_dir=str(tmp_path),
-        log_format=log_format,
-        log_images=False,
+    grader_response = ModelOutput.from_content(
+        "mockllm/grader",
+        [
+            ContentText(text="Grader explanation"),
+            *response_media,
+            ContentText(text=grader_output),
+        ],
+    )
+    requests: list[list[ChatMessage]] = []
+
+    def capture(
+        messages: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        requests.append(deepcopy(messages))
+        return grader_response
+
+    grader_model = get_model("mockllm/grader", custom_outputs=capture)
+    log = (
+        await eval_async(
+            Task(
+                dataset=[Sample(input=sample_input, target="Answer")],
+                scorer=scorer_factory(model=grader_model),
+            ),
+            model=subject_model,
+            log_dir=str(tmp_path),
+            log_format=log_format,
+            log_images=False,
+        )
     )[0]
 
-    saved_log = read_eval_log(log.location)
-    assert saved_log.samples
-    sample = saved_log.samples[0]
-    assert sample.scores
-    score = sample.scores["model_graded_fact"]
-    assert score.reason == expected_reason
-    assert score.metadata
-    grading_prompt = score.metadata["grading"][0]
-    assert isinstance(grading_prompt, dict)
-    assert grading_prompt["id"]
-    assert isinstance(grading_prompt["content"], str)
-    assert "Question" in grading_prompt["content"]
-    assert "attachment://" not in grading_prompt["content"]
-    grading_response = score.metadata["grading"][1]
-    assert isinstance(grading_response, dict)
-    assert grading_response["id"]
-    assert isinstance(grading_response["content"], str)
-    assert grader_output in grading_response["content"]
-    assert "base64" not in score.model_dump_json()
+    assert log.status == "success"
+    assert len(requests) == 1
+    assert len(requests[0]) == 1
+    request = requests[0][0]
+    assert isinstance(request.content, list)
+    assert isinstance(request.content[0], ContentText)
+    assert "Question (see [Task media])" in request.content[0].text
+    assert "[Submission]: See [Submission media]" in request.content[0].text
+    assert request.content[1:] == [
+        ContentText(text="[Task media]"),
+        *task_media,
+        ContentText(text="[Submission media]"),
+        submission_image,
+    ]
 
-    grading_event = next(
-        event
-        for event in sample.events
-        if event.event == "model"
-        and event.input
-        and event.input[0].id == grading_prompt["id"]
-    )
-    event_content = grading_event.input[0].content
-    assert isinstance(event_content, list)
-    assert [
-        type(item)
-        for item in event_content
-        if isinstance(item, (ContentImage, ContentAudio, ContentVideo, ContentDocument))
-    ] == [ContentImage, ContentAudio, ContentVideo, ContentDocument]
+    default_log = await read_eval_log_async(log.location)
+    resolved_log = await read_eval_log_async(log.location, resolve_attachments=True)
+    saved_metadata = []
+    for saved_log in (default_log, resolved_log):
+        assert saved_log.samples
+        sample = saved_log.samples[0]
+        assert sample.scores
+        score = sample.scores[scorer_factory.__name__]
+        assert score.reason == expected_reason
+        if expected_reason is None:
+            assert score.value == CORRECT
+        else:
+            assert isinstance(score.value, float) and math.isnan(score.value)
+        assert score.metadata
+        saved_metadata.append(score.metadata)
+        grading_prompt, grading_response = score.metadata["grading"]
+        assert isinstance(grading_prompt, dict)
+        assert isinstance(grading_response, dict)
+        assert grading_prompt["id"] == request.id
+        assert grading_prompt["id"]
+        assert grading_response["id"]
+        assert grading_response["id"] != grading_prompt["id"]
+        assert grading_prompt["content"] == request.text
+        assert grading_response["content"] == f"Grader explanation\n{grader_output}"
+        assert "base64" not in score.model_dump_json()
+        assert "attachment://" not in score.model_dump_json()
+
+        grading_events = [
+            event
+            for event in sample.events
+            if event.event == "model"
+            and event.input
+            and event.input[0].id == request.id
+        ]
+        assert len(grading_events) == 1
+        grading_event = grading_events[0]
+        assert grading_event.output.message.id == grading_response["id"]
+        if saved_log is resolved_log:
+            assert grading_event.input[0].text == grading_prompt["content"]
+            assert grading_event.output.message.text == grading_response["content"]
+        assert [item.type for item in grading_event.input[0].content_list] == [
+            "text",
+            "text",
+            "image",
+            "audio",
+            "video",
+            "document",
+            "text",
+            "image",
+        ]
+        assert [item.type for item in grading_event.output.message.content_list] == [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "document",
+            "text",
+        ]
+
+    assert saved_metadata[0] == saved_metadata[1]
+    assert grader_response.message.content == [
+        ContentText(text="Grader explanation"),
+        *response_media,
+        ContentText(text=grader_output),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`model_graded_qa()` and `model_graded_fact()` flatten the original sample input to text. A grader answering a question about a reference image therefore receives the question but not the image; original audio, video, and documents are lost in the same way.

Fixes #5177.

### What is the new behavior?

Both scorers pass original input media to the grader in message/content order. Explicit `[Task media]` and `[Submission media]` groups distinguish the reference from the model's answer, including an image-only answer. Text-only requests retain their existing shape; image-only questions and full/callable history remain supported.

Media remains in the actual grader request. Grading metadata instead stores media-free copies of the request and response, preserving their text and message IDs, for both scored and unscored results. This prevents raw media from being duplicated into saved `.eval` and JSON score metadata when `log_images=False`.

Repository regressions independently capture mock-provider requests and read the saved logs through both default and attachment-resolving readers. They cover both public scorers, distinct task/submission/grader payloads, image/audio/video/document content, exact request/response text and event-ID linkage, and immutability of the actual scorer input. Async cases use the shared repository fixture and run in separate asyncio and Trio processes. Thanks to @AdemVessell for the supplementary validation and reader-coverage suggestions.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No public scorer signature changes. Multimodal grading metadata becomes text-only; the corresponding model events retain their message IDs and follow the normal media logging policy.

### Other information:

Validation on refreshed head `b848358d` (rebased onto `1f6f8ff8`, 2026-09-11). Both PR commits are patch-identical before/after the rebase (`git range-diff`):

- `make check` with the project virtualenv active: passed.
- `.venv/bin/pytest tests/scorer/test_model_graded.py -q -o addopts=''`: 104 passed, 16 skipped.
- `.venv/bin/pytest tests/scorer/test_model_graded.py --runtrio -q -o addopts=''`: 16 passed, 104 skipped; 12 warnings from the unchanged control-server `Server.serve` path.
- `PYTEST_ADDOPTS='-q -r fE' make test` with the project virtualenv active: 11,920 passed, 5,209 skipped, 35 warnings; no failures.
- Previously validated before this patch-identical rebase (not rerun for the refresh): eight local, process-isolated negative controls were rejected: request-media leakage, response-media leakage, regenerated IDs, lost response text, in-place message sanitization, missing request media, reversed groups, and mutation of the actual scorer input. These controls were applied in memory, without changing the production source.

These are mock-provider transport and serialization tests, not media-decoding, live-provider, or model-comprehension validation. Live-provider and Docker/slow tests were not run; the changed code is scorer request construction and metadata handling.

Implemented with Codex assistance.

### Agent review

- Rebase review: a fresh-context Codex reviewer, using the inherited parent model configuration, reviewed the complete 3-file diff and the three new upstream commits. No actionable findings; both commits remain patch-identical and the submodule gitlink is unchanged. This was static review; the parent independently ran the checks and suites above.

- GPT-6 via Codex: one fresh-context review of the complete PR plus the strengthened tests, followed by verification in the same reviewer context. Found one test gap: eval copies the input, so checking the original sample could miss scorer-side mutation. Fixed by checking the actual `TaskState.input` around direct scorer calls; a negative control verifies that this catches mutations. No remaining actionable findings after follow-up.
- Earlier GPT-5.6 Luna Max review: one fresh-context pass plus a follow-up. Fixed grader-response media leakage and the missing multimodal-response regression. Dismissed expanding model-output document support because that preexisting limitation is outside this input-media fix.
