### PR TITLE
fix(approval): avoid prefix over-matching for exact tool names in ApprovalPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Approval: Avoid prefix over-matching for exact tool names in ApprovalPolicy. (#5231)
 - Grok: Oversized prompts now return `stop_reason="model_length"` instead of failing with a generation error under xAI's current context-overflow wording.
 - Eval Log: Sample summaries now keep `Score.reason`, so an explicit reason is no longer dropped (and a stale `metadata["unscored_reason"]` cannot replace it).
 - Agent bridge: A Chat Completions response truncated by the output-token limit now reports `finish_reason="length"` instead of `"stop"`.

--- a/src/inspect_ai/approval/_policy.py
+++ b/src/inspect_ai/approval/_policy.py
@@ -41,7 +41,9 @@ def policy_approver(policies: str | list[ApprovalPolicy]) -> Approver:
         tools: list[str] = []
         for spec in tool_specs:
             tools.extend([t.strip() for t in spec.split(",") if t.strip()])
-        globs = [tool if tool.endswith("*") else f"{tool}*" for tool in tools]
+        globs = [
+            tool if tool.endswith("*") or "(" in tool else f"{tool}(*" for tool in tools
+        ]
         policy_matchers.append((globs, policy.approver))
 
     # generator for policies that match a tool_call

--- a/tests/approval/test_approval.py
+++ b/tests/approval/test_approval.py
@@ -146,6 +146,19 @@ def test_approve_pattern():
     )
 
 
+def test_approve_exact_tool_name():
+    # Exact tool name "addition" matches the addition tool
+    check_approval(
+        ApprovalPolicy(approver=auto_approver(), tools="addition"), decision="approve"
+    )
+    # Prefix "add" without wildcard must not match "addition"
+    check_approval(
+        ApprovalPolicy(approver=auto_approver(), tools="add"),
+        decision="reject",
+        approver="policy",
+    )
+
+
 def test_approve_multi_pattern():
     check_approval(
         ApprovalPolicy(approver=auto_approver(), tools=["spoo*", "add*"]),


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5231

In `src/inspect_ai/approval/_policy.py`, `policy_approver()` formed tool matching globs via:
```python
globs = [tool if tool.endswith("*") else f"{tool}*" for tool in tools]
```
For an exact tool name without wildcards (such as `tools: add` or `tools: bash`), this resulted in `"add*"` or `"bash*"`. Because matching is evaluated with `fnmatch` against formatted function calls (e.g. `addition(x=1)` or `bash_session(cmd='ls')`), `"add*"` matched any tool beginning with `add` (such as `addition` or `add_user`), causing exact-tool approval policies to inadvertently match prefix-sharing tools.

### What is the new behavior?

Exact tool names that do not end in `*" and do not contain call signature patterns `(` are now mapped to `f"{tool}(*"`. This ensures that `tools: add` matches calls to `add` (`add()` or `add(x=1)`) while correctly rejecting calls to distinct tools that share the prefix (`addition`).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified exact tool matching and wildcard patterns behave as expected; all checks passed)