### PR TITLE
fix(_util): pass unknown template placeholders through unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
 - Sandboxes: Compose files using long syntax volume mounts, `pids_limit`, `read_only`, `cgroup`, `stop_grace_period`, `build.no_cache`, or `build.pull` no longer fail validation when starting an eval.
+- Solver: Prompt templates now leave an unresolved `{placeholder}` exactly as written, including its `!conversion` and `:format spec`. Previously an unescaped JSON example such as `{"answer": "value"}` was silently rearranged (and `{"ok":1}` lost its value), so an eval could run with a corrupted prompt; a template placeholder that looks like a variable name (e.g. a typo'd `{promt}`) now also logs a one-time warning. (#5256)
 
 ## 0.3.263 (03 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Solver: Prompt templates now leave an unresolved `{placeholder}` exactly as written, including its `!conversion` and `:format spec`. Previously an unescaped JSON example such as `{"answer": "value"}` was silently rearranged (and `{"ok":1}` lost its value), so an eval could run with a corrupted prompt; a template placeholder that looks like a variable name (e.g. a typo'd `{promt}`) now also logs a one-time warning. (#5256)
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/_util/format.py
+++ b/src/inspect_ai/_util/format.py
@@ -1,7 +1,13 @@
 import pprint
+import re
+from logging import getLogger
 from string import Formatter
 from textwrap import indent
 from typing import Any
+
+from inspect_ai._util.logger import warn_once
+
+logger = getLogger(__name__)
 
 
 def format_function_call(
@@ -64,35 +70,86 @@ def format_template(
     """
 
     class SafeFormatter(Formatter):
-        def get_field(self, field_name: str, args: Any, kwargs: Any) -> Any:
-            try:
-                # Handle array indexing and nested attributes
-                first, rest = (
-                    field_name.split(".", 1)
-                    if "." in field_name
-                    else (field_name, None)
-                )
-                first = first.split("[")[0]  # Remove any array indexing for the check
+        def vformat(self, format_string: str, args: Any, kwargs: Any) -> str:
+            result: list[str] = []
+            for literal_text, field_name, format_spec, conversion in self.parse(
+                format_string
+            ):
+                if literal_text:
+                    result.append(literal_text)
 
-                if first not in params and skip_unknown:
-                    return "{" + field_name + "}", field_name
+                if field_name is None:
+                    continue
 
-                obj = params.get(first)
-                if obj is None and skip_unknown:
-                    return "{" + field_name + "}", field_name
+                # reconstruct the placeholder exactly as it was written, so an
+                # unresolvable field passes through byte-for-byte (including its
+                # !conversion and :format_spec)
+                original = _render_field(field_name, format_spec, conversion)
 
-                return super().get_field(field_name, args, kwargs)
-            except (AttributeError, KeyError, IndexError) as e:
-                if skip_unknown:
-                    return "{" + field_name + "}", field_name
-                raise KeyError(f"Failed to format field '{field_name}'") from e
+                if not self._resolvable(field_name):
+                    if skip_unknown:
+                        _warn_unresolved(field_name)
+                        result.append(original)
+                        continue
+                    raise KeyError(f"Failed to format field '{field_name}'")
 
-        def format_field(self, value: Any, format_spec: str) -> Any:
-            try:
-                return super().format_field(value, format_spec)
-            except (ValueError, TypeError):
-                if skip_unknown:
-                    return "{" + str(value) + ":" + format_spec + "}"
-                raise
+                try:
+                    obj = super().get_field(field_name, args, kwargs)[0]
+                    obj = self.convert_field(obj, conversion)
+                    # a format spec may itself contain placeholders
+                    spec = self.vformat(format_spec or "", args, kwargs)
+                    result.append(self.format_field(obj, spec))
+                except (
+                    AttributeError,
+                    KeyError,
+                    IndexError,
+                    ValueError,
+                    TypeError,
+                ) as e:
+                    if skip_unknown:
+                        _warn_unresolved(field_name)
+                        result.append(original)
+                    else:
+                        raise KeyError(f"Failed to format field '{field_name}'") from e
+
+            return "".join(result)
+
+        def _resolvable(self, field_name: str) -> bool:
+            """Whether field_name's root refers to a supplied param."""
+            first = field_name.split(".", 1)[0].split("[", 1)[0]
+            return first in params and params.get(first) is not None
 
     return SafeFormatter().format(template, **params)
+
+
+def _render_field(
+    field_name: str, format_spec: str | None, conversion: str | None
+) -> str:
+    """Rebuild the original `{field!conv:spec}` text of a parsed placeholder.
+
+    `str.Formatter.parse()` reports an absent spec and an empty one identically,
+    so a redundant trailing colon (`{x:}`) round-trips as `{x}`. The two format
+    the same, so this is a normalization rather than a loss.
+    """
+    text = "{" + field_name
+    if conversion:
+        text += "!" + conversion
+    if format_spec:
+        text += ":" + format_spec
+    return text + "}"
+
+
+# a field name that looks like an identifier path is most likely a typo'd or
+# missing param, whereas JSON-ish braces (quoted/spaced/etc.) are almost always
+# literal content the author meant to keep
+_VARIABLE_FIELD = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:[.\[][^{}]*)?$")
+
+
+def _warn_unresolved(field_name: str) -> None:
+    if _VARIABLE_FIELD.match(field_name):
+        warn_once(
+            logger,
+            f"Template contains placeholder '{{{field_name}}}' which does not "
+            "match any provided parameter; it will be left as-is. Use "
+            "'{{' and '}}' to escape literal braces.",
+        )

--- a/tests/util/test_format_template.py
+++ b/tests/util/test_format_template.py
@@ -188,3 +188,103 @@ def test_complex_nested_structures() -> None:
     for case in test_cases:
         result = format_template(case.template, case.params)
         assert result == case.expected
+
+
+def test_unescaped_json_braces_pass_through() -> None:
+    """Unescaped JSON-style braces are preserved rather than rewritten (#5256)."""
+    test_cases: list[FormatterCase] = [
+        # a space after the colon makes the remainder parse as a format spec
+        FormatterCase(
+            params={},
+            template='Return output in JSON format: {"answer": "value"}.',
+            expected='Return output in JSON format: {"answer": "value"}.',
+        ),
+        # without the space the spec is a valid width, which silently
+        # swallowed the value before the fix
+        FormatterCase(
+            params={},
+            template='Emit {"ok":1} on success.',
+            expected='Emit {"ok":1} on success.',
+        ),
+        FormatterCase(
+            params={"prompt": "Q"},
+            template='{prompt} -> {"a": 1, "b": 2}',
+            expected='Q -> {"a": 1, "b": 2}',
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_unknown_placeholder_preserves_format_spec() -> None:
+    """An unknown placeholder keeps its format spec and conversion verbatim."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(params={}, template="{custom:>10}", expected="{custom:>10}"),
+        FormatterCase(params={}, template="{missing!r}", expected="{missing!r}"),
+        FormatterCase(params={}, template="{missing!s:^8}", expected="{missing!s:^8}"),
+        FormatterCase(
+            params={"known": "v"},
+            template="{known} {other:.2f}",
+            expected="v {other:.2f}",
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_escaped_braces_still_supported() -> None:
+    """The {{ }} escaping introduced alongside #5174 keeps working."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={},
+            template='Return output in JSON format: {{"answer": "value"}}.',
+            expected='Return output in JSON format: {"answer": "value"}.',
+        ),
+        FormatterCase(
+            params={"name": "John"},
+            template="{{name}} {name}",
+            expected="{name} John",
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_nested_format_spec_still_expands() -> None:
+    """A format spec that references another param is still expanded."""
+    result = format_template("{value:>{width}}", {"value": "a", "width": 4})
+    assert result == "   a"
+
+
+def test_warns_for_variable_like_placeholder(caplog) -> None:
+    """An unresolved identifier-shaped placeholder warns (likely a typo)."""
+    import logging
+
+    from inspect_ai._util import logger as logger_module
+
+    logger_module._warned.clear()
+    with caplog.at_level(logging.WARNING):
+        result = format_template("Answer the {promt} carefully.", {})
+
+    assert result == "Answer the {promt} carefully."
+    assert any("promt" in record.message for record in caplog.records)
+
+
+def test_no_warning_for_json_braces(caplog) -> None:
+    """JSON-style braces are literal content and must not warn."""
+    import logging
+
+    from inspect_ai._util import logger as logger_module
+
+    logger_module._warned.clear()
+    with caplog.at_level(logging.WARNING):
+        result = format_template('Emit {"ok": 1} now.', {})
+
+    assert result == 'Emit {"ok": 1} now.'
+    assert not caplog.records


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #5256

### What is the current behavior?

`format_template()` rebuilt an unresolvable placeholder inside `get_field()`, returning the literal text `{name}`. But `Formatter._vformat()` applies the `!conversion` and `:format_spec` *after* `get_field()` returns, so that rebuilt text was then formatted as if it were a value. Unknown placeholders were silently rewritten rather than passed through:

```python
from inspect_ai._util.format import format_template

format_template('Return output in JSON format: {"answer": "value"}.', {})
# 'Return output in JSON format: {{"answer"}: "value"}.'

format_template('Emit {"ok":1} on success.', {})
# 'Emit {"ok"} on success.'          <- value silently dropped
```

`{"answer": "value"}` parses as field `"answer"` with format spec `" value"`; `{"ok":1}` parses with spec `1`, which is a *valid* width, so `str.__format__` applies it without error and the value disappears.

The same root cause affected two cases not in the issue:

```python
format_template("{custom:>10}", {})   # '  {custom}'   <- spec dropped
format_template("{thing!r}", {})      # "'{thing}'"    <- conversion applied
```

Since #5174 removed the `KeyError`, an eval runs with the corrupted prompt and no signal. This contradicts the docstring and the #5166 changelog line, which both promise unknown placeholders pass through unchanged.

### What is the new behavior?

Resolution moves to the parse level (`vformat`), which is the only place the original field name, `!conversion` and `:format_spec` are all still available together and unmodified. When a field can't be resolved, that exact text is re-emitted:

```python
format_template('Return output in JSON format: {"answer": "value"}.', {})
# 'Return output in JSON format: {"answer": "value"}.'

format_template('Emit {"ok":1} on success.', {})
# 'Emit {"ok":1} on success.'

format_template("{custom:>10}", {})   # '{custom:>10}'
format_template("{thing!r}", {})      # '{thing!r}'
```

The format spec is expanded only for fields that *do* resolve, so nested specs such as `{value:>{width}}` keep working. Reconstructing from the original spec (rather than the recursively-expanded one `format_field` receives) is what makes this correct.

Per the direction on the issue, this also warns once per message when an unresolved placeholder looks like a variable name — catching a typo'd `{promt}` or a missing param. JSON-style field names are quoted or spaced, so they don't match and don't warn.

`skip_unknown=False` still raises `KeyError`.

Tests cover both JSON cases from the issue (with and without the space), `{custom:>10}` pass-through, conversions, nested specs, that the `{{ }}` escaping from #5174 still works, and both warning behaviors.

### Does this PR introduce a breaking change?

No. Substitution of known params, format specs, conversions, nested attribute/index access and `{{ }}` escaping are unchanged — the existing tests pass untouched. The only behavior change is that placeholders which previously came out mangled now come out verbatim, which is what the docstring already promised.

Two incidental improvements fall out of the same fix: `{}` and `{0}` now pass through as literal text instead of raising `IndexError` / being rewritten to `{0}` (`format_template` takes no positional args, so neither could ever resolve).

### Other information:

`{x:}` — a placeholder with a redundant empty format spec — normalizes to `{x}`, because `Formatter.parse()` reports an absent spec and an empty one identically (both `''`). The two format the same, so this is a normalization rather than a loss; noted in a docstring.

Verified `tests/util/test_format_template.py` (19 passed, including 6 new) and the full `tests/solver/` suite (97 passed) locally. The warning test was mutation-checked: it fails if the warning is removed. Unrelated pre-existing failures in `tests/util/test_file.py`, `test_subprocess.py` and `test_sandbox_service.py` reproduce with this change stashed (Windows path/`find` artifacts on my machine).
