### PR TITLE
Forward and return Anthropic probabilities through the agent bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Agent bridge: An Anthropic client using the probabilities beta now has its `probabilities` request forwarded and the model's probabilities returned, instead of both being dropped.
+
 ## 0.3.263 (03 September 2026)
 
 - OpenAI: Added support for GPT-6 Astra (`gpt-6-astra`).

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -50,6 +50,8 @@ from inspect_ai.model._model import ModelName
 from inspect_ai.model._model_output import ModelUsage, StopReason
 from inspect_ai.model._providers._anthropic_citations import to_inspect_citation
 from inspect_ai.model._providers.anthropic import (
+    EXTRA_BODY,
+    PROBABILITIES,
     ToolParamDef,
     anthropic_extra_body_fields,
     assistant_message_blocks,
@@ -149,7 +151,7 @@ async def inspect_anthropic_api_request_impl(
     debug_log("INSPECT MESSAGES", messages)
 
     # extract generate config (hoist instructions into system messages)
-    config = generate_config_from_anthropic(json_data)
+    config = generate_config_from_anthropic(json_data, ModelName(model).api)
     if not bridge.forward_generation_config:
         clear_generation_params(config)
     validate_client_config(config)
@@ -188,6 +190,9 @@ async def inspect_anthropic_api_request_impl(
 
     # return message (use beta message type if request came from beta endpoint)
     message_class = BetaMessage if beta else Message
+    # the provider parks undeclared response fields under metadata[EXTRA_BODY];
+    # hand back only the probability field, not the whole bag.
+    probabilities = (output.metadata or {}).get(EXTRA_BODY, {}).get(PROBABILITIES)
     message = message_class.model_construct(
         id=output.message.id or uuid(),
         content=await assistant_message_blocks(output.message, beta=beta),
@@ -196,6 +201,7 @@ async def inspect_anthropic_api_request_impl(
         stop_reason=anthropic_stop_reason(output.stop_reason),
         type="message",
         usage=anthropic_usage(output.usage or ModelUsage(), beta=beta),
+        **({PROBABILITIES: probabilities} if probabilities is not None else {}),
     )
     debug_log("SCAFFOLD RESPONSE", message)
 
@@ -237,7 +243,9 @@ def anthropic_system_to_texts(value: Any) -> list[str]:
     return texts
 
 
-def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
+def generate_config_from_anthropic(
+    json_data: dict[str, Any], model_api: str = "anthropic"
+) -> GenerateConfig:
     config = GenerateConfig()
     config.max_tokens = json_data.get("max_tokens", None)
     config.stop_seqs = json_data.get("stop_sequences", None) or None
@@ -316,6 +324,10 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
     for field in anthropic_extra_body_fields():
         if field in json_data:
             extra_body[field] = json_data[field]
+    # probabilities is an Anthropic-only beta field, so a model resolved to another
+    # provider must not receive it (sagemaker, for one, forwards extra_body verbatim).
+    if PROBABILITIES in json_data and model_api == "anthropic":
+        extra_body[PROBABILITIES] = json_data[PROBABILITIES]
     if len(extra_body) > 0:
         config.extra_body = extra_body
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1138,6 +1138,10 @@ class AnthropicAPI(ModelAPI):
             # pass through context_management for compaction
             if CONTEXT_MANAGEMENT in config.extra_body:
                 extra_body[CONTEXT_MANAGEMENT] = config.extra_body[CONTEXT_MANAGEMENT]
+            # probabilities is a beta field the SDK does not accept as a keyword
+            # argument, so it travels in extra_body rather than params.
+            if PROBABILITIES in config.extra_body:
+                extra_body[PROBABILITIES] = config.extra_body[PROBABILITIES]
 
         # return config
         return params, extra_body, headers, betas
@@ -4053,6 +4057,7 @@ EDIT_TYPE = "type"
 COMPACT_20260112 = "compact_20260112"
 EXTRA_BODY = "extra_body"
 CONTEXT_MANAGEMENT = "context_management"
+PROBABILITIES = "probabilities"
 MIN_COMPACTION_TOKENS = 50000  # Anthropic API minimum trigger value
 FALLBACK_BETA = "server-side-fallback-2026-06-01"
 

--- a/tests/agent/test_bridge_anthropic_probabilities.py
+++ b/tests/agent/test_bridge_anthropic_probabilities.py
@@ -1,0 +1,242 @@
+"""Unit tests for Anthropic `probabilities` passthrough in the agent bridge.
+
+An Anthropic client using the `probabilities-2024-07-31` beta sends a
+`probabilities` request field alongside the beta header. The header survived
+bridge filtering, but `generate_config_from_anthropic` copied only the fields in
+`anthropic_extra_body_fields()`, so the directive was dropped before the host
+model call; and the bridge rebuilt the reply with a fixed set of fields, so a
+returned `probabilities` never reached the client either (#5210).
+
+`probabilities` is not an Anthropic SDK keyword argument, so it travels in the
+request's `extra_body` (like `context_management`) rather than in the typed
+params. It is Anthropic-only, so it is not handed to a model from another
+provider.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from anthropic import AsyncAnthropic
+from anthropic.types import Message as AnthropicMessage
+from test_helpers.utils import skip_if_no_anthropic_package
+
+from inspect_ai import Task, eval
+from inspect_ai.agent import Agent, AgentState, agent, agent_bridge
+from inspect_ai.agent._bridge.anthropic_api_impl import generate_config_from_anthropic
+from inspect_ai.dataset import Sample
+from inspect_ai.model import (
+    ChatMessage,
+    GenerateConfig,
+    ModelOutput,
+    get_model,
+)
+from inspect_ai.model._providers.anthropic import AnthropicAPI
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+ANSWER = "A"
+PROBABILITIES_REQUEST: dict[str, Any] = {"type": "choices", "choices": ["A", "B"]}
+PROBABILITIES_RESPONSE: dict[str, Any] = {"choices": [{"A": 0.9}, {"B": 0.1}]}
+
+
+def anthropic_request(**extra: Any) -> dict[str, Any]:
+    return {"model": "inspect", "messages": [], "max_tokens": 1, **extra}
+
+
+# request extraction
+
+
+def test_probabilities_extracted_into_extra_body() -> None:
+    config = generate_config_from_anthropic(
+        anthropic_request(probabilities=PROBABILITIES_REQUEST)
+    )
+
+    assert config.extra_body is not None
+    assert config.extra_body["probabilities"] == PROBABILITIES_REQUEST
+
+
+def test_no_probabilities_leaves_extra_body_unset() -> None:
+    config = generate_config_from_anthropic(anthropic_request())
+
+    assert config.extra_body is None
+
+
+def test_probabilities_joins_existing_extra_body_fields() -> None:
+    config = generate_config_from_anthropic(
+        anthropic_request(
+            probabilities=PROBABILITIES_REQUEST,
+            metadata={"user_id": "u1"},
+            service_tier="auto",
+        )
+    )
+
+    assert config.extra_body == {
+        "metadata": {"user_id": "u1"},
+        "service_tier": "auto",
+        "probabilities": PROBABILITIES_REQUEST,
+    }
+
+
+def test_probabilities_not_extracted_for_another_provider() -> None:
+    config = generate_config_from_anthropic(
+        anthropic_request(probabilities=PROBABILITIES_REQUEST), "openai"
+    )
+
+    assert config.extra_body is None
+
+
+def test_other_extra_body_fields_survive_for_another_provider() -> None:
+    config = generate_config_from_anthropic(
+        anthropic_request(probabilities=PROBABILITIES_REQUEST, service_tier="auto"),
+        "openai",
+    )
+
+    assert config.extra_body == {"service_tier": "auto"}
+
+
+# provider forwarding: `probabilities` is not an SDK kwarg, so it must ride in
+# extra_body or client.messages.create() would reject it
+
+
+@skip_if_no_anthropic_package
+def test_provider_routes_probabilities_to_extra_body_not_params() -> None:
+    api = AnthropicAPI(model_name="claude-sonnet-4-5", api_key="test-key")
+
+    params, extra_body, _headers, _betas = api.completion_config(
+        GenerateConfig(extra_body={"probabilities": PROBABILITIES_REQUEST})
+    )
+
+    assert extra_body["probabilities"] == PROBABILITIES_REQUEST
+    assert "probabilities" not in params
+
+
+@skip_if_no_anthropic_package
+def test_provider_still_routes_declared_fields_to_params() -> None:
+    api = AnthropicAPI(model_name="claude-sonnet-4-5", api_key="test-key")
+
+    params, extra_body, _headers, _betas = api.completion_config(
+        GenerateConfig(extra_body={"service_tier": "auto"})
+    )
+
+    assert params["service_tier"] == "auto"
+    assert "service_tier" not in extra_body
+
+
+# bridge round trips
+
+
+def run_bridge_test(solver: Agent, model_output: ModelOutput) -> None:
+    task = Task(
+        dataset=[Sample(input="hello", target="done")],
+        solver=solver,
+        scorer=None,
+    )
+    log = eval(task, model=get_model("mockllm/model", custom_outputs=[model_output]))[0]
+    assert log.status == "success", (
+        log.error.message if log.error else "eval did not succeed"
+    )
+
+
+async def bridge_message(extra_body: dict[str, Any] | None = None) -> AnthropicMessage:
+    """Call the bridged Anthropic endpoint the way a probabilities client would.
+
+    `probabilities` is not an SDK keyword argument, so a real client sends it in
+    `extra_body`, which the SDK merges into the request JSON body.
+    """
+    async with AsyncAnthropic(api_key="test") as client:
+        return await client.messages.create(
+            model="inspect",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hello"}],
+            extra_body=extra_body,
+            extra_headers={"anthropic-beta": "probabilities-2024-07-31"},
+        )
+
+
+@agent
+def probabilities_response_agent() -> Agent:
+    """Asserts the provider's probabilities field reaches the Anthropic client."""
+
+    async def execute(state: AgentState) -> AgentState:
+        async with agent_bridge(state) as bridge:
+            message = await bridge_message()
+            assert message.model_extra is not None
+            assert message.model_extra["probabilities"] == PROBABILITIES_RESPONSE
+            # only the probability field is copied out of the output metadata
+            assert "trace_id" not in message.model_extra
+            return bridge.state
+
+    return execute
+
+
+@agent
+def no_probabilities_agent() -> Agent:
+    """Asserts a reply without probabilities is unchanged."""
+
+    async def execute(state: AgentState) -> AgentState:
+        async with agent_bridge(state) as bridge:
+            message = await bridge_message()
+            assert not (message.model_extra or {}).get("probabilities")
+            return bridge.state
+
+    return execute
+
+
+@skip_if_no_anthropic_package
+def test_response_returns_only_probabilities_to_client() -> None:
+    model_output = ModelOutput.from_content("mockllm/model", ANSWER)
+    model_output.metadata = {
+        "extra_body": {
+            "probabilities": PROBABILITIES_RESPONSE,
+            "trace_id": "should-not-be-copied",
+        }
+    }
+
+    run_bridge_test(probabilities_response_agent(), model_output)
+
+
+@skip_if_no_anthropic_package
+def test_response_without_probabilities_is_unchanged() -> None:
+    run_bridge_test(
+        no_probabilities_agent(),
+        ModelOutput.from_content("mockllm/model", ANSWER),
+    )
+
+
+# cross-provider gating
+
+
+@skip_if_no_anthropic_package
+def test_probabilities_not_forwarded_to_non_anthropic_model() -> None:
+    seen: list[GenerateConfig] = []
+
+    def capture(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        seen.append(config)
+        return ModelOutput.from_content("mockllm/model", ANSWER)
+
+    @agent
+    def gate_agent() -> Agent:
+        async def execute(state: AgentState) -> AgentState:
+            async with agent_bridge(state) as bridge:
+                await bridge_message({"probabilities": PROBABILITIES_REQUEST})
+                return bridge.state
+
+        return execute
+
+    task = Task(
+        dataset=[Sample(input="hello", target="done")],
+        solver=gate_agent(),
+        scorer=None,
+    )
+    log = eval(task, model=get_model("mockllm/model", custom_outputs=capture))[0]
+    assert log.status == "success", (
+        log.error.message if log.error else "eval did not succeed"
+    )
+
+    assert seen, "model was never called"
+    assert not (seen[0].extra_body or {}).get("probabilities")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5210.

An Anthropic client routed through Agent Bridge cannot use the
`probabilities-2024-07-31` beta, even when the resolved Inspect model is Anthropic.

The beta header survives bridge header filtering, but `generate_config_from_anthropic()`
copies only the fields in `anthropic_extra_body_fields()` (`metadata`, `service_tier`),
so the `probabilities` request field is dropped before the host model call:

```python
config = generate_config_from_anthropic(
    {"model": "inspect", "messages": [], "max_tokens": 1,
     "probabilities": {"type": "choices", "choices": ["A", "B"]}}
)
assert config.extra_body is None   # passes on main
```

There is a second loss on the response leg. The provider captures undeclared response
fields under `ModelOutput.metadata["extra_body"]`, but the bridge rebuilds a `Message`
from a fixed field list (id, content, model, role, stop_reason, type, usage), so a
returned `probabilities` never reaches the client.

Downstream probability scorers then see no probabilities and can silently record their
missing-data floor.

### What is the new behavior?

The client's `probabilities` directive is carried into `GenerateConfig.extra_body`, and
the provider's `probabilities` response field is handed back to the client.

Three things worth calling out:

**It travels in `extra_body`, not the typed params.** `probabilities` is not an Anthropic
SDK keyword argument — `AsyncMessages.create()` has no such parameter and no `**kwargs`,
so passing it there raises `TypeError`. It is therefore routed through the request's
`extra_body` alongside `context_management`, which is the existing path for reaching
`/v1/messages` without SDK kwarg validation. Adding it to `anthropic_extra_body_fields()`
would have put it in the typed params and broken the request.

**Deny-by-default is preserved.** Only this one field is named; no general `extra_body`
passthrough is enabled, and only the probability key is copied out of the response
metadata, not the whole bag.

**It is gated to Anthropic.** `generate_config_from_anthropic()` takes the resolved
provider and skips the field for any other one, so an Anthropic-only field is never
handed to another provider (`sagemaker`, for one, forwards `extra_body` verbatim). The
parameter defaults to `"anthropic"`, so existing callers are unaffected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `generate_config_from_anthropic()` gains a trailing optional parameter that defaults
to today's behavior, the provider only acts on an `extra_body` key that nothing set
before, and a reply without probabilities is byte-identical to today.

### Other information:

New tests in `tests/agent/test_bridge_anthropic_probabilities.py` (no network, no API keys
— `mockllm` plus the existing offline `AnthropicAPI(api_key="test-key")` pattern):

- request extraction, alone and alongside `metadata` / `service_tier`
- no `probabilities` in the request leaves `extra_body` unset
- cross-provider gating, at the extractor and through a bridge round trip
- other `extra_body` fields still survive for a non-Anthropic model
- provider routes it to `extra_body` and keeps it out of the typed params
- provider still routes declared fields (`service_tier`) to the params
- round trip: the client receives the probabilities, and `trace_id` sitting beside them
  in the metadata is not copied
- a reply with no probabilities is unchanged

Before the fix 4 of these failed (request extraction, extraction alongside existing
fields, provider routing, and the response round trip); the rest are the guards that had
to keep passing. Removing the provider gate turns 3 of them red, so the gate is covered
rather than assumed.

```
pytest -q tests/agent/test_bridge_anthropic_probabilities.py     -> 10 passed
pytest -q tests/agent/test_bridge_anthropic_probabilities.py \
         tests/agent/test_bridge_generation_config.py \
         tests/agent/test_bridge_anthropic_messages.py \
         tests/agent/test_bridge_raw_response.py \
         tests/model/providers/test_anthropic.py \
         tests/model/test_reasoning_effort.py                    -> 469 passed, 85 skipped
make check                                                       -> ruff clean, mypy clean
                                                                    (1448 files),
                                                                    suppressions ledger
                                                                    unchanged
make test                                                        -> 11267 passed, 4836 skipped
```

Note on the CHANGELOG: the entry is appended at the end of `## Unreleased` rather than
beside the other `Agent bridge:` line, to avoid conflicting with #5219, which inserts at
that spot. It can be regrouped once either lands.
