### PR TITLE
Reject sandbox-tools binaries that fail SHA256 verification instead of running them with a warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,9 +519,6 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
-          # Digest verification is warning-only by default during its soft
-          # launch; CI exercises strict mode.
-          INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS: 1
         run: uv run pytest --runslow -m slow tests/tools/ -x
 
       - name: Minimize uv cache
@@ -624,9 +621,6 @@ jobs:
           # the non-dev name; _check_main_divergence would otherwise return
           # "edited" on this PR (version.txt differs from main).
           INSPECT_SANDBOX_TOOLS_INSTALL_STATE: clean
-          # Digest verification is warning-only by default during its soft
-          # launch; CI exercises strict mode.
-          INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS: 1
         run: uv run pytest --runslow -m slow tests/tools/ -x
 
       - name: Minimize uv cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
 - Sandboxes: Compose files using long syntax volume mounts, `pids_limit`, `read_only`, `cgroup`, `stop_grace_period`, `build.no_cache`, or `build.pull` no longer fail validation when starting an eval.
+- Sandbox Tools: Binaries downloaded from S3 that fail SHA256 verification or lack a pinned digest are now rejected instead of run with a warning; `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` has been removed.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -583,16 +583,6 @@ def _binaries_dir() -> Path:
     return Path(inspect_ai.__file__).parent / "binaries"
 
 
-# Soft launch of digest verification: failures warn by default and are fatal
-# only when this env var is set (any value other than "", "0", "false"). A
-# follow-on release makes them fatal unconditionally and removes the var.
-STRICT_DIGESTS_VAR = "INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS"
-
-
-def _strict_digests() -> bool:
-    return os.environ.get(STRICT_DIGESTS_VAR, "").lower() not in ("", "0", "false")
-
-
 async def _download_from_s3(filename: str) -> bool:
     """Download executable from S3, verified against the vendored SHA256SUMS.
 
@@ -600,25 +590,20 @@ async def _download_from_s3(filename: str) -> bool:
     (403/404 — not yet published; the caller falls through to the local-build
     tier). A digest mismatch or a missing sums entry must never be conflated
     with "missing" — they are the tampering/corruption signals this
-    verification exists to surface. With ``STRICT_DIGESTS_VAR`` set they raise
-    (reaching the user wrapped in SandboxInjectionError); by default they log
-    a warning and the unverified bytes are used anyway.
+    verification exists to surface. They raise ``PrerequisiteError`` (reaching
+    the user wrapped in SandboxInjectionError) with nothing written to the
+    binaries directory.
     """
-    expected_sha256: str | None
     try:
         # Raises if the sums file is unreadable or has no entry for this name —
         # deliberately before any network I/O.
         expected_sha256 = lookup_digest(filename)
     except RuntimeError as e:
-        if _strict_digests():
-            raise
-        warn_once(
-            logger,
-            f"Sandbox tools digest lookup failed ({e}); downloading without "
-            f"verification. This will become a fatal error in a future "
-            f"release; set {STRICT_DIGESTS_VAR}=1 to make it fatal now.",
-        )
-        expected_sha256 = None
+        raise PrerequisiteError(
+            f"Cannot verify sandbox tools executable {filename}: {e} If "
+            f"reinstalling inspect_ai does not resolve this, report it to the "
+            f"inspect_ai maintainers rather than retrying."
+        ) from e
 
     binaries_path = _binaries_dir()
     binaries_path.mkdir(exist_ok=True)
@@ -626,38 +611,21 @@ async def _download_from_s3(filename: str) -> bool:
     url = f"{_BUCKET_BASE_URL}/{filename}"
 
     try:
-        if expected_sha256 is not None:
-            try:
-                await anyio.to_thread.run_sync(
-                    _download_and_verify_blocking,
-                    url,
-                    expected_sha256,
-                    executable_path,
-                )
-                return True
-            except ValueError as e:
-                message = (
-                    f"Digest verification failed for {filename} downloaded from "
-                    f"S3: {e}. The published artifact does not match the digest "
-                    f"pinned in this inspect_ai release, which may indicate a "
-                    f"compromised or corrupted artifact — please report this to "
-                    f"the inspect_ai maintainers rather than retrying."
-                )
-                if _strict_digests():
-                    raise PrerequisiteError(message) from e
-                warn_once(
-                    logger,
-                    f"{message} Proceeding with the unverified artifact. This "
-                    f"will become a fatal error in a future release; set "
-                    f"{STRICT_DIGESTS_VAR}=1 to make it fatal now.",
-                )
-        # Unverified download — no pinned digest, or verification failed and
-        # strict mode is off (download() discarded the mismatching bytes, so
-        # fetch again without verification).
         await anyio.to_thread.run_sync(
-            _download_unverified_blocking, url, executable_path
+            _download_and_verify_blocking,
+            url,
+            expected_sha256,
+            executable_path,
         )
         return True
+    except ValueError as e:
+        raise PrerequisiteError(
+            f"Digest verification failed for {filename} downloaded from "
+            f"S3: {e}. The published artifact does not match the digest "
+            f"pinned in this inspect_ai release, which may indicate a "
+            f"compromised or corrupted artifact — please report this to "
+            f"the inspect_ai maintainers rather than retrying."
+        ) from e
     except httpx.HTTPStatusError as e:
         if e.response.status_code in (403, 404):
             print(f"Executable '{filename}' not found on S3")
@@ -683,29 +651,6 @@ def _download_and_verify_blocking(url: str, sha256: str, dest: Path) -> None:
     tmp = Path(tmp_path)
     try:
         download(url, sha256, tmp, timeout=60)
-        tmp.chmod(0o755)
-        os.replace(tmp, dest)
-    finally:
-        tmp.unlink(missing_ok=True)
-
-
-def _download_unverified_blocking(url: str, dest: Path) -> None:
-    """Download ``url`` to ``dest`` with no digest check (blocking).
-
-    Soft-launch fallback only (see ``_download_from_s3``). Same unique-tempfile
-    + ``os.replace`` discipline as ``_download_and_verify_blocking``.
-
-    Raises ``httpx.HTTPStatusError`` on HTTP errors (no transient retries).
-    """
-    fd, tmp_path = tempfile.mkstemp(prefix=f"{dest.name}.", dir=dest.parent)
-    os.close(fd)
-    tmp = Path(tmp_path)
-    try:
-        with httpx.stream("GET", url, timeout=60, follow_redirects=True) as response:
-            response.raise_for_status()
-            with open(tmp, "wb") as f:
-                for chunk in response.iter_bytes():
-                    f.write(chunk)
         tmp.chmod(0o755)
         os.replace(tmp, dest)
     finally:

--- a/src/inspect_sandbox_tools/design/RELEASING.md
+++ b/src/inspect_sandbox_tools/design/RELEASING.md
@@ -77,7 +77,7 @@ The script refuses to run unless `{VERSION}` matches the committed `sandbox_tool
 
 Commit the rewritten `SHA256SUMS` to the release PR branch (the upload script prints the exact commands). The digests must land in the same PR as the version bump: every consumer (runtime S3 download, `pypi-release.py`, the `slow-tool-tests-release` CI gate) verifies fetched bytes against them, and the release gate stays red until both the upload completes and the sums are pushed.
 
-Fail-closed window: while a version bump is merged (or installed non-editably from the PR branch) with the sums not yet rewritten, clean/pypi runtime downloads treat the missing sums entry as an integrity failure (fatal with `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` set, a warning by default during the digest soft launch). Once the rewritten sums are committed but before the S3 objects land, downloads 404 and fall back to the local-build prompt; the upload-before-commit ordering makes that window hard to reach. After upload, a digest mismatch anywhere is a stop-the-line signal — investigate; never re-upload over a published object.
+Fail-closed window: while a version bump is merged (or installed non-editably from the PR branch) with the sums not yet rewritten, clean/pypi runtime downloads treat the missing sums entry as a fatal integrity failure. Once the rewritten sums are committed but before the S3 objects land, downloads 404 and fall back to the local-build prompt; the upload-before-commit ordering makes that window hard to reach. After upload, a digest mismatch anywhere is a stop-the-line signal — investigate; never re-upload over a published object.
 
 ### 7. Merge the PR
 

--- a/tests/tools/sandbox_tools_utils/test_sandbox_tools_digests.py
+++ b/tests/tools/sandbox_tools_utils/test_sandbox_tools_digests.py
@@ -158,7 +158,6 @@ async def test_download_from_s3_mismatch_raises_and_caches_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     filename = "inspect-sandbox-tools-amd64-v999"
-    monkeypatch.setenv(sandbox_module.STRICT_DIGESTS_VAR, "1")
     monkeypatch.setattr(sandbox_module, "_binaries_dir", lambda: tmp_path)
     monkeypatch.setattr(sandbox_module, "lookup_digest", lambda name: "0" * 64)
 
@@ -168,29 +167,7 @@ async def test_download_from_s3_mismatch_raises_and_caches_nothing(
             await sandbox_module._download_from_s3(filename)
 
     assert list(tmp_path.iterdir()) == []
-
-
-async def test_download_from_s3_mismatch_warns_and_proceeds_by_default(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    filename = "inspect-sandbox-tools-amd64-v999"
-    monkeypatch.delenv(sandbox_module.STRICT_DIGESTS_VAR, raising=False)
-    monkeypatch.setattr(sandbox_module, "_binaries_dir", lambda: tmp_path)
-    monkeypatch.setattr(sandbox_module, "lookup_digest", lambda name: "0" * 64)
-
-    # First response feeds the (failing) verified attempt; second feeds the
-    # unverified re-fetch. Patching httpx.stream via either importer patches
-    # the shared httpx module attribute, so one patch covers both call sites.
-    stream_mock = _stream_factory(
-        _FakeStream(200, b"tampered bytes"), _FakeStream(200, b"tampered bytes")
-    )
-    with patch("inspect_ai._util.download.httpx.stream", stream_mock):
-        assert await sandbox_module._download_from_s3(filename) is True
-
-    dest = tmp_path / filename
-    assert dest.read_bytes() == b"tampered bytes"
-    assert dest.stat().st_mode & 0o755 == 0o755
-    assert [p.name for p in tmp_path.iterdir()] == [filename]
+    stream_mock.assert_called_once()
 
 
 async def test_download_from_s3_404_returns_false(
@@ -212,7 +189,6 @@ async def test_download_from_s3_missing_sums_entry_raises_without_network(
 ) -> None:
     sums = tmp_path / "SHA256SUMS"
     write_sha256sums({"some-other-file": "d" * 64}, sums)
-    monkeypatch.setenv(sandbox_module.STRICT_DIGESTS_VAR, "1")
     monkeypatch.setattr(sandbox_module, "_binaries_dir", lambda: tmp_path)
     monkeypatch.setattr(
         sandbox_module, "lookup_digest", lambda name: lookup_digest(name, sums)
@@ -220,33 +196,11 @@ async def test_download_from_s3_missing_sums_entry_raises_without_network(
 
     stream_mock = _stream_factory()
     with patch("inspect_ai._util.download.httpx.stream", stream_mock):
-        with pytest.raises(RuntimeError, match="No SHA256 entry"):
+        with pytest.raises(PrerequisiteError, match="No SHA256 entry"):
             await sandbox_module._download_from_s3("inspect-sandbox-tools-amd64-v999")
 
     stream_mock.assert_not_called()
-
-
-async def test_download_from_s3_missing_sums_entry_warns_and_downloads_by_default(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    filename = "inspect-sandbox-tools-amd64-v999"
-    sums = tmp_path / "SHA256SUMS"
-    write_sha256sums({"some-other-file": "d" * 64}, sums)
-    monkeypatch.delenv(sandbox_module.STRICT_DIGESTS_VAR, raising=False)
-    monkeypatch.setattr(sandbox_module, "_binaries_dir", lambda: tmp_path)
-    monkeypatch.setattr(
-        sandbox_module, "lookup_digest", lambda name: lookup_digest(name, sums)
-    )
-
-    content = b"unverified binary bytes"
-    stream_mock = _stream_factory(_FakeStream(200, content))
-    with patch("inspect_ai._util.download.httpx.stream", stream_mock):
-        assert await sandbox_module._download_from_s3(filename) is True
-
-    dest = tmp_path / filename
-    assert dest.read_bytes() == content
-    assert dest.stat().st_mode & 0o755 == 0o755
-    assert sorted(p.name for p in tmp_path.iterdir()) == ["SHA256SUMS", filename]
+    assert [p.name for p in tmp_path.iterdir()] == ["SHA256SUMS"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## This PR contains:
- [x] Other (change in security posture)

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#446.

Digest verification of the sandbox-tools binary fetched from S3 is warning-only unless `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` is set. On a digest mismatch or a missing pinned digest the binary is re-fetched with no verification, cached in the package's binaries directory, and run as root inside every sandbox.

### What is the new behavior?

- A digest mismatch or a missing/unreadable `SHA256SUMS` entry is fatal (`PrerequisiteError`, surfaced through `SandboxInjectionError`). Nothing is written to the binaries directory and there is no second fetch.
- The unverified download fallback and `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` are removed; the CI jobs that set it no longer do.
- A 403/404 (artifact not yet published) still falls through to the local-build tier, unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes. An eval whose sandbox-tools download fails verification now errors instead of running the artifact with a warning. Setting `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` no longer has any effect and can be removed.

### Other information:

* Out of scope: re-verifying artifacts already cached in `binaries/`. Only pre-verification releases could cache unverified bytes, all under the current v29 name or earlier; the resolver opens only the artifact named for the current version, so the next version bump retires them. Beyond that, altering the cache requires host filesystem write access, which is outside the threat model.
* We _could_ add a `INSPECT_SANDBOX_TOOLS_ALLOW_UNVERIFIED` env var, but I'm not aware of a use case that merits this. We have the opportunity to add this in a later PR if need be.

### Agent review
- Authored with Claude Fable 5.1 (Claude Code); design decisions (drop the env var outright, missing entry fatal, `PrerequisiteError` for both paths, snapshot design doc left untouched) made by the maintainer.
- Pass 1: Claude Fable 5.1 subagent, fresh context, read-only. 8 findings, no blockers: 5 fixed (error message ordering, CHANGELOG wording, three doc nits later mooted by leaving `BINARY_INTEGRITY.md` identical to main), 1 addressed (slow-test reporting, below), 2 dismissed (a pre-existing note that `download()` surfaces retry exhaustion as a tenacity error, unrelated; remaining strict-mode mentions in the snapshot design doc, deliberately untouched). Also confirmed the rewritten tests fail against the pre-fix code.
- Pass 2: OpenAI GPT-6 via Codex, fresh context independent of authoring. Confirmed the fail-closed download fix; 1 finding: previously cached binaries and derived tar files bypass verification (dismissed by the maintainer as out of scope).

### Slow tests
- `uv run pytest tests/tools/sandbox_tools_utils/test_sandbox_tools_digests.py` — 14 passed, 4 skipped (trio variants); with `--runtrio` — 4 passed, 14 skipped (non-trio).
- `uv run pytest --runslow tests/tools/sandbox_tools_utils/test_sandbox_tools.py::test_text_editor_read_missing` — 1 passed. On a clean editable checkout with an empty `binaries/` this took the real verified S3 download of `inspect-sandbox-tools-arm64-v29` (hash matched the vendored sums) followed by Docker injection.
- Not run: the rest of `pytest --runslow -m slow tests/tools/`. No live provider tests apply.
