### PR TITLE
fix(util): handle surrogate characters in dictionary keys in to_json_safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Util: Handle surrogate characters in dictionary keys in to_json_safe. (#5229)
 - Grok: Oversized prompts now return `stop_reason="model_length"` instead of failing with a generation error under xAI's current context-overflow wording.
 - Eval Log: Sample summaries now keep `Score.reason`, so an explicit reason is no longer dropped (and a stale `metadata["unscored_reason"]` cannot replace it).
 - Agent bridge: A Chat Completions response truncated by the output-token limit now reports `finish_reason="length"` instead of `"stop"`.

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -171,16 +171,22 @@ def to_json_safe(
     exclude: _IncEx | None = None,
     indent: int | None = 2,
 ) -> bytes:
-    normalized = jsonable_python(x)
-
     def clean_utf8_json(obj: Any) -> Any:
         if isinstance(obj, str):
             return obj.encode("utf-8", errors="backslashreplace").decode("utf-8")
         elif isinstance(obj, dict):
-            return {k: clean_utf8_json(v) for k, v in obj.items()}
+            return {clean_utf8_json(k): clean_utf8_json(v) for k, v in obj.items()}
         elif isinstance(obj, list):
             return [clean_utf8_json(item) for item in obj]
         return obj
+
+    try:
+        normalized = jsonable_python(x)
+    except (UnicodeEncodeError, PydanticSerializationError) as ex:
+        if "surrogates not allowed" in str(ex):
+            normalized = jsonable_python(clean_utf8_json(x))
+        else:
+            raise
 
     try:
         return to_json(

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -39,6 +39,19 @@ def test_json_unicode_replace_preserves_exclude():
     assert json.loads(result) == {"keep": "\\ud800"}
 
 
+def test_json_unicode_replace_surrogate_keys():
+    data = {
+        "key_\ud800": "value1",
+        "nested": {"nested_key_\ud83c": "value2"},
+    }
+    json_str = to_json_str_safe(data)
+    deserialized = json.loads(json_str)
+    assert deserialized == {
+        "key_\\ud800": "value1",
+        "nested": {"nested_key_\\ud83c": "value2"},
+    }
+
+
 def test_json_changes_tracks_replaced_value_through_array_shifts():
     before = {"x": ["a", "b"]}
     after = {"x": ["c", "a", "d"]}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5229

In `src/inspect_ai/_util/json.py`, `to_json_safe()` previously cleaned surrogates from strings and dictionary values, but did not clean dictionary keys. In addition, when dictionary keys contained surrogate characters, `jsonable_python(x)` failed with `UnicodeEncodeError: 'utf-8' codec can't encode character ...: surrogates not allowed` before reaching the `to_json()` try-block.

### What is the new behavior?

1. `clean_utf8_json()` now cleans dictionary keys in addition to values.
2. `to_json_safe()` catches surrogate `UnicodeEncodeError` / `PydanticSerializationError` during `jsonable_python(x)` and cleans `x` before normalisation, ensuring dictionaries with surrogate keys serialize cleanly without crashing.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified surrogate dictionary keys serialize and deserialize cleanly; all checks passed)