### PR TITLE
Return host-model logprobs to Responses clients in the agent bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Agent bridge: A Responses client that requests `message.output_text.logprobs` now receives the model's token and top-token logprobs instead of an empty list.
 - Sandboxes: Compose files using long syntax volume mounts, `pids_limit`, `read_only`, `cgroup`, `stop_grace_period`, `build.no_cache`, or `build.pull` no longer fail validation when starting an eval.
 - Sandbox Tools: Binaries downloaded from S3 that fail SHA256 verification or lack a pinned digest are now rejected instead of run with a warning; `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` has been removed.
 - Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -60,6 +60,15 @@ from openai.types.responses.response_output_item import (
     McpListTools,
     McpListToolsTool,
 )
+from openai.types.responses.response_output_message import (
+    Content as OutputMessageContent,
+)
+from openai.types.responses.response_output_text import (
+    Logprob as LogprobResponses,
+)
+from openai.types.responses.response_output_text import (
+    LogprobTopLogprob,
+)
 from openai.types.responses.tool_param import CodeInterpreter
 from pydantic import TypeAdapter
 from shortuuid import uuid
@@ -91,7 +100,7 @@ from inspect_ai.model._internal import (
     parse_content_with_internal,
 )
 from inspect_ai.model._model import Model, ModelName
-from inspect_ai.model._model_output import StopReason
+from inspect_ai.model._model_output import Logprobs, StopReason
 from inspect_ai.model._openai_responses import (
     RESPONSES_NAMESPACE,
     RESPONSES_VERBATIM,
@@ -331,7 +340,7 @@ async def inspect_responses_api_request_impl(
         model=model_name,
         object="response",
         output=responses_output_items_from_assistant_message(
-            output.message, tool_namespaces
+            output.message, tool_namespaces, logprobs=output.choices[0].logprobs
         ),
         parallel_tool_calls=parallel_tool_calls,
         tool_choice=responses_tool_choice_param_to_tool_choice(responses_tool_choice),
@@ -1159,11 +1168,36 @@ output_item_adapter = TypeAdapter(list[ResponseOutputItem])
 mcp_tool_adapter = TypeAdapter(list[McpListToolsTool])
 
 
+def _responses_logprobs_from_logprobs(
+    logprobs: Logprobs,
+) -> list[LogprobResponses]:
+    return [
+        LogprobResponses(
+            token=lp.token,
+            logprob=lp.logprob,
+            bytes=lp.bytes or [],
+            top_logprobs=[
+                LogprobTopLogprob(
+                    token=tlp.token, logprob=tlp.logprob, bytes=tlp.bytes or []
+                )
+                for tlp in lp.top_logprobs or []
+            ],
+        )
+        for lp in logprobs.content
+    ]
+
+
 def responses_output_items_from_assistant_message(
     message: ChatMessageAssistant,
     tool_namespaces: dict[str, str] | None = None,
+    logprobs: Logprobs | None = None,
 ) -> list[ResponseOutputItem]:
     output: list[ResponseOutputItem] = []
+    # choice logprobs cover one generated token sequence: they attach to the first
+    # genuine output_text, not a reasoning think tag, a refusal, or a later block.
+    pending_logprobs = (
+        _responses_logprobs_from_logprobs(logprobs) if logprobs is not None else None
+    )
     # normalize message content to list
     message_content = (
         [ContentText(text=message.content)]
@@ -1181,21 +1215,25 @@ def responses_output_items_from_assistant_message(
             # apply internal to content
             content_text = f"{content.text}{internal}"
 
+            if content.refusal:
+                output_content: OutputMessageContent = ResponseOutputRefusal(
+                    type="refusal", refusal=content_text
+                )
+            else:
+                output_content = ResponseOutputText(
+                    type="output_text",
+                    text=content_text,
+                    annotations=[],
+                    logprobs=pending_logprobs or [],
+                )
+                pending_logprobs = None
+
             output.append(
                 ResponseOutputMessage(
                     type="message",
                     id=uuid(),
                     role="assistant",
-                    content=[
-                        ResponseOutputRefusal(type="refusal", refusal=content_text)
-                        if content.refusal
-                        else ResponseOutputText(
-                            type="output_text",
-                            text=content_text,
-                            annotations=[],
-                            logprobs=[],
-                        )
-                    ],
+                    content=[output_content],
                     status="completed",
                 )
             )

--- a/tests/agent/test_bridge_responses_logprobs.py
+++ b/tests/agent/test_bridge_responses_logprobs.py
@@ -1,0 +1,215 @@
+"""Unit tests for Responses logprob passthrough in the agent bridge.
+
+A Responses client asks for logprobs with `include:
+["message.output_text.logprobs"]`. The bridge maps that onto
+`GenerateConfig.logprobs`, so the resolved model can populate
+`ChatCompletionChoice.logprobs` — but the response builder used to rebuild every
+`ResponseOutputText` with `logprobs=[]`, so the client never saw them and
+downstream scorers silently fell back to their missing-logprobs path (#5211).
+
+The logprobs describe one generated token sequence, so they attach to the first
+genuine `output_text` block only: not to reasoning think tags, not to refusals,
+and never to a second text block.
+"""
+
+from __future__ import annotations
+
+from openai import AsyncOpenAI
+from openai.types.responses import Response, ResponseOutputItem, ResponseOutputText
+from openai.types.responses.response_output_text import (
+    Logprob as LogprobResponses,
+)
+from test_helpers.utils import skip_if_no_openai_package
+
+from inspect_ai import Task, eval
+from inspect_ai._util.content import ContentReasoning, ContentText
+from inspect_ai.agent import Agent, AgentState, agent, agent_bridge
+from inspect_ai.agent._bridge.responses_impl import (
+    responses_output_items_from_assistant_message,
+)
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ChatMessageAssistant, ModelOutput, get_model
+from inspect_ai.model._model_output import Logprob, Logprobs, TopLogprob
+from inspect_ai.scorer import includes
+
+ANSWER = "hi"
+
+
+def logprobs_fixture() -> Logprobs:
+    return Logprobs(
+        content=[
+            Logprob(
+                token="hi",
+                logprob=-0.1,
+                bytes=[104, 105],
+                top_logprobs=[
+                    TopLogprob(token="hi", logprob=-0.1, bytes=[104, 105]),
+                    TopLogprob(token="hey", logprob=-2.3, bytes=[104, 101, 121]),
+                ],
+            )
+        ]
+    )
+
+
+def output_texts(items: list[ResponseOutputItem]) -> list[ResponseOutputText]:
+    return [
+        content
+        for item in items
+        if item.type == "message"
+        for content in item.content
+        if content.type == "output_text"
+    ]
+
+
+def text_logprobs(text: ResponseOutputText) -> list[LogprobResponses]:
+    assert text.logprobs is not None
+    return text.logprobs
+
+
+def test_output_text_carries_choice_logprobs() -> None:
+    message = ChatMessageAssistant(content=ANSWER)
+
+    items = responses_output_items_from_assistant_message(
+        message, logprobs=logprobs_fixture()
+    )
+
+    texts = output_texts(items)
+    assert len(texts) == 1
+    logprobs = text_logprobs(texts[0])
+    assert len(logprobs) == 1
+    assert logprobs[0].token == "hi"
+    assert logprobs[0].logprob == -0.1
+    assert logprobs[0].bytes == [104, 105]
+    assert [(t.token, t.logprob, t.bytes) for t in logprobs[0].top_logprobs] == [
+        ("hi", -0.1, [104, 105]),
+        ("hey", -2.3, [104, 101, 121]),
+    ]
+
+
+def test_output_text_has_no_logprobs_when_choice_has_none() -> None:
+    message = ChatMessageAssistant(content=ANSWER)
+
+    items = responses_output_items_from_assistant_message(message)
+
+    assert output_texts(items)[0].logprobs == []
+
+
+def test_empty_choice_logprobs_leave_output_text_empty() -> None:
+    message = ChatMessageAssistant(content=ANSWER)
+
+    items = responses_output_items_from_assistant_message(
+        message, logprobs=Logprobs(content=[])
+    )
+
+    assert output_texts(items)[0].logprobs == []
+
+
+def test_absent_bytes_and_top_logprobs_become_empty_lists() -> None:
+    message = ChatMessageAssistant(content=ANSWER)
+    logprobs = Logprobs(content=[Logprob(token="hi", logprob=-0.1)])
+
+    items = responses_output_items_from_assistant_message(message, logprobs=logprobs)
+
+    converted = text_logprobs(output_texts(items)[0])
+    assert converted[0].bytes == []
+    assert converted[0].top_logprobs == []
+
+
+def test_reasoning_block_does_not_carry_logprobs() -> None:
+    message = ChatMessageAssistant(
+        content=[ContentReasoning(reasoning="thinking"), ContentText(text=ANSWER)]
+    )
+
+    items = responses_output_items_from_assistant_message(
+        message, logprobs=logprobs_fixture()
+    )
+
+    texts = output_texts(items)
+    assert len(texts) == 2
+    assert texts[0].logprobs == []
+    assert texts[1].text == ANSWER
+    assert len(text_logprobs(texts[1])) == 1
+
+
+def test_logprobs_attach_to_only_the_first_text_block() -> None:
+    message = ChatMessageAssistant(
+        content=[ContentText(text=ANSWER), ContentText(text="there")]
+    )
+
+    items = responses_output_items_from_assistant_message(
+        message, logprobs=logprobs_fixture()
+    )
+
+    texts = output_texts(items)
+    assert len(texts) == 2
+    assert len(text_logprobs(texts[0])) == 1
+    assert texts[1].logprobs == []
+
+
+def test_refusal_does_not_consume_logprobs() -> None:
+    message = ChatMessageAssistant(
+        content=[
+            ContentText(text="i cannot help with that", refusal=True),
+            ContentText(text=ANSWER),
+        ]
+    )
+
+    items = responses_output_items_from_assistant_message(
+        message, logprobs=logprobs_fixture()
+    )
+
+    refusals = [
+        content
+        for item in items
+        if item.type == "message"
+        for content in item.content
+        if content.type == "refusal"
+    ]
+    assert len(refusals) == 1
+
+    texts = output_texts(items)
+    assert len(texts) == 1
+    assert texts[0].text == ANSWER
+    assert len(text_logprobs(texts[0])) == 1
+
+
+@agent
+def logprobs_agent() -> Agent:
+    """Bridge agent asserting a Responses client receives the host model's logprobs."""
+
+    async def execute(state: AgentState) -> AgentState:
+        async with agent_bridge(state, forward_generation_config=True) as bridge:
+            async with AsyncOpenAI(api_key="test") as client:
+                response = await client.responses.create(
+                    model="inspect",
+                    input="hello",
+                    include=["message.output_text.logprobs"],
+                    top_logprobs=2,
+                )
+                assert isinstance(response, Response)
+                texts = output_texts(list(response.output))
+                assert len(texts) == 1
+                logprobs = text_logprobs(texts[0])
+                assert [lp.token for lp in logprobs] == ["hi"]
+                assert logprobs[0].bytes == [104, 105]
+                assert [t.token for t in logprobs[0].top_logprobs] == ["hi", "hey"]
+            return bridge.state
+
+    return execute
+
+
+@skip_if_no_openai_package
+def test_bridge_returns_logprobs_to_responses_client() -> None:
+    model_output = ModelOutput.from_content("mockllm/model", ANSWER)
+    model_output.choices[0].logprobs = logprobs_fixture()
+
+    task = Task(
+        dataset=[Sample(input="hello", target="done")],
+        solver=logprobs_agent(),
+        scorer=includes(),
+    )
+    log = eval(task, model=get_model("mockllm/model", custom_outputs=[model_output]))[0]
+
+    assert log.status == "success", (
+        log.error.message if log.error else "eval did not succeed"
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5211.

`generate_config_from_openai_responses()` correctly maps a client's
`include: ["message.output_text.logprobs"]` and `top_logprobs` onto
`GenerateConfig.logprobs` / `GenerateConfig.top_logprobs`, so the resolved model
can return a populated `ChatCompletionChoice.logprobs`.

But `inspect_responses_api_request_impl()` passed only `output.message` to
`responses_output_items_from_assistant_message()`, and that function rebuilt every
`ResponseOutputText` with `logprobs=[]`. An in-process or sandboxed Responses client
therefore always received an empty logprob list, even when the host model returned
token and top-token logprobs. A scorer reading those logprobs silently took its
missing-logprobs fallback instead of evaluating the requested distribution.

The Chat Completions half of the bridge does not have this gap — it builds choices
through `openai_chat_choices()`, which already forwards `choice.logprobs`.

### What is the new behavior?

The Responses builder accepts the choice logprobs and maps them onto
`ResponseOutputText.logprobs`, preserving token, bytes, logprob, and each
top-logprob's token, bytes, and logprob.

They attach to the first genuine `output_text` block only. A single generated token
sequence produced them, so they are not duplicated onto a second text block, and not
attached to reasoning `<think>` tag text or to refusals. When the choice has no
logprobs (or an empty list), `output_text.logprobs` stays `[]` as before.

Inspect's `Logprob.bytes` and `Logprob.top_logprobs` are optional while the Responses
`Logprob` requires both, so an absent value maps to `[]`.

The new `logprobs` parameter is optional and last, so the existing call sites are
unaffected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `responses_output_items_from_assistant_message()` gains a trailing optional
parameter that defaults to today's behavior, and clients that never requested
logprobs see an unchanged payload.

### Other information:

New tests in `tests/agent/test_bridge_responses_logprobs.py` (no network, no API keys):

- conversion of token / bytes / logprob / nested top-logprobs
- `logprobs=None` and `Logprobs(content=[])` both leave `output_text.logprobs == []`
- absent `bytes` / `top_logprobs` become `[]`
- reasoning-then-text: only the text block carries logprobs
- two text blocks: only the first carries them
- refusal-then-text: the refusal is unchanged and does not consume the logprobs
- a bridge round-trip over `mockllm` with `forward_generation_config=True`, asserting a
  Responses client receives the host model's logprobs unchanged

Before the fix, 7 of those 8 failed — the round-trip with `assert [] == ['hi']`, the rest
because the builder had no way to receive logprobs. The eighth (the no-logprobs guard)
passed before and after.

```
pytest -q tests/agent/test_bridge_responses_logprobs.py          -> 8 passed
pytest -q tests/agent tests/model/providers/test_openai_responses.py
                                                                 -> 1611 passed, 1225 skipped
pytest -q --runtrio tests/agent/test_bridge_responses_logprobs.py
        tests/agent/test_bridge_generation_config.py
        tests/agent/test_bridge_tool_search.py
        tests/agent/test_bridge_namespace_tool.py
        tests/agent/test_bridge_raw_response.py                  -> 6 passed, 110 skipped
make check                                                       -> ruff clean, mypy clean
                                                                    (1448 files), suppressions
                                                                    ledger unchanged
make test                                                        -> 11260 passed, 4836 skipped
```
