### PR TITLE
fix(dataset): clamp limit to dataset size in hf_dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Dataset: Clamp limit to dataset length in hf_dataset so limits exceeding dataset size do not raise IndexError. (#5200)
 - Scorer (breaking): Model-graded scorers with a panel of graders now require a strict majority: samples with no majority grade (even-split ties, three-way splits, or ties after a grader returns no parseable grade) come back unscored and leave the metric denominator, rather than the most common grade winning with ties broken by grader order. Pass `reducer="mode"` to `model_graded_qa()`/`model_graded_fact()` to restore the previous behavior. (#4721)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)

--- a/src/inspect_ai/dataset/_sources/hf.py
+++ b/src/inspect_ai/dataset/_sources/hf.py
@@ -264,7 +264,7 @@ def hf_dataset(
         if shuffle:
             dataset = dataset.shuffle(seed=seed)
         if limit is not None:
-            dataset = dataset.select(range(limit))
+            dataset = dataset.select(range(min(limit, len(dataset))))
         records = dataset.to_list()
         if recover_ids:
             # pop the tag so it can't leak into sample metadata

--- a/tests/dataset/test_hf_dataset.py
+++ b/tests/dataset/test_hf_dataset.py
@@ -285,7 +285,9 @@ def _install_fake_datasets_full(monkeypatch, tmp_path, load_dataset, load_from_d
     )
 
 
-@pytest.mark.parametrize("limit,expected", [(None, 2), (0, 0), (1, 1)])
+@pytest.mark.parametrize(
+    "limit,expected", [(None, 2), (0, 0), (1, 1), (5, 2), (100, 2)]
+)
 def test_hf_dataset_limit(limit, expected, tmp_path, monkeypatch) -> None:
     records = [{"input": "a", "target": "1"}, {"input": "b", "target": "2"}]
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5200

In `src/inspect_ai/dataset/_sources/hf.py`, `hf_dataset` uses `dataset.select(range(limit))` when `limit` is provided. When `limit` exceeds the total number of records in the dataset, `dataset.select(range(limit))` crashes with an `IndexError`.

### What is the new behavior?

`hf_dataset` now clamps the select range to `range(min(limit, len(dataset)))`, matching the behavior of `csv_dataset`, `json_dataset`, and the custom multi-sample mapping branch of `hf_dataset` by returning all available samples when `limit >= len(dataset)`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified limit exceeding dataset size returns full dataset without error; all tests pass)