### PR TITLE
Fix on_model_usage hook always reporting 0 HTTP retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Hooks: `on_model_usage` now reports the HTTP retries that occurred within the model call, which was previously always 0.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -263,7 +263,12 @@ class ModelUsageData:
     task_name: str | None = None
     """The name of the task that generated this usage (if any)."""
     retries: int = 0
-    """The number of HTTP retries made before the successful call."""
+    """The number of HTTP retries made within the successful model call.
+
+    Retries made by Inspect's outer retry loop, and those made within
+    attempts that failed, are not counted -- so this plus the number of
+    `on_model_retry` firings is not the call's total.
+    """
 
 
 @dataclass(frozen=True)
@@ -937,7 +942,7 @@ async def emit_sample_attempt_end(
 
 
 async def emit_model_usage(
-    model_name: str, usage: ModelUsage, call_duration: float
+    model_name: str, usage: ModelUsage, call_duration: float, retries: int
 ) -> None:
     from inspect_ai.log._samples import sample_active
 
@@ -947,19 +952,11 @@ async def emit_model_usage(
     run_id: str | None = None
     eval_id: str | None = None
     task_name: str | None = None
-    retries: int = 0
     if active is not None:
         eval_set_id = active.eval_set_id
         run_id = active.run_id
         eval_id = active.eval_id
         task_name = active.task
-
-    # Read retry count from the active model event (if available).
-    from inspect_ai.log._samples import _active_model_event
-
-    model_event = _active_model_event.get()
-    if model_event is not None and model_event.retries is not None:
-        retries = model_event.retries
 
     data = ModelUsageData(
         model_name=model_name,

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1653,9 +1653,13 @@ class Model:
             if output.usage:
                 record_and_check_model_usage(self, output.usage, role=self.role)
 
-                # send telemetry to hooks
+                # retries must come from `event`: this frame is outside
+                # track_active_model_event, so the contextvar is unset here
                 await emit_model_usage(
-                    model_name=str(self), usage=output.usage, call_duration=output.time
+                    model_name=str(self),
+                    usage=output.usage,
+                    call_duration=output.time,
+                    retries=event.retries or 0,
                 )
                 await send_telemetry_legacy(
                     "model_usage",

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -224,6 +224,38 @@ def test_can_subscribe_to_events_with_multiple_hooks(
         assert len(h.before_model_generate_events) == 1
 
 
+def test_model_usage_hook_reports_http_retries(mock_hooks: MockHooks) -> None:
+    from inspect_ai._util.retry import report_http_retry
+    from inspect_ai.model import (
+        ChatMessage,
+        GenerateConfig,
+        ModelOutput,
+        ModelUsage,
+        get_model,
+    )
+    from inspect_ai.tool import ToolChoice, ToolInfo
+
+    def custom_output(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        # real providers report retries from inside generate()
+        report_http_retry()
+        report_http_retry()
+        output = ModelOutput.from_content(model="mockllm", content="ok")
+        output.usage = ModelUsage(input_tokens=1, output_tokens=1, total_tokens=2)
+        return output
+
+    eval(
+        Task(dataset=[Sample("sample_1")]),
+        model=get_model("mockllm/model", custom_outputs=custom_output),
+    )
+
+    assert [event.retries for event in mock_hooks.model_usage_events] == [2]
+
+
 def test_model_retry_hook(mock_hooks: MockHooks) -> None:
     import anyio
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`ModelUsageData.retries`, delivered to every registered hook via `Hooks.on_model_usage()`, is
always `0`. It has never reported anything else since the field was added in #3491, so any hook
using it to spot model calls that fought the provider sees nothing.

`emit_model_usage()` reads the count from the `_active_model_event` ContextVar, but its only
call site in `Model._generate.generate()` runs *after* the `with track_active_model_event(event)`
block has exited, so the ContextVar is always unset by then and the count falls back to its `0`
default.

This surfaced while investigating rate-limit backpressure: a proposed decision rule keyed on
`retries == 0` turned out to be a no-op, because the field is `0` unconditionally.

### What is the new behavior?

`emit_model_usage()` takes the count as a parameter, and the call site passes it from the
`ModelEvent` it already holds. The ContextVar indirection is deleted.

A hook now sees the HTTP retries that occurred inside the successful provider call — provider
SDK retries surfaced through `HttpxHooks`, and `chatapi`'s inner retry loop.

The field's docstring is narrowed to say what it actually counts. Two categories are *not*
included, and both were verified by reproduction rather than inspection:

- Retries driven by Inspect's outer retry loop. `Model.should_retry` runs after
  `track_active_model_event` has reset the ContextVar, and each attempt builds a fresh
  `ModelEvent`, so those retries land on no event at all.
- Retries made inside attempts that *failed*. `emit_model_usage` only runs for the attempt that
  succeeds.

Consequently `ModelUsageData.retries` plus the number of `on_model_retry` firings is **not** the
call's total — the two are disjoint but not exhaustive. Measured on a 3-attempt call with one
inner retry per attempt: 5 real retries, `on_model_retry` fires twice, the field reports 1, and
the naive sum gives 3. The docstring now warns about this explicitly, since summing them is the
obvious thing to reach for and it silently under-reports during exactly the provider incident a
consumer cares about.

Deliberately *not* changed: the field is left per-call rather than widened to cover the whole
logical `generate()`. `ModelUsageData`'s sibling fields are already attempt-scoped by explicit
prior contract (`call_duration` is documented as the successful call's duration; `usage` is the
winning attempt's usage), so widening one field would leave a record whose three numeric fields
no longer share a denominator. The complete per-sample totals already exist on
`ActiveSample.http_retries` and `http_retries_count()`, and per-model rate-limit-vs-transient
counts exist on the throughput registry.

### Does this PR introduce a breaking change?

No. A consumer relying on the constant `0` was relying on a bug. `ModelUsageData` is not
serialized, appears in no schema, and reaches no persisted surface — no eval log record, no
OpenAPI type, no dataframe column, no ts-mono type. `emit_model_usage` is private with a single
call site.

### Other information:

Production code is +13/−12; the rest of the diff is the test and one CHANGELOG line.

#### Verification

New test in `tests/hooks/test_hooks.py` fails against the pre-fix tree with `assert [0] == [2]`
and passes with the change. Also checked by hand: a clean call reports `0`, and a call with two
in-attempt retries reports `2`.

- `pytest tests/hooks tests/model tests/log tests/util/test_adaptive_concurrency.py` — all pass
- `mypy --exclude tests/test_package src tests` — clean (1452 files)
- `ruff check` / `ruff format` — clean

#### Slow tests

The change touches the model generate/retry path but adds no async structure (no task groups,
cancellation, or bridges) and touches no provider, tool, sandbox, or agent code. Ran the trio
variants for the affected areas:

```
pytest --runtrio tests/hooks tests/model
715 passed, 3238 skipped
```

(The skips are the non-trio variants, which `--runtrio` excludes by design, plus tests gated on
Docker or provider keys.)

Not run: `--runslow` and `--runapi`. No provider, tool, or sandbox code is touched, so neither
class covers this change.

#### Pre-existing miscounts this makes visible

Two upstream issues inflate the number this field now reports. Both predate the change, live in
code it does not touch, and are left alone here (one issue per PR) — but they are worth knowing
about, since this PR is what makes them observable through a hook.

1. **Anthropic `pause_turn` continuations are counted as retries.** `request_id` is allocated once
   per `generate()` (`_providers/anthropic.py:508`) and the continuation reuses it
   (`tail_request = dict(request)`, `_providers/anthropic.py:906`), so
   `HttpxHooks.update_request_time` sees `new_attempts > 1` and reports a retry
   (`_providers/util/hooks.py:157-161`). Reproduced with a mock transport: two `200` responses,
   zero real retries, one counted. Verified pre-existing — `http_retries_count()` reports the same
   phantom retry with this change reverted. It also affects `ActiveSample.http_retries`,
   `ModelEvent.retries`, and `_request_had_retry` (which suppresses adaptive scale-up), so any
   generate using Anthropic server-side tools is affected today.
2. **Batch admin-op retries are attributed to whichever request started the shared worker.** The
   `Batcher` worker is spawned from inside `track_active_model_event`, pinning request #1's
   `ModelEvent` for its lifetime; requests #2..N see zero. `_retry.py:185-198` already documents
   this hazard as the reason admin ops pass `report_retry_wait=False`.

#### Agent review

- Reviewer: Claude Opus 5, fresh context, 5 parallel reviewers across separate dimensions
  (value-correctness, regression, concurrency, test quality, docs/contract), each finding then
  adversarially verified by 2 further agents instructed to refute it — 29 agents total.
- Findings: 12 raw, 11 dismissed on verification (pre-existing, unreachable, or style). 1
  confirmed and reproduced: the outer-retry-loop gap described above. Fixed by narrowing the
  docstring rather than widening the field.
- A separate 3-agent panel then argued the widen-vs-keep question from the consumer,
  implementation-cost, and contract-coherence angles. All three independently recommended
  keeping per-call semantics. The implementation angle priced widening at +16/−3 in one file and
  still advised against it, on the grounds that the resulting number would disagree with every
  persisted surface. That panel also corrected an incorrect claim made by one of its own members
  (that the two hooks sum to the total); the correction was reproduced before being accepted.
- Second reviewer: OpenAI `gpt-6-astra` via codex CLI (fresh context, different model family,
  xhigh reasoning). Reproduced two telemetry-correctness findings, both listed above as
  pre-existing: the batch attribution issue and the Anthropic continuation miscount. The latter
  was new to this review; I reproduced it independently and confirmed it predates the change.
  It raised no defect in the change itself.
- The Claude reviews share a model with the author; the codex pass does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
