### PR TITLE
docs: remove doubled words in intervention and agent-custom pages

### DIFF
--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -447,7 +447,7 @@ background(worker)
 
 The above code demonstrates a couple of important characteristics of a sample background worker:
 
-1.  Background workers typically operate in a loop, often polling a a sandbox or other endpoint for activity. In a loop like this it's important to sleep at regular intervals so your background work doesn't monopolise CPU resources.
+1.  Background workers typically operate in a loop, often polling a sandbox or other endpoint for activity. In a loop like this it's important to sleep at regular intervals so your background work doesn't monopolise CPU resources.
 
 2.  When the sample ends, background workers are cancelled (which results in a cancelled error being raised in the worker). Therefore, if you need to do cleanup in your worker it should occur in a `finally` block.
 

--- a/docs/intervention.qmd
+++ b/docs/intervention.qmd
@@ -102,7 +102,7 @@ In some cases you may want agents to initiate intervention. You can do this by p
 
 ### Ask User Tool
 
-The `ask_user()` tool enables models to request structured information from users. It uses the the [ACP Elicitation](https://agentclientprotocol.com/rfds/elicitation) standard, which provides for a variety of field types (text, boolean, enum, etc.)
+The `ask_user()` tool enables models to request structured information from users. It uses the [ACP Elicitation](https://agentclientprotocol.com/rfds/elicitation) standard, which provides for a variety of field types (text, boolean, enum, etc.)
 
 For example, here we add `ask_user()` to a `react()` agent:
 


### PR DESCRIPTION
Two doubled-word typos in the docs pages:

- `docs/intervention.qmd:105`: "It uses the the [ACP Elicitation](…) standard"
- `docs/agent-custom.qmd:450`: "often polling a a sandbox or other endpoint"

Docs-only, one word removed per line.