### PR TITLE
docs: rewrite web browser README to match the actual implementation

### DIFF
--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/README.md
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/README.md
@@ -6,15 +6,15 @@ This directory contains an implementation for the Headless Browser Tool which ca
 
 #### 1. Start the Docker container
 
-A web server with the headless browser will be launched automatically on starting of the docker container and will be ready to receive client requests.
+A JSON-RPC server exposing the headless browser will be launched automatically on starting of the docker container and will be ready to receive client requests.
 
 #### 2. Send the command
 
-Use the following format:
+The tool is driven through the inspect-tool-support CLI (the `web_*` commands below are dispatched over JSON-RPC by the server — see `json_rpc_methods.py`, `controller.py`, and `playwright_browser.py` in this directory):
 
 ```
 # Inside the Docker container
-$ python web_client.py [COMMAND] [args]
+$ inspect-tool-support [COMMAND] [args]
 ```
 
 ###### Commands
@@ -44,20 +44,8 @@ web_at: <accessibility tree of the visible elements of the page>
 
 ### Design
 
-The following diagram describes the design and the intended usage of the tool:
-
-![diagram](images/usage_diagram.svg)
-
 The tool consists of the following components:
 
-- [WebServer](web_server.py) - a server which launches a stateful session with the headless chromium browser and interacts with it through the [Playwright API](https://playwright.dev/python/docs/intro) upon receiving client commands. The server components are:
-
-  - _dm_env_servicer.py_ - an implementation for the gRPC Service based on [dm_env_rpc protocol](https://github.com/google-deepmind/dm_env_rpc).
-  - _web_environment.py_ - an environment which gets instantiated by the servicer and which launches the browser, stores its state and maps client commands to Playwright API.
-  - _playwright_crawler.py_ - a wrapper over the sync Playwright API.
-
-- [WebClient](web_client.py) - a simple stateless client to interact with the server. When launched, the client:
-  1. creates a connection with the server;
-  2. sends user command to the server;
-  3. receives the response in the form of observations and prints them to stdout;
-  4. Destroys the connection.
+- _json_rpc_methods.py_ - JSON-RPC method definitions exposed to the client.
+- _controller.py_ - the controller that maps incoming commands to browser actions.
+- _playwright_browser.py_ - a wrapper over the sync Playwright API driving the headless chromium browser.


### PR DESCRIPTION
### This PR

The Headless Browser Tool README referenced files that don't exist at this path — `python web_client.py [COMMAND]` usage, `[WebServer](web_server.py)` / `[WebClient](web_client.py)` links, and `_dm_env_servicer.py` / `_web_environment.py` components (`git log --all --diff-filter=D` shows those files were never part of the history here). Rewrote the usage and design sections to describe the actual JSON-RPC architecture:

- entry point: the `inspect-tool-support` CLI → `json_rpc_methods.py`, `controller.py`, `playwright_browser.py` (the same components the earlier sections of this directory use)

### Checklist

- [x] Documentation-only change (single README, well under 25 lines of net change)
- [x] Every file name referenced now verified via `git ls-files`