### PR TITLE
AGENTS.md: PRs touching gated-test areas must run and report the slow/live tests; add slow-tests skill

### DIFF
--- a/.claude/skills/slow-tests/SKILL.md
+++ b/.claude/skills/slow-tests/SKILL.md
@@ -64,19 +64,3 @@ test attempt in a 5-minute timeout, sync tests get none. If a test hangs,
 rerun with `--timeout=<seconds>`; the conftest watchdog then dumps every
 thread stack 300 seconds before the kill, or at the threshold in
 `INSPECT_TEST_HANG_DUMP_SECONDS` if you set one.
-
-## Reporting a run in a PR
-
-AGENTS.md requires a PR that touches gated-test areas to report its run.
-Under "Other information" in the PR description, add a `### Slow tests`
-section with:
-
-- the exact command(s) run
-- what ran, per class or provider, with the passed and skipped counts from
-  the summary
-- what you could not run, and why (no key, no Docker, no model access,
-  needs a local server)
-
-A test that skipped did not run. Say so rather than counting it. If you ran
-nothing, say that, so a maintainer with the keys or Docker runs the tests
-before merge.

--- a/.claude/skills/slow-tests/SKILL.md
+++ b/.claude/skills/slow-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slow-tests
-description: Run the gated test classes that plain `pytest` skips (slow Docker/sandbox tests, live model-provider API tests, flaky tests, trio variants) and report the run in a PR description. Use when a change touches model providers, sandbox or tool code, agents, or async plumbing, or when asked to run slow/live/api/trio tests or to write the "Slow tests" section of a PR.
+description: Run the gated test classes that plain `pytest` skips (slow Docker/sandbox tests, live model-provider API tests, flaky tests, trio variants). Use when asked to run slow, live, api, or trio tests, when debugging one, or when a change touches model providers, sandbox or tool code, agents, or async plumbing and needs its gated coverage run.
 ---
 
 # Running the gated tests
@@ -13,8 +13,7 @@ the class, then read the skip summary at the end of the run (`-ra` is in
 
 PR CI runs almost none of these. A scheduled job in `meridianlabs-ai/actions`
 runs `pytest --runslow --runapi` against `main` every couple of hours, so a
-gated test your PR breaks fails there, after merge. Running the relevant
-gated tests before opening the PR is how that breakage gets caught first.
+gated test that a change breaks fails there, after merge.
 
 | Class | Flag | How a test joins it | What it needs | Does PR CI run it? |
 |---|---|---|---|---|
@@ -66,8 +65,9 @@ rerun with `--timeout=<seconds>`; the conftest watchdog then dumps every
 thread stack 300 seconds before the kill, or at the threshold in
 `INSPECT_TEST_HANG_DUMP_SECONDS` if you set one.
 
-## Report the run in the PR
+## Reporting a run in a PR
 
+AGENTS.md requires a PR that touches gated-test areas to report its run.
 Under "Other information" in the PR description, add a `### Slow tests`
 section with:
 

--- a/.claude/skills/slow-tests/SKILL.md
+++ b/.claude/skills/slow-tests/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: slow-tests
+description: Run the gated test classes that plain `pytest` skips (slow Docker/sandbox tests, live model-provider API tests, flaky tests, trio variants) and report the run in a PR description. Use when a change touches model providers, sandbox or tool code, agents, or async plumbing, or when asked to run slow/live/api/trio tests or to write the "Slow tests" section of a PR.
+---
+
+# Running the gated tests
+
+Plain `pytest` (and `make test`) runs the fast suite only. Four classes of
+test are gated behind flags defined in `tests/conftest.py`. A gated test
+that is not enabled shows as skipped, and the run still exits green. Enable
+the class, then read the skip summary at the end of the run (`-ra` is in
+`addopts`) to confirm the tests you meant to run actually ran.
+
+PR CI runs almost none of these. A scheduled job in `meridianlabs-ai/actions`
+runs `pytest --runslow --runapi` against `main` every couple of hours, so a
+gated test your PR breaks fails there, after merge. Running the relevant
+gated tests before opening the PR is how that breakage gets caught first.
+
+| Class | Flag | How a test joins it | What it needs | Does PR CI run it? |
+|---|---|---|---|---|
+| slow | `--runslow` | `@pytest.mark.slow` | Usually Docker (`@skip_if_no_docker`), sometimes a provider key too | Only `tests/tools/` when tool or sandbox code changed, plus the areas in the `detect-slow` table in `.github/workflows/build.yml` |
+| api | `--runapi` | `skip_if_no_<provider>` decorators in `tests/test_helpers/utils.py` add the `api` marker | The provider's key or opt-in variable; the decorator names it | No. CI has no provider keys |
+| flaky | `--runflaky` | `@pytest.mark.flaky` | Whatever the underlying test needs (Docker or a key) | No |
+| trio | `--runtrio` | Every async test gets a `[trio]` variant automatically | A separate pytest invocation; it runs only the trio variants | No |
+
+Flags combine, except `--runtrio`, which must be its own run.
+
+## Which tests to run for which change
+
+Run the gated tests that cover the code you changed, scoped to the test
+directories that exercise it. The whole gated suite is large and spends
+provider credit; leave that to the scheduled job.
+
+| You changed | Run |
+|---|---|
+| `src/inspect_ai/model/_providers/**` or a provider conversion module in `src/inspect_ai/model/` | `pytest --runapi --runslow tests/model/providers/test_<provider>*.py` with that provider's key set. Shared code (`_providers/util/`, `openai_compatible.py`, `providers.py`) is used by many providers; run `tests/model tests/tools tests/agent` with a key for each provider built on it |
+| `src/inspect_ai/tool/**` or `src/inspect_sandbox_tools/**` | `pytest --runslow -m slow tests/tools/ -x` with Docker running. Add `--local-inspect-tools` to build the sandbox tools from your working tree instead of using the published binary (see `src/inspect_sandbox_tools/AGENTS.md`) |
+| `src/inspect_ai/util/_sandbox/**` or `src/inspect_ai/util/_checkpoint/**` | `pytest --runslow tests/util/ tests/checkpoint/` with Docker running |
+| `src/inspect_ai/agent/**` | `pytest --runslow --runapi tests/agent/`. Many of these are ACP and TUI tests that need only time; the rest need Docker or an OpenAI or Anthropic key |
+| Async plumbing (task groups, cancellation, anything under `_util/_async.py` or a bridge) | The affected tests once normally and once with `--runtrio` |
+| A test marked `flaky`, or the code it covers | That test with `--runflaky` |
+
+## Provider keys
+
+Most providers gate on `<PROVIDER>_API_KEY` (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, and so on). Bedrock
+and Vertex authenticate through AWS and gcloud credentials, so their gate is
+an opt-in switch: `ENABLE_BEDROCK_TESTS`, `ENABLE_VERTEX_TESTS`. Azure-hosted
+OpenAI and Mistral skip on their `AZUREAI_*` variables without the `api`
+marker. When unsure, read the decorator on the test.
+
+A provider file's tests often gate on several keys. With only
+`OPENAI_API_KEY` set, `test_openai*.py` still reports skips for Together,
+Bedrock, vLLM, and reasoning-summary access. Those are expected. A skip
+whose reason names the key you set means that test did not run.
+
+## Docker
+
+`@skip_if_no_docker` checks that the `docker` binary exists, not that the
+daemon is up. With Docker installed but stopped the tests fail instead of
+skipping. Start Docker first.
+
+Local runs set no `--timeout` (CI uses 900s); conftest wraps each async
+test attempt in a 5-minute timeout, sync tests get none. If a test hangs,
+rerun with `--timeout=<seconds>`; the conftest watchdog then dumps every
+thread stack 300 seconds before the kill, or at the threshold in
+`INSPECT_TEST_HANG_DUMP_SECONDS` if you set one.
+
+## Report the run in the PR
+
+Under "Other information" in the PR description, add a `### Slow tests`
+section with:
+
+- the exact command(s) run
+- what ran, per class or provider, with the passed and skipped counts from
+  the summary
+- what you could not run, and why (no key, no Docker, no model access,
+  needs a local server)
+
+A test that skipped did not run. Say so rather than counting it. If you ran
+nothing, say that, so a maintainer with the keys or Docker runs the tests
+before merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,50 +159,21 @@ All async test functions automatically run under both asyncio and trio backends 
 
 ## Live provider tests
 
-A PR that changes a model provider must have run that provider's live tests
-before it opens, and the PR description must say which ones ran. Provider
-files are `src/inspect_ai/model/_providers/**` and the provider-specific
-conversion modules in `src/inspect_ai/model/` (`_anthropic_convert.py`,
-`_google_convert.py`, `_openai*.py`, `_openrouter_reasoning.py`). CI does not
-run these tests on pull requests: they call the real provider API and need that
-provider's key, which CI does not have.
+CI cannot run the live provider tests. They call real provider APIs and need
+API keys. So a PR that changes `src/inspect_ai/model/_providers/**`, or the
+provider conversion modules in `src/inspect_ai/model/`, must run them locally,
+and the PR description must report the run.
 
-Live tests are the ones gated by a `skip_if_no_<provider>` decorator from
-`tests/test_helpers/utils.py`. They carry the `api` marker and run only with
-`--runapi` (the Azure-hosted OpenAI and Mistral gates skip on the env var
-alone); some are also marked `slow` and need `--runslow`. Each one skips when
-its gating variable is unset, so a run with no key passes with everything
-skipped. Set the key, pass both flags, and read the skip summary pytest prints
-(`-ra` is on by default here) to confirm the tests ran:
-
-```bash
-OPENAI_API_KEY=... pytest --runapi --runslow tests/model/providers/test_openai*.py
-```
-
-Skips from other gates in the same files (Together, Bedrock, reasoning
-summaries, vLLM) are expected; a skip whose reason names the key you set means
-that test did not run. The gating variable is the provider's API key
-(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, ...)
-or, where credentials live outside the environment, an opt-in switch such as
-`ENABLE_BEDROCK_TESTS` or `ENABLE_VERTEX_TESTS`; the decorator names it.
-
-The provider's own suite is `tests/model/providers/test_<provider>*.py`. Tests
-in `tests/model/`, `tests/tools/`, and `tests/agent/` gate on the same keys, so
-a change to shared code (`_providers/util/`, `openai_compatible.py`,
-`providers.py`) calls for those directories too, for every provider that
-depends on the changed code:
-
-```bash
-pytest --runapi --runslow tests/model tests/tools tests/agent
-```
+Live tests are the ones decorated with `skip_if_no_<provider>` in
+`tests/test_helpers/utils.py`. That file names each provider's key or opt-in
+variable, and `tests/conftest.py` defines the `--runapi` and `--runslow` flags
+they need. A run without the key skips them and still exits green, so read the
+skip summary.
 
 In the PR description, under "Other information", add a `### Live tests`
-section with: the exact command(s) run, the providers exercised with the
-passed/skipped counts from the summary, and each provider you could not run
-and why (no key, no model access, needs a local server, no live tests exist for
-it). A test that skipped did not run; say so. A PR with no live run at all may
-still open, but must say so, so a maintainer with the key runs them before
-merge.
+section listing the command(s) run, each provider exercised with its
+passed/skipped counts, and each provider not run and why. A skipped test did
+not run; say so.
 
 ## Subsystem Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,23 +157,22 @@ All async test functions automatically run under both asyncio and trio backends 
   task) is owned by whichever component created it — cleanup belongs there,
   not in a caller or bridge that merely passes it through.
 
-## Live provider tests
+## Gated tests (slow, api, flaky, trio)
 
-CI cannot run the live provider tests. They call real provider APIs and need
-API keys. So a PR that changes `src/inspect_ai/model/_providers/**`, or the
-provider conversion modules in `src/inspect_ai/model/`, must run them locally,
-and the PR description must report the run.
+Plain `pytest` skips the Docker-based slow tests, the live model-provider
+tests, flaky tests, and trio variants. PR CI runs only the slow tests under
+`tests/tools/` and a short list of other areas; it never runs the live
+provider tests, because they need API keys. So a PR that changes model
+providers, sandbox or tool code, agents, or async plumbing must run the gated
+tests that cover the change locally, and the PR description must report the
+run.
 
-Live tests are the ones decorated with `skip_if_no_<provider>` in
-`tests/test_helpers/utils.py`. That file names each provider's key or opt-in
-variable, and `tests/conftest.py` defines the `--runapi` and `--runslow` flags
-they need. A run without the key skips them and still exits green, so read the
-skip summary.
-
-In the PR description, under "Other information", add a `### Live tests`
-section listing the command(s) run, each provider exercised with its
-passed/skipped counts, and each provider not run and why. A skipped test did
-not run; say so.
+The `slow-tests` skill (`.claude/skills/slow-tests/SKILL.md`) says which flags
+and directories go with which change, what each class needs (Docker, a key),
+and how to read the skip summary. Follow it, then add a `### Slow tests`
+section under "Other information" in the PR description listing the command(s)
+run, what ran with passed/skipped counts, and what you could not run and why.
+A skipped test did not run; say so.
 
 ## Subsystem Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,34 +162,47 @@ All async test functions automatically run under both asyncio and trio backends 
 A PR that changes a model provider must have run that provider's live tests
 before it opens, and the PR description must say which ones ran. Provider
 files are `src/inspect_ai/model/_providers/**` and the provider-specific
-conversion modules beside them (`_anthropic_convert.py`, `_google_convert.py`,
-`_openai*.py`, `_openrouter_reasoning.py` in `src/inspect_ai/model/`). CI does
-not run these tests on pull requests: they call the real provider API and need
-that provider's key, which CI does not have.
+conversion modules in `src/inspect_ai/model/` (`_anthropic_convert.py`,
+`_google_convert.py`, `_openai*.py`, `_openrouter_reasoning.py`). CI does not
+run these tests on pull requests: they call the real provider API and need that
+provider's key, which CI does not have.
 
-Live tests carry the `api` marker (added by the `skip_if_no_<provider>`
-decorators in `tests/test_helpers/utils.py`) and run only with `--runapi`; a
-few are also marked `slow` and need `--runslow` too. Each one skips when its
-gating variable is unset, so a run with no key passes with everything skipped.
-Set the key, pass both flags, and read the `-ra` skip summary to confirm the
-tests ran:
+Live tests are the ones gated by a `skip_if_no_<provider>` decorator from
+`tests/test_helpers/utils.py`. They carry the `api` marker and run only with
+`--runapi` (the Azure-hosted OpenAI and Mistral gates skip on the env var
+alone); some are also marked `slow` and need `--runslow`. Each one skips when
+its gating variable is unset, so a run with no key passes with everything
+skipped. Set the key, pass both flags, and read the skip summary pytest prints
+(`-ra` is on by default here) to confirm the tests ran:
 
 ```bash
 OPENAI_API_KEY=... pytest --runapi --runslow tests/model/providers/test_openai*.py
 ```
 
-The gating variable is the provider's API key (`OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, ...) or an opt-in switch
-where credentials live outside the environment (`ENABLE_BEDROCK_TESTS`,
-`ENABLE_VERTEX_TESTS`); the decorator names it. A change to shared code
-(`_providers/util/`, `openai_compatible.py`, `providers.py`) touches every
-provider built on it, so run the live tests for each provider that depends on
-the changed code, not only the one you set out to fix.
+Skips from other gates in the same files (Together, Bedrock, reasoning
+summaries, vLLM) are expected; a skip whose reason names the key you set means
+that test did not run. The gating variable is the provider's API key
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, ...)
+or, where credentials live outside the environment, an opt-in switch such as
+`ENABLE_BEDROCK_TESTS` or `ENABLE_VERTEX_TESTS`; the decorator names it.
+
+The provider's own suite is `tests/model/providers/test_<provider>*.py`. Tests
+in `tests/model/`, `tests/tools/`, and `tests/agent/` gate on the same keys, so
+a change to shared code (`_providers/util/`, `openai_compatible.py`,
+`providers.py`) calls for those directories too, for every provider that
+depends on the changed code:
+
+```bash
+pytest --runapi --runslow tests/model tests/tools tests/agent
+```
 
 In the PR description, under "Other information", add a `### Live tests`
 section with: the exact command(s) run, the providers exercised with the
 passed/skipped counts from the summary, and each provider you could not run
-and why (no key, no model access). A test that skipped did not run; say so.
+and why (no key, no model access, needs a local server, no live tests exist for
+it). A test that skipped did not run; say so. A PR with no live run at all may
+still open, but must say so, so a maintainer with the key runs them before
+merge.
 
 ## Subsystem Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,14 +165,21 @@ tests, flaky tests, and trio variants. PR CI runs only the slow tests under
 provider tests, because they need API keys. So a PR that changes model
 providers, sandbox or tool code, agents, or async plumbing must run the gated
 tests that cover the change locally, and the PR description must report the
-run.
+run. The `slow-tests` skill (`.claude/skills/slow-tests/SKILL.md`) says which
+flags and directories go with which change and what each class needs.
 
-The `slow-tests` skill (`.claude/skills/slow-tests/SKILL.md`) says which flags
-and directories go with which change, what each class needs (Docker, a key),
-and how to read the skip summary. Follow it, then add a `### Slow tests`
-section under "Other information" in the PR description listing the command(s)
-run, what ran with passed/skipped counts, and what you could not run and why.
-A skipped test did not run; say so.
+Report the run under "Other information" in the PR description, in a
+`### Slow tests` section with:
+
+- the exact command(s) run
+- what ran, per class or provider, with the passed and skipped counts from
+  the summary
+- what you could not run, and why (no key, no Docker, no model access,
+  needs a local server)
+
+A test that skipped did not run. Say so rather than counting it. If you ran
+nothing, say that, so a maintainer with the keys or Docker runs the tests
+before merge.
 
 ## Subsystem Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,40 @@ All async test functions automatically run under both asyncio and trio backends 
   task) is owned by whichever component created it — cleanup belongs there,
   not in a caller or bridge that merely passes it through.
 
+## Live provider tests
+
+A PR that changes a model provider must have run that provider's live tests
+before it opens, and the PR description must say which ones ran. Provider
+files are `src/inspect_ai/model/_providers/**` and the provider-specific
+conversion modules beside them (`_anthropic_convert.py`, `_google_convert.py`,
+`_openai*.py`, `_openrouter_reasoning.py` in `src/inspect_ai/model/`). CI does
+not run these tests on pull requests: they call the real provider API and need
+that provider's key, which CI does not have.
+
+Live tests carry the `api` marker (added by the `skip_if_no_<provider>`
+decorators in `tests/test_helpers/utils.py`) and run only with `--runapi`; a
+few are also marked `slow` and need `--runslow` too. Each one skips when its
+gating variable is unset, so a run with no key passes with everything skipped.
+Set the key, pass both flags, and read the `-ra` skip summary to confirm the
+tests ran:
+
+```bash
+OPENAI_API_KEY=... pytest --runapi --runslow tests/model/providers/test_openai*.py
+```
+
+The gating variable is the provider's API key (`OPENAI_API_KEY`,
+`ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, ...) or an opt-in switch
+where credentials live outside the environment (`ENABLE_BEDROCK_TESTS`,
+`ENABLE_VERTEX_TESTS`); the decorator names it. A change to shared code
+(`_providers/util/`, `openai_compatible.py`, `providers.py`) touches every
+provider built on it, so run the live tests for each provider that depends on
+the changed code, not only the one you set out to fix.
+
+In the PR description, under "Other information", add a `### Live tests`
+section with: the exact command(s) run, the providers exercised with the
+passed/skipped counts from the summary, and each provider you could not run
+and why (no key, no model access). A test that skipped did not run; say so.
+
 ## Subsystem Documentation
 
 Additional files provide context when working in specific areas:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

AGENTS.md asks contributors to run `make check` and `make test` before a PR. `make test` skips four classes of test: Docker-based `slow` tests, live provider tests (`api` marker, via the `skip_if_no_<provider>` decorators), `flaky` tests, and trio variants. PR CI runs the slow tests under `tests/tools/` when tool code changes and a short list of other areas; it never runs the live provider tests because the runners have no provider keys. So a PR that changes a provider can go green without any request ever reaching that provider, and nothing tells the contributor which gated tests to run or how.

### What is the new behavior?

A new skill, `.claude/skills/slow-tests/SKILL.md`, covers running all four gated classes: the flag for each, how a test joins the class, what it needs (Docker, a key, a second invocation), which classes PR CI runs, a "you changed X, run Y" table, the provider key and opt-in variables, and the Docker and timeout gotchas. It is a general how-to, not PR-specific.

A new `## Gated tests` section in AGENTS.md states the rule: a PR that changes model providers, sandbox or tool code, agents, or async plumbing must run the gated tests that cover the change locally, follow the skill for how, and report the run in a `### Slow tests` section of the PR description (command, what ran with passed/skipped counts, what could not run and why).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Docs only.

### Other information:

Claims in the skill were checked against the repo: flag and marker gating in `tests/conftest.py`, the decorators and env vars in `tests/test_helpers/utils.py`, the `test` and `slow-tool-tests-dev` jobs and `detect-slow` table in `build.yml`, and the scheduled `--runslow --runapi` run described in the ci-perf skill. Ran `pytest --runapi --runslow tests/model/providers/test_groq.py` with no key to confirm the skip behavior the skill describes (19 passed, 3 live tests skipped naming `GROQ_API_KEY`).

### Agent review
- Reviewer: Claude Fable 5.1 subagent, fresh context, 2 passes (one on the first AGENTS.md-only draft, one on the skill plus final section)
- Pass 1 findings: 11 (5 should-fix, 6 nits), 10 fixed, 1 dismissed (a cross-reference clause in "Authoring pull requests"; kept the change to one section). Most of that text later moved into the skill.
- Pass 2 findings: 14 (2 must-fix, 7 should-fix, 5 nits), all 14 fixed. The must-fixes: the skill pointed at `--local-inspect-tools`, a pytest option no test reads any more (the runtime picks the `-dev` binary itself), and the expected-skip list for `test_openai*.py` named reasoning summaries (a network-free test) instead of the model-access probe. Should-fixes included `--runtrio` combining with the other flags, `tests/util/sandbox/` rather than all of `tests/util/`, a checkpoint test needing an Anthropic key, Google-gated agent tests, `-x` truncating counts, and duplication between the AGENTS.md section and the skill (the section is now rule plus report format only).
- Not fixed here, out of scope: `src/inspect_sandbox_tools/AGENTS.md` lines 90-93 still describe `--local-inspect-tools` and a test file that does not exist.
