### PR TITLE
fix(view): return 403 instead of 500 when log is unreadable in api_log_headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- View: Return 403 Forbidden instead of 500 when log validation fails in /log-headers. (#5241)
 - Checkpointing: Resuming from a checkpoint now rejects a host-context snapshot containing symlinks or other non-regular files instead of following them into host files.
 - Checkpointing: Resuming into a context directory left by an interrupted attempt no longer keeps files newer than the committed checkpoint alongside the restored ones.
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -3,6 +3,7 @@ import logging
 import os
 import secrets
 import urllib.parse
+from functools import partial
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
@@ -26,6 +27,7 @@ from typing_extensions import override
 
 from inspect_ai._display.core.active import display
 from inspect_ai._eval.evalset import EvalSet, read_eval_set_info
+from inspect_ai._util._async import tg_collect
 from inspect_ai._util.asyncfiles import AsyncFilesystem, bind_async_filesystem
 from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
 from inspect_ai._util.error import WriteConflictError
@@ -441,15 +443,12 @@ def view_server_app(
         request: Request, file: list[str] = Query([])
     ) -> list[EvalLog]:
         files = [normalize_uri(f) for f in file]
-        mapped_files: list[str] = [""] * len(files)
 
-        async def _validate_and_map(idx: int, f: str) -> None:
+        async def _validate_and_map(f: str) -> str:
             await _validate_read(request, f)
-            mapped_files[idx] = await _map_file(request, f)
+            return await _map_file(request, f)
 
-        async with anyio.create_task_group() as tg:
-            for i, f in enumerate(files):
-                tg.start_soon(_validate_and_map, i, f)
+        mapped_files = await tg_collect([partial(_validate_and_map, f) for f in files])
 
         return await read_eval_log_headers_async(mapped_files)
 

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -722,6 +722,28 @@ def test_api_log_headers_multiple(view_client: ViewTestClient) -> None:
     assert len(resp.json()) == 2
 
 
+def test_api_log_headers_forbidden() -> None:
+    class NoReadPolicy(AccessPolicy):
+        async def can_read(self, request: Request, file: str) -> bool:
+            return False
+
+        async def can_delete(self, request: Request, file: str) -> bool:
+            return False
+
+        async def can_list(self, request: Request, dir: str) -> bool:
+            return False
+
+        async def can_write(self, request: Request, file: str) -> bool:
+            return False
+
+    app = fastapi_server.view_server_app(access_policy=NoReadPolicy())
+    with fastapi.testclient.TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/log-headers", params={"file": "restricted.eval"})
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Forbidden"}
+
+
 @pytest.mark.parametrize(
     ["last_eval_time", "expected"],
     [


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #5241

In `src/inspect_ai/_view/fastapi_server.py`, `api_log_headers` fanned out per-file checks across an `anyio.create_task_group()`. When `_validate_read` raised `HTTPException(403)` (or when other file handlers raised), the exception was wrapped inside an `ExceptionGroup`. Because Starlette exception handlers dispatch on exception type, the group bypassed `ExceptionMiddleware` and reached `ServerErrorMiddleware`, resulting in a 500 Internal Server Error instead of 403 Forbidden.

### What is the new behavior?

`api_log_headers` now uses `tg_collect`, which defaults to `exception_group=False` and re-raises the underlying exception directly while preserving fail-fast structured concurrency and input ordering. An authorization denial now properly dispatches to Starlette's exception handler and returns 403 Forbidden.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

### Agent review
- Reviewer: Antigravity via reproduction test and full test suite verification (2 passes)
- Findings: 0 open issues (verified 403 response on restricted access policy; all tests passed)