### PR TITLE
fix(scorer): exclude unscored NaN values from frequency metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Scorer: Exclude unscored Score.unscored() (NaN) samples from frequency() categorical metric. (#5202)
 - Scorer (breaking): Model-graded scorers with a panel of graders now require a strict majority: samples with no majority grade (even-split ties, three-way splits, or ties after a grader returns no parseable grade) come back unscored and leave the metric denominator, rather than the most common grade winning with ties broken by grader order. Pass `reducer="mode"` to `model_graded_qa()`/`model_graded_fact()` to restore the previous behavior. (#4721)
 - Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - Bugfix: Bump the `fsspec` upper bound from `<=2025.9.0` to `<=2026.6.0` to align with the current `huggingface/datasets` cap. (#4761)

--- a/src/inspect_ai/scorer/_metrics/categorical.py
+++ b/src/inspect_ai/scorer/_metrics/categorical.py
@@ -1,3 +1,4 @@
+import math
 from collections import Counter
 from typing import Mapping, Sequence
 
@@ -39,7 +40,8 @@ def _frequencies(
     categories: list[str] | None,
     normalize: bool,
 ) -> dict[str, float]:
-    counts: Counter[str] = Counter(str(v) for v in values)
+    scored_values = [v for v in values if not (isinstance(v, float) and math.isnan(v))]
+    counts: Counter[str] = Counter(str(v) for v in scored_values)
     keys = list(dict.fromkeys((*(categories or ()), *counts)))
     total = sum(counts.values())
     denom = float(total) if (normalize and total > 0) else 1.0

--- a/tests/scorer/test_categorical.py
+++ b/tests/scorer/test_categorical.py
@@ -99,6 +99,37 @@ def test_frequency_rejects_string_categories() -> None:
         frequency(categories="yes")
 
 
+def test_frequency_skips_unscored_nan() -> None:
+    unscored = SampleScore(score=Score.unscored(reason="refusal"))
+    nan_score = SampleScore(score=Score(value=float("nan")))
+    scores = [ss("yes"), ss("no"), unscored, nan_score]
+
+    # observed only: unscored samples excluded, no "nan" category
+    assert call(frequency(), scores) == {"yes": 0.5, "no": 0.5}
+
+    # explicit categories: unscored samples excluded, declared categories preserved
+    assert call(frequency(categories=Verdict), scores) == {
+        "yes": 0.5,
+        "no": 0.5,
+        "unsure": 0.0,
+    }
+
+    # raw counts (normalize=False)
+    assert call(frequency(categories=Verdict, normalize=False), scores) == {
+        "yes": 1.0,
+        "no": 1.0,
+        "unsure": 0.0,
+    }
+
+    # all unscored
+    assert call(frequency(), [unscored, nan_score]) == {}
+    assert call(frequency(categories=Verdict), [unscored, nan_score]) == {
+        "yes": 0.0,
+        "no": 0.0,
+        "unsure": 0.0,
+    }
+
+
 def test_categorical_resolves_enum_to_list() -> None:
     from inspect_ai._util.registry import registry_params
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5202

In `src/inspect_ai/scorer/_metrics/categorical.py`, `_frequencies` constructed category counts using `Counter(str(v) for v in values)`. When a sample had `Score.unscored()` (setting `value=float("nan")`), `str(v)` stringified the float NaN into `"nan"`. This caused `"nan"` to be reported as an observed category, and counted unscored samples into `denom`, corrupting normalized category proportions.

### What is the new behavior?

`_frequencies` now filters out NaN values (the unscored sentinel) before computing counts, consistent with all other Inspect metrics (`accuracy`, `mean`, `std`, `stderr`, `aggregate`), ensuring unscored samples are excluded from frequency distributions and proportions.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified frequency metric excludes NaN unscored samples across default, explicit categories, and unnormalized modes; all tests pass)