### PR TITLE
Fix scheduled live-test failures: skip gpt-6-astra tests when the account lacks access

### DIFF
--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -2,7 +2,7 @@ import base64
 import json
 
 import pytest
-from test_helpers.utils import skip_if_no_openai, skip_if_no_openai_gpt_6
+from test_helpers.utils import skip_if_no_openai, skip_if_no_openai_model
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset._dataset import Sample
@@ -608,12 +608,11 @@ async def test_chat_completions_streaming_converts_mid_stream_safeguard_block() 
 #
 # Astra always reasons and rejects sampling params, so these exercise the
 # frontier request shape end to end. gpt-6-astra is gated per-account, so they
-# are opt-in via ENABLE_OPENAI_GPT_6 — a key without access gets a 404
-# model_not_found, which would fail the run rather than skip it.
+# skip (rather than fail with 404 model_not_found) when the key lacks access.
 
 
 @skip_if_no_openai
-@skip_if_no_openai_gpt_6
+@skip_if_no_openai_model("gpt-6-astra")
 async def test_openai_gpt_6_astra_generate() -> None:
     # temperature is dropped (with a warning) rather than sent, so this must not 400
     model = get_model(
@@ -627,7 +626,7 @@ async def test_openai_gpt_6_astra_generate() -> None:
 
 
 @skip_if_no_openai
-@skip_if_no_openai_gpt_6
+@skip_if_no_openai_model("gpt-6-astra")
 async def test_openai_gpt_6_astra_max_reasoning_effort() -> None:
     model = get_model(
         "openai/gpt-6-astra", config=GenerateConfig(reasoning_effort="max")
@@ -637,7 +636,7 @@ async def test_openai_gpt_6_astra_max_reasoning_effort() -> None:
 
 
 @skip_if_no_openai
-@skip_if_no_openai_gpt_6
+@skip_if_no_openai_model("gpt-6-astra")
 async def test_openai_gpt_6_astra_tool_call() -> None:
     @tool
     def addition():
@@ -659,3 +658,117 @@ async def test_openai_gpt_6_astra_tool_call() -> None:
     )
     assert output.message.tool_calls
     assert output.message.tool_calls[0].function == "addition"
+
+
+# -- skip_if_no_openai_model gate (no network) --
+
+
+class _FakeOpenAIClient:
+    """Stands in for openai.AsyncOpenAI: `models.retrieve` raises `error` if set."""
+
+    def __init__(self, error: Exception | None) -> None:
+        self._error = error
+        self.models = self
+        self.closed = False
+
+    async def retrieve(self, model: str) -> None:
+        if self._error is not None:
+            raise self._error
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake_openai(
+    monkeypatch: pytest.MonkeyPatch, error: Exception | None
+) -> list[_FakeOpenAIClient]:
+    import openai
+    from test_helpers import utils
+
+    clients: list[_FakeOpenAIClient] = []
+
+    def make_client(*args: object, **kwargs: object) -> _FakeOpenAIClient:
+        clients.append(_FakeOpenAIClient(error))
+        return clients[-1]
+
+    monkeypatch.setattr(openai, "AsyncOpenAI", make_client)
+    monkeypatch.setattr(utils, "_openai_model_access", {})
+    return clients
+
+
+def _openai_api_error(status: int, code: str | None) -> Exception:
+    # openai >= 3 is built on httpx2, so its errors expect httpx2 responses
+    import httpx2
+    import openai
+
+    request = httpx2.Request("GET", "https://api.openai.com/v1/models/gpt-6-astra")
+    response = httpx2.Response(status, request=request)
+    message = f"Error code: {status} - {code}"
+    body = {"code": code}
+    if status == 404:
+        return openai.NotFoundError(message, response=response, body=body)
+    if status == 403:
+        return openai.PermissionDeniedError(message, response=response, body=body)
+    return openai.AuthenticationError(message, response=response, body=body)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(_openai_api_error(404, "model_not_found"), id="model_not_found"),
+        pytest.param(_openai_api_error(403, None), id="permission_denied"),
+    ],
+)
+async def test_skip_if_no_openai_model_skips_without_access(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    clients = _install_fake_openai(monkeypatch, error)
+    ran = False
+
+    @skip_if_no_openai_model("gpt-6-astra")
+    async def gated() -> None:
+        nonlocal ran
+        ran = True
+
+    with pytest.raises(pytest.skip.Exception, match="no access to model gpt-6-astra"):
+        await gated()
+    assert not ran
+    assert [c.closed for c in clients] == [True]
+
+
+async def test_skip_if_no_openai_model_runs_with_access_and_probes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clients = _install_fake_openai(monkeypatch, None)
+    runs = 0
+
+    @skip_if_no_openai_model("gpt-6-astra")
+    async def gated() -> None:
+        nonlocal runs
+        runs += 1
+
+    await gated()
+    await gated()
+    assert runs == 2
+    assert len(clients) == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(_openai_api_error(401, "invalid_api_key"), id="bad_key"),
+        # a 404 that isn't model_not_found (e.g. a gateway without /models)
+        pytest.param(_openai_api_error(404, None), id="endpoint_not_found"),
+    ],
+)
+async def test_skip_if_no_openai_model_propagates_other_errors(
+    monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    _install_fake_openai(monkeypatch, error)
+
+    @skip_if_no_openai_model("gpt-6-astra")
+    async def gated() -> None:
+        pass
+
+    with pytest.raises(type(error)):
+        await gated()

--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -2,7 +2,7 @@ import base64
 import json
 
 import pytest
-from test_helpers.utils import skip_if_no_openai
+from test_helpers.utils import skip_if_no_openai, skip_if_no_openai_gpt_6
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset._dataset import Sample
@@ -607,11 +607,13 @@ async def test_chat_completions_streaming_converts_mid_stream_safeguard_block() 
 # -- GPT-6 Astra (live) --
 #
 # Astra always reasons and rejects sampling params, so these exercise the
-# frontier request shape end to end. They fail with `model_not_found` until the
-# account has access to the model.
+# frontier request shape end to end. gpt-6-astra is gated per-account, so they
+# are opt-in via ENABLE_OPENAI_GPT_6 — a key without access gets a 404
+# model_not_found, which would fail the run rather than skip it.
 
 
 @skip_if_no_openai
+@skip_if_no_openai_gpt_6
 async def test_openai_gpt_6_astra_generate() -> None:
     # temperature is dropped (with a warning) rather than sent, so this must not 400
     model = get_model(
@@ -625,6 +627,7 @@ async def test_openai_gpt_6_astra_generate() -> None:
 
 
 @skip_if_no_openai
+@skip_if_no_openai_gpt_6
 async def test_openai_gpt_6_astra_max_reasoning_effort() -> None:
     model = get_model(
         "openai/gpt-6-astra", config=GenerateConfig(reasoning_effort="max")
@@ -634,6 +637,7 @@ async def test_openai_gpt_6_astra_max_reasoning_effort() -> None:
 
 
 @skip_if_no_openai
+@skip_if_no_openai_gpt_6
 async def test_openai_gpt_6_astra_tool_call() -> None:
     @tool
     def addition():

--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -764,11 +764,15 @@ async def test_skip_if_no_openai_model_runs_with_access_and_probes_once(
 async def test_skip_if_no_openai_model_propagates_other_errors(
     monkeypatch: pytest.MonkeyPatch, error: Exception
 ) -> None:
-    _install_fake_openai(monkeypatch, error)
+    clients = _install_fake_openai(monkeypatch, error)
 
     @skip_if_no_openai_model("gpt-6-astra")
     async def gated() -> None:
         pass
 
-    with pytest.raises(type(error)):
-        await gated()
+    # the error must not be cached: a bad key or an outage re-probes on the
+    # next test (or flaky retry) instead of poisoning the per-process cache
+    for _ in range(2):
+        with pytest.raises(type(error)):
+            await gated()
+    assert [c.closed for c in clients] == [True, True]

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -285,6 +285,13 @@ def skip_if_no_openai_reasoning_summaries(func):
     )
 
 
+def skip_if_no_openai_gpt_6(func):
+    # gpt-6-astra is gated per-account: a key without access gets a 404
+    # model_not_found, so live gpt-6 tests are opt-in like reasoning summaries.
+    func._needs_flaky_retry = True
+    return pytest.mark.api(skip_if_env_var("ENABLE_OPENAI_GPT_6", exists=False)(func))
+
+
 def skip_if_no_anthropic(func):
     func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func))

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -505,8 +505,6 @@ def skip_if_async_backend(backend):
 
     For sync functions this is a no-op — they never run under an async backend.
     """
-    import inspect
-
     import sniffio
 
     def decorator(func):

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import functools
 import importlib.util
+import inspect
 import os
 import signal
 import subprocess
@@ -285,11 +286,66 @@ def skip_if_no_openai_reasoning_summaries(func):
     )
 
 
-def skip_if_no_openai_gpt_6(func):
-    # gpt-6-astra is gated per-account: a key without access gets a 404
-    # model_not_found, so live gpt-6 tests are opt-in like reasoning summaries.
-    func._needs_flaky_retry = True
-    return pytest.mark.api(skip_if_env_var("ENABLE_OPENAI_GPT_6", exists=False)(func))
+# model name -> skip reason (None when the account has access); probed once per
+# process so stacking the gate on several tests costs a single request.
+_openai_model_access: dict[str, str | None] = {}
+
+
+async def _openai_model_access_error(model: str) -> str | None:
+    """Return why the current OpenAI account can't use `model`, or None if it can.
+
+    Access-gated models (e.g. gpt-6-astra) answer the models endpoint with a
+    404 `model_not_found` (or a 403) for accounts without entitlement, so
+    retrieving the model is a cheap, token-free way to tell access apart from a
+    real provider failure. Anything else -- a bad key, a network error, a 404
+    from a gateway that doesn't implement the endpoint -- propagates so the
+    test fails loudly instead of skipping forever.
+    """
+    if model not in _openai_model_access:
+        import openai
+
+        client = openai.AsyncOpenAI()
+        try:
+            await client.models.retrieve(model)
+            _openai_model_access[model] = None
+        except openai.PermissionDeniedError as ex:
+            _openai_model_access[model] = _no_access_reason(model, ex)
+        except openai.NotFoundError as ex:
+            if ex.code != "model_not_found":
+                raise
+            _openai_model_access[model] = _no_access_reason(model, ex)
+        finally:
+            await client.close()
+    return _openai_model_access[model]
+
+
+def _no_access_reason(model: str, ex: Exception) -> str:
+    return f"OpenAI account has no access to model {model}: {ex}"
+
+
+def skip_if_no_openai_model(model: str):
+    """Skip an async live test at runtime if the OpenAI account can't use `model`.
+
+    Unlike an env-var gate this needs no configuration: an account that gains
+    access to the model regains the coverage automatically. Stack it under
+    `skip_if_no_openai`, which supplies the `api` marker, flaky retry, and the
+    package/key check the probe relies on.
+    """
+
+    def decorator(func):
+        if not inspect.iscoroutinefunction(func):
+            raise TypeError("skip_if_no_openai_model only supports async tests")
+
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            reason = await _openai_model_access_error(model)
+            if reason is not None:
+                pytest.skip(reason)
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def skip_if_no_anthropic(func):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Fixes meridianlabs-ai/inspect_ai#435

### What is the current behavior? (You can also link to an open issue here)

The three live tests `test_openai_gpt_6_astra_*` in `tests/model/providers/test_openai.py` (added in #5236) are gated only on `@skip_if_no_openai`, i.e. on `OPENAI_API_KEY` being present. `gpt-6-astra` is access-gated per OpenAI account, so any key without access gets `404 model_not_found` and the tests **fail** rather than skip. Every scheduled slow-test run currently fails on exactly these 6 cases (3 tests × asyncio/trio) with everything else green.

### What is the new behavior?

The three live gpt-6-astra tests are additionally decorated with `@skip_if_no_openai_model("gpt-6-astra")`, a new helper in `tests/test_helpers/utils.py` that decides **at runtime** whether the account can use the model:

- Before the test body runs it calls `AsyncOpenAI().models.retrieve("gpt-6-astra")` (token-free, one request), caches the answer per process, and skips the test with a reason such as `OpenAI account has no access to model gpt-6-astra: ...` on a `404 model_not_found` or a `403`.
- With access, the probe succeeds and the tests run unchanged. No configuration needed: an account that gains access regains the coverage automatically.
- Anything else (bad key, network error, a 404 that isn't `model_not_found`, e.g. a gateway `OPENAI_BASE_URL` without `/models`) propagates, so the tests fail loudly rather than skipping forever.
- `pytest.skip` is honored by the flaky-retry wrapper (not retried), and the helper is stacked under `@skip_if_no_openai`, which supplies the `api` marker, flaky retry, and the package/key check.

Five non-network unit tests cover the gate with a faked OpenAI client: skip on `model_not_found`, skip on `403`, run with access and probe only once, propagate a `401`, propagate a non-`model_not_found` `404`.

This replaces the initial version of this PR, which gated the tests behind an `ENABLE_OPENAI_GPT_6` environment variable; the maintainer asked for a runtime check instead.

Non-network gpt-6 coverage (`test_openai_model_names.py`, `test_openai_responses.py`, `test_reasoning_effort.py`, `test_model_info.py`, etc.) is untouched and keeps running.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test-only change; no `src/` or CHANGELOG change.

### Other information:

Verification (run in the autonomous run on this branch, `pip install -e ".[dev]"`):

- `pytest tests/model/providers/test_openai.py -k skip_if_no_openai_model` under asyncio and `--runtrio`: 5 passed each.
- `pytest tests/model/providers/test_openai.py -k gpt_6_astra` without `OPENAI_API_KEY`: 6 skipped (outer `skip_if_no_openai` gate).
- `ruff check` / `ruff format --check` on both changed files: clean.
- `mypy` on both changed files: clean.
- Not run: the live probe against the real OpenAI API (no `OPENAI_API_KEY` in the runner). The exact `404 model_not_found` shape is taken from the failing scheduled runs in the issue; the scheduled workflow's next run is the real check.

### Agent review
- Author: Claude Fable 5.1 (Claude Code, autonomous run from issue #435, then revised on maintainer feedback)
- Reviewer: Claude Opus via a fresh-context subagent (different model from the author), 1 pass on the runtime-probe revision (a separate 1-pass review was run on the earlier env-var version)
- Findings: 0 bugs, 6 nits
  - Fixed: a generic 404 (gateway without `/models`, model rename) would have skipped forever with green CI → only `model_not_found` 404s skip, other 404s propagate, with a test.
  - Fixed: the `403 PermissionDeniedError` branch had no test → added parametrized case.
  - Fixed: "probed once per session" comment was wrong under `pytest -n` → "per process".
  - Fixed: `import inspect` moved to module level.
  - Dismissed: non-access probe errors aren't cached, so an outage re-probes on each test/retry. Intentional: those are real failures and should surface on each test.
  - Dismissed: `await client.close()` in `finally` runs inside a cancelled scope if the 300s test timeout fires mid-probe, leaking the httpx pool for that process. Edge case in an already-failing run; same behavior as every other live test's client.
- Reviewer verified (by simulating the stacked decorators through conftest's auto timeout/flaky-retry wrapping with a faked client) that `pytest.skip` from the probe is reported as a skip and is not retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)