### PR TITLE
Fix sandbox tools archive being swappable by the sandbox user before root extracts it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
 - Sandboxes: Compose files using long syntax volume mounts, `pids_limit`, `read_only`, `cgroup`, `stop_grace_period`, `build.no_cache`, or `build.pull` no longer fail validation when starting an eval.
+- Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.
 
 ## 0.3.263 (03 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
 - Sandboxes: Compose files using long syntax volume mounts, `pids_limit`, `read_only`, `cgroup`, `stop_grace_period`, `build.no_cache`, or `build.pull` no longer fail validation when starting an eval.
 - Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.
+- Docker: Timed commands no longer run an agent-planted timeout executable from the sandbox's PATH with elevated privileges.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -298,7 +298,8 @@ async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
             raise RuntimeError(f"Failed to start sandbox tools server: {result.stderr}")
     except Exception as e:
         raise SandboxInjectionError(
-            f"Failed to inject sandbox tools into sandbox: {e}", cause=e
+            f"Failed to inject sandbox tools into sandbox: {str(e) or type(e).__name__}",
+            cause=e,
         ) from e
 
 
@@ -343,13 +344,22 @@ async def _create_tools_dir_as_root(sandbox: SandboxEnvironment) -> bool:
         return False
 
 
+_EXTRACT_TIMEOUT = 600
+"""Bounds the archive transfer and extraction (docker `write_file`'s timeout, which
+carried the transfer before); a timeout also arms compose's retry of a hung exec."""
+
+
 async def _extract_tools_tree(
     sandbox: SandboxEnvironment, name: str, gz_bytes: bytes, user: str | None
 ) -> None:
     """Extract the gzipped onedir tar into SANDBOX_TOOLS_DIR.
 
-    The artifact is staged to a temp file via write_file (which base64-encodes binary
-    content reliably; raw binary stdin through exec is not safe) and then extracted.
+    The archive travels to `tar` on stdin, so no copy of it exists at a path another
+    principal could write to before the tools user reads it. `write_file` cannot do
+    this: it has no `user` parameter, so it stages as the default user, and a
+    root-owned 0700 directory is closed to that user. Large binary stdin is part of the
+    sandbox contract (`self_check`), though a provider that inlines stdin into a shell
+    script may cap it lower; the uncompressed fallback is the largest payload here.
     Extraction runs through the framework-directory helper, so `tar` unpacks into the
     verified directory object (its cwd) rather than into whatever the path names at
     that moment.
@@ -358,19 +368,20 @@ async def _extract_tools_tree(
     container's `tar` lacks gzip support, fall back to injecting an uncompressed tar,
     which only needs plain `tar xf` (the broadest assumption). The uncompressed tar is
     cached in the binaries dir so we decompress at most once per artifact.
+
+    A failing `tar` exits before reading stdin, and providers then raise on the broken
+    stdin write instead of returning tar's status, so on failure the wrapper drains
+    stdin and fails explicitly.
     """
-    gz_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tgz"
-    await sandbox.write_file(gz_tmp, gz_bytes)
-    try:
-        result = await exec_in_framework_directory(
-            sandbox,
-            SANDBOX_TOOLS_DIR,
-            ["tar", "xzf", gz_tmp],
-            user=user,
-            expected_uid=_expected_uid(user),
-        )
-    finally:
-        await _remove_staged_archive(sandbox, gz_tmp, user)
+    result = await exec_in_framework_directory(
+        sandbox,
+        SANDBOX_TOOLS_DIR,
+        ["sh", "-c", "tar xzf - || { cat >/dev/null; exit 1; }"],
+        user=user,
+        expected_uid=_expected_uid(user),
+        input=gz_bytes,
+        timeout=_EXTRACT_TIMEOUT,
+    )
     if result.success:
         return
 
@@ -380,55 +391,17 @@ async def _extract_tools_tree(
         TRACE_SANDBOX_TOOLS,
         f"tar xzf failed ({result.stderr.strip()}); retrying with uncompressed tar",
     )
-    tar_tmp = f"{SANDBOX_TOOLS_DIR}.pkg.tar"
-    await sandbox.write_file(tar_tmp, _uncompressed_tar_bytes(name, gz_bytes))
-    try:
-        result = await exec_in_framework_directory(
-            sandbox,
-            SANDBOX_TOOLS_DIR,
-            ["tar", "xf", tar_tmp],
-            user=user,
-            expected_uid=_expected_uid(user),
-        )
-    finally:
-        await _remove_staged_archive(sandbox, tar_tmp, user)
+    result = await exec_in_framework_directory(
+        sandbox,
+        SANDBOX_TOOLS_DIR,
+        ["sh", "-c", "tar xf - || { cat >/dev/null; exit 1; }"],
+        user=user,
+        expected_uid=_expected_uid(user),
+        input=_uncompressed_tar_bytes(name, gz_bytes),
+        timeout=_EXTRACT_TIMEOUT,
+    )
     if not result.success:
         raise RuntimeError(f"Failed to extract sandbox tools: {result.stderr}")
-
-
-async def _remove_staged_archive(
-    sandbox: SandboxEnvironment, path: str, user: str | None
-) -> None:
-    """Best-effort removal of a staged archive, as the extraction user.
-
-    Runs through the framework-directory helper rather than as a bare-name ``rm``
-    so the command resolves through the helper's pinned ``PATH``, not the image's
-    (this runs as root in a root-capable sandbox, and in a ``finally``, so it would
-    otherwise run even right after verification refused a planted entry). A helper
-    verdict here means the tools directory is gone or untrusted; the archive is then
-    left behind rather than masking the exception that is already propagating.
-    """
-    try:
-        result = await exec_in_framework_directory(
-            sandbox,
-            SANDBOX_TOOLS_DIR,
-            ["rm", "-f", path],
-            user=user,
-            expected_uid=_expected_uid(user),
-        )
-    except RuntimeError as ex:
-        # Covers every helper verdict (all subclass RuntimeError) as well as the
-        # helper's own "check never ran" failure; anything else propagates.
-        trace_message(
-            logger, TRACE_SANDBOX_TOOLS, f"staged archive {path} not removed: {ex}"
-        )
-        return
-    if not result.success:
-        trace_message(
-            logger,
-            TRACE_SANDBOX_TOOLS,
-            f"staged archive {path} not removed: {result.stderr.strip()}",
-        )
 
 
 def _uncompressed_tar_bytes(name: str, gz_bytes: bytes) -> bytes:

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -345,7 +345,9 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         # alone leaves orphaned processes inside the container).
         in_container_cmd = cmd
         if timeout is not None:
-            in_container_cmd = ["timeout", "-k", "5s", f"{timeout}s", *cmd]
+            # Resolve the wrapper independently of the image's potentially
+            # user-writable PATH, while preserving PATH for the requested command.
+            in_container_cmd = ["/usr/bin/timeout", "-k", "5s", f"{timeout}s", *cmd]
 
         # add a buffer to the host timeout so the in-container timeout
         # fires first under normal conditions. the in-container timeout

--- a/src/inspect_ai/util/_sandbox/docker/failure.py
+++ b/src/inspect_ai/util/_sandbox/docker/failure.py
@@ -29,6 +29,7 @@ misclassify a healthy sandbox as unavailable. Two consequences worth knowing:
 """
 
 import re
+from pathlib import PurePosixPath
 from typing import NamedTuple
 
 from inspect_ai.util._subprocess import ExecResult
@@ -55,6 +56,9 @@ _NO_CONTAINER = re.compile(r'^service "[^"]*" is not running\b')
 # containerd/runc could not start the process; it names the binary it tried
 _RUNC_PREFIX = "oci runtime exec failed"
 _RUNC_NOT_FOUND = re.compile(r'exec: "([^"]*)": executable file not found')
+_RUNC_PATH_NOT_FOUND = re.compile(
+    r'exec: "([^"]*)": stat \1: no such file or directory'
+)
 
 # the binary a `timeout`-style wrapper quotes in its complaint, verbatim as
 # handed to it. GNU quotes with U+2018/U+2019, busybox with ASCII quotes.
@@ -115,7 +119,9 @@ def classify_exec_failure(
 
     if head.startswith(_RUNC_PREFIX):
         # search the original line: the binary-name comparison is case-exact
-        not_found = _RUNC_NOT_FOUND.search(lines[0])
+        not_found = _RUNC_NOT_FOUND.search(lines[0]) or _RUNC_PATH_NOT_FOUND.search(
+            lines[0]
+        )
         if not_found is not None:
             # our own wrapper has gone missing, so the provider could not reach
             # the caller's command. a binary the *caller* named is their problem,
@@ -145,7 +151,10 @@ def classify_exec_failure(
     if (
         wrapper is not None
         and result.returncode == 126
-        and head.startswith(f"{wrapper.binary}: ")
+        # GNU reports the absolute argv[0]; BusyBox reports the applet name.
+        and head.startswith(
+            (f"{wrapper.binary}: ", f"{PurePosixPath(wrapper.binary).name}: ")
+        )
         and "permission denied" in output.lower()
     ):
         quoted = _WRAPPER_QUOTED.search(output)

--- a/tests/tools/docker-compose-context-nogzip/Dockerfile
+++ b/tests/tools/docker-compose-context-nogzip/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.12-bookworm
+RUN rm /usr/bin/gzip

--- a/tests/tools/sandbox_tools_utils/test_sandbox_tools.py
+++ b/tests/tools/sandbox_tools_utils/test_sandbox_tools.py
@@ -384,6 +384,92 @@ def test_tools_tree_is_inaccessible_to_default_user_after_root_injection():
 
 
 @pytest.mark.slow
+def test_injection_ignores_archive_planted_at_former_staging_path():
+    """A non-root default user plants files where older releases staged the archive.
+
+    The archive travels to `tar` on stdin, so injection must neither read nor touch
+    the planted files, and the genuine tools must come up.
+    """
+    planted = [f"{SANDBOX_TOOLS_DIR}.pkg.tgz", f"{SANDBOX_TOOLS_DIR}.pkg.tar"]
+    setup = "".join(f"printf planted > {path}\n" for path in planted)
+    probe = "; ".join(f"cat {path}" for path in planted)
+    task = Task(
+        dataset=[Sample(input="probe", setup=f"#!/bin/sh\n{setup}")],
+        solver=[use_tools([bash_session()]), generate()],
+        scorer=match(),
+        sandbox=("docker", NONROOT_COMPOSE),
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": f"{probe}; echo; echo probe-done",
+                },
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success", log.error
+    assert log.samples
+    messages = log.samples[0].messages
+    tool_call = get_tool_call(messages, "bash_session")
+    assert tool_call
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert response.error is None, f"Tool call returns error: {response.error}"
+    assert "plantedplanted\nprobe-done" in response.text
+
+
+@pytest.mark.slow
+def test_injection_falls_back_to_uncompressed_tar_without_gzip():
+    """Injection falls back to the uncompressed tar when `tar` cannot gunzip.
+
+    The first `tar xzf` exits without reading its stdin, which is the case where an
+    unhandled broken stdin write would abort injection instead of falling back.
+    """
+    task = Task(
+        dataset=[Sample(input="probe")],
+        solver=[use_tools([bash_session()]), generate()],
+        scorer=match(),
+        sandbox=(
+            "docker",
+            str(Path(__file__).parent / ".." / "test_sandbox_compose_nogzip.yaml"),
+        ),
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": "command -v gzip || echo no-gzip; echo probe-done",
+                },
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success", log.error
+    assert log.samples
+    messages = log.samples[0].messages
+    tool_call = get_tool_call(messages, "bash_session")
+    assert tool_call
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert response.error is None, f"Tool call returns error: {response.error}"
+    assert "no-gzip\nprobe-done" in response.text
+
+
+@pytest.mark.slow
 def test_text_editor_relative_path():
     file_content = "here's the file contents"
     task = Task(

--- a/tests/tools/sandbox_tools_utils/test_sandbox_tools_injection.py
+++ b/tests/tools/sandbox_tools_utils/test_sandbox_tools_injection.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from io import BytesIO
 from typing import AsyncIterator, BinaryIO, NamedTuple
 
+import anyio
 import pytest
 from test_helpers.sandbox import CannedSandbox
 
@@ -105,6 +106,10 @@ def helper_flags(cmd: list[str]) -> HelperFlags:
     assert is_framework_dir_call(cmd)
     leaf = SANDBOX_TOOLS_DIR.rsplit("/", 1)[1]
     return HelperFlags(*cmd[cmd.index(leaf) - 4 : cmd.index(leaf) - 1])
+
+
+TAR_XZF_STDIN = "tar xzf - || { cat >/dev/null; exit 1; }"
+TAR_XF_STDIN = "tar xf - || { cat >/dev/null; exit 1; }"
 
 
 def helper_ok(cmd: list[str], user: str | None) -> ExecResult[str]:
@@ -353,17 +358,30 @@ async def test_inject_aborts_when_reverification_before_start_fails(
     assert not any(cmd[:1] == [SANDBOX_CLI] for cmd, _ in sandbox.exec_calls)
 
 
-async def test_extract_runs_tar_inside_verified_directory() -> None:
+async def test_inject_names_a_message_less_exception(
+    stub_artifact: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken stdin write raises with no message; the error still says what happened."""
+
+    async def broken_extract(*_args: object) -> None:
+        raise anyio.BrokenResourceError()
+
+    monkeypatch.setattr(sandbox_tools, "_extract_tools_tree", broken_extract)
+    with pytest.raises(
+        sandbox_tools.SandboxInjectionError, match="BrokenResourceError"
+    ):
+        await sandbox_tools._inject_container_tools_code(CannedSandbox(helper_ok))
+
+
+async def test_extract_streams_archive_to_tar_inside_verified_directory() -> None:
     sandbox = CannedSandbox(helper_ok)
     await sandbox_tools._extract_tools_tree(sandbox, "name", b"gz", "root")
 
-    (tar_cmd, user), (rm_cmd, rm_user) = sandbox.exec_calls
+    [(tar_cmd, user)] = sandbox.exec_calls
     assert user == "root"
-    assert wrapped_command(tar_cmd) == ["tar", "xzf", f"{SANDBOX_TOOLS_DIR}.pkg.tgz"]
-    assert "-C" not in tar_cmd
-    # Cleanup also goes through the helper (pinned PATH), never a bare-name rm as root.
-    assert rm_user == "root"
-    assert wrapped_command(rm_cmd) == ["rm", "-f", f"{SANDBOX_TOOLS_DIR}.pkg.tgz"]
+    assert wrapped_command(tar_cmd) == ["sh", "-c", TAR_XZF_STDIN]
+    assert sandbox.inputs == [b"gz"]
+    assert sandbox.written == []
 
 
 async def test_extract_falls_back_to_plain_tar_inside_verified_directory(
@@ -374,7 +392,7 @@ async def test_extract_falls_back_to_plain_tar_inside_verified_directory(
     )
 
     def policy(cmd: list[str], user: str | None) -> ExecResult[str]:
-        if is_framework_dir_call(cmd) and "xzf" in cmd:
+        if is_framework_dir_call(cmd) and TAR_XZF_STDIN in cmd:
             return ExecResult(
                 success=False,
                 returncode=2,
@@ -386,43 +404,41 @@ async def test_extract_falls_back_to_plain_tar_inside_verified_directory(
     sandbox = CannedSandbox(policy)
     await sandbox_tools._extract_tools_tree(sandbox, "name", b"gz", None)
 
-    tar_calls = [
-        wrapped_command(cmd)
-        for cmd, _ in sandbox.exec_calls
-        if is_framework_dir_call(cmd) and wrapped_command(cmd)[:1] == ["tar"]
+    assert [wrapped_command(cmd) for cmd, _ in sandbox.exec_calls] == [
+        ["sh", "-c", TAR_XZF_STDIN],
+        ["sh", "-c", TAR_XF_STDIN],
     ]
-    assert tar_calls == [
-        ["tar", "xzf", f"{SANDBOX_TOOLS_DIR}.pkg.tgz"],
-        ["tar", "xf", f"{SANDBOX_TOOLS_DIR}.pkg.tar"],
-    ]
+    assert sandbox.inputs == [b"gz", b"tar"]
+    assert sandbox.written == []
 
 
-async def test_extract_propagates_tar_failure_and_removes_archive() -> None:
-    def policy(cmd: list[str], user: str | None) -> ExecResult[str]:
-        if is_framework_dir_call(cmd) and wrapped_command(cmd)[:1] == ["tar"]:
-            return violation(f"{SANDBOX_TOOLS_DIR} is a symbolic link")
-        return helper_ok(cmd, user)
-
-    sandbox = CannedSandbox(policy)
-    with pytest.raises(FrameworkDirectoryError, match="is a symbolic link"):
-        await sandbox_tools._extract_tools_tree(sandbox, "name", b"gz", "root")
-    # The staged archive is not left behind in the world-writable parent.
-    assert [
-        wrapped_command(cmd)
-        for cmd, user in sandbox.exec_calls
-        if is_framework_dir_call(cmd) and user == "root"
-    ][-1] == ["rm", "-f", f"{SANDBOX_TOOLS_DIR}.pkg.tgz"]
-    assert not any(cmd[:1] == ["rm"] for cmd, _ in sandbox.exec_calls)
-
-
-async def test_extract_cleanup_verdict_does_not_mask_original_error() -> None:
-    """If the directory is untrusted, the rm is skipped rather than raising over tar's error."""
+async def test_extract_propagates_helper_verdict() -> None:
     sandbox = CannedSandbox(
         lambda cmd, user: violation(f"{SANDBOX_TOOLS_DIR} is a symbolic link")
     )
     with pytest.raises(FrameworkDirectoryError, match="is a symbolic link"):
         await sandbox_tools._extract_tools_tree(sandbox, "name", b"gz", "root")
-    assert not any(cmd[:1] == ["rm"] for cmd, _ in sandbox.exec_calls)
+    assert len(sandbox.exec_calls) == 1
+    assert sandbox.written == []
+
+
+async def test_extract_reports_failure_of_both_tar_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sandbox_tools, "_uncompressed_tar_bytes", lambda name, gz: b"tar"
+    )
+    sandbox = CannedSandbox.returning(
+        ExecResult(
+            success=False,
+            returncode=2,
+            stdout="",
+            stderr=f"{_VERIFIED_MARKER}\ntar: short read\n",
+        )
+    )
+    with pytest.raises(RuntimeError, match="Failed to extract sandbox tools"):
+        await sandbox_tools._extract_tools_tree(sandbox, "name", b"gz", "root")
+    assert len(sandbox.exec_calls) == 2
 
 
 async def test_detector_checks_as_known_tools_user() -> None:

--- a/tests/tools/test_sandbox_compose_nogzip.yaml
+++ b/tests/tools/test_sandbox_compose_nogzip.yaml
@@ -1,0 +1,9 @@
+services:
+  default:
+    build:
+      context: docker-compose-context-nogzip
+      dockerfile: Dockerfile
+    command: "tail -f /dev/null"
+    init: true
+    network_mode: none
+    stop_grace_period: 1s

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -174,3 +174,45 @@ def sandbox_env(request, _config_and_env: ConfigAndEnv) -> SandboxEnvironment:
         request.node.add_marker(pytest.mark.xfail(reason=reason, strict=True))
 
     return _config_and_env.env
+
+
+@pytest.mark.parametrize("user", [None, "root"])
+async def test_docker_timeout_ignores_untrusted_path(
+    sandbox_env: SandboxEnvironment, user: str | None
+) -> None:
+    """Timeout uses system utilities while the requested command keeps its PATH."""
+    if not isinstance(sandbox_env, DockerSandboxEnvironment):
+        pytest.skip("Docker-specific timeout wrapper")
+
+    result = await sandbox_env.exec(["mktemp", "-d"])
+    assert result.success, result.stderr
+    directory = result.stdout.strip()
+    try:
+        await sandbox_env.write_file(
+            f"{directory}/timeout", "#!/bin/sh\nprintf 'planted timeout ran\\n'\n"
+        )
+        await sandbox_env.write_file(
+            f"{directory}/path-probe", '#!/bin/sh\nprintf "%s" "$1"\n'
+        )
+        result = await sandbox_env.exec(
+            [
+                "chmod",
+                "755",
+                directory,
+                f"{directory}/timeout",
+                f"{directory}/path-probe",
+            ]
+        )
+        assert result.success, result.stderr
+
+        argument = "literal spaces; $HOME $(id)"
+        result = await sandbox_env.exec(
+            ["path-probe", argument],
+            env={"PATH": directory},
+            user=user,
+            timeout=10,
+        )
+        assert result.success, result.stderr
+        assert result.stdout == argument
+    finally:
+        await sandbox_env.exec(["rm", "-rf", directory])

--- a/tests/util/sandbox/test_sandbox_exec_failure_classification.py
+++ b/tests/util/sandbox/test_sandbox_exec_failure_classification.py
@@ -24,7 +24,7 @@ from inspect_ai.util._sandbox.docker.util import ComposeProject
 from inspect_ai.util._sandbox.environment import SandboxUnavailableError
 
 # what `exec` injects for `bash(timeout=N)`: GNU `timeout` in front of `bash`
-WRAPPER = InjectedWrapper(binary="timeout", target="bash")
+WRAPPER = InjectedWrapper(binary="/usr/bin/timeout", target="bash")
 
 # --- the four ways a model wrecks its container (issue #4709 repro) --------
 
@@ -36,16 +36,16 @@ KILL_WORKLOAD = ExecResult(
 # `rm -rf /bin /usr/bin` — the binary runc cannot start is Inspect's own
 # `timeout` wrapper, not anything the model named.
 #
-# Captured from docker 29.6.2: the CLI reports this on *stdout*, with CRLF
-# line endings, and leaves stderr empty. Guarding on "output on stdout means
-# a process in the container produced it" therefore misses this entirely,
+# The CLI reports this on *stdout* and leaves stderr empty. Assuming stdout
+# means a process in the container produced it therefore misses this entirely,
 # which is what the end-to-end test below caught.
 RM_BIN = ExecResult(
     success=False,
     returncode=127,
     stdout=(
         "OCI runtime exec failed: exec failed: unable to start container "
-        'process: exec: "timeout": executable file not found in $PATH\r\n'
+        'process: exec: "/usr/bin/timeout": stat /usr/bin/timeout: '
+        "no such file or directory\r\n"
     ),
     stderr="",
 )
@@ -58,7 +58,7 @@ CHMOD_SHELL = ExecResult(
     success=False,
     returncode=126,
     stdout="",
-    stderr="timeout: failed to run command ‘bash’: Permission denied",
+    stderr="/usr/bin/timeout: failed to run command ‘bash’: Permission denied",
 )
 
 # deliberately NOT classified — see the exclusion test below
@@ -84,6 +84,30 @@ def test_unrunnable_sandbox_recognised(result: ExecResult[str]) -> None:
     error = classify_exec_failure(result, wrapper=WRAPPER)
     assert error is not None
     assert (result.stdout or result.stderr).strip() in str(error)
+
+
+@pytest.mark.parametrize(
+    "binary,stat_path,returncode",
+    [
+        ("/usr/bin/timeout", "/usr/bin/timeout", 1),
+        ("/usr/bin/timeout", "/some/other/file", 127),
+        ("/tmp/timeout", "/tmp/timeout", 127),
+        ("/usr/bin/bash", "/usr/bin/bash", 127),
+    ],
+)
+def test_absolute_wrapper_failure_requires_exact_path_and_exit_code(
+    binary: str, stat_path: str, returncode: int
+) -> None:
+    result = ExecResult(
+        success=False,
+        returncode=returncode,
+        stdout=(
+            "OCI runtime exec failed: exec failed: unable to start container "
+            f'process: exec: "{binary}": stat {stat_path}: no such file or directory'
+        ),
+        stderr="",
+    )
+    assert classify_exec_failure(result, wrapper=WRAPPER) is None
 
 
 # --- must not fire on the model's own output -------------------------------


### PR DESCRIPTION
Fixes meridianlabs-ai/inspect_ai#445

## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

Sandbox tools injection writes the tools archive with `write_file` to the fixed path `/var/tmp/.<hash>.pkg.tgz`, then root runs `tar xzf <path>` in a separate exec. `write_file` has no `user` parameter, so in a hardened sandbox the file is written as the agent's own uid. Between the two execs the agent can replace it, and root unpacks and runs the agent's launcher. The uncompressed `tar xf` fallback has the same gap.

### What is the new behavior?

- Both extraction attempts stream the archive bytes as exec stdin to `tar` inside the verified tools directory. Nothing is written to a path first, so there is no window and nothing to clean up.
- The wrapped command is `tar xzf - || { cat >/dev/null; exit 1; }` (fallback: `tar xf -`). A `tar` that cannot gunzip exits before reading stdin; on docker and local the host's stdin write then raises instead of returning tar's status, which would have silently disabled the fallback.
- The extraction exec keeps the 600 s timeout the transfer had under Docker `write_file` (it arms Compose's retry).
- Docker now invokes `/usr/bin/timeout` directly, preventing an agent-planted `timeout` on the image's PATH from running with the extraction user's privileges before directory verification. The requested command still receives its original PATH and arguments. This also protects other timed Docker exec calls and addresses the timeout PATH vulnerability tracked in meridianlabs-ai/inspect_ai#447.

Why stdin rather than a digest-checked staged file: checking a file in world-writable `/var/tmp` immediately before extracting it leaves the same race. Staging inside the verified directory was not an option either, since `write_file` cannot write as root. Raw bytes rather than base64: binary and large stdin are self-check provider contracts, and `inject_restic` already streams a binary to root this way.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Timed Docker commands now require `timeout` at `/usr/bin/timeout`, as provided by the tested Debian and Alpine images. Images that supply it only through a custom PATH location must provide it at that system path. No public API changes.

### Other information:

### Slow tests

Run locally on macOS (Docker Desktop):

- `pytest --runslow -m slow tests/tools/`: 224 passed, 185 skipped, 5 xfailed, 4 failed. The 4 failures are the known macOS ARG_MAX `test_exec_large_command` cases, identical on `main`.
- `pytest --runslow tests/tools/sandbox_tools_utils/test_sandbox_tools.py -k "planted or inaccessible or former_staging or without_gzip or bash_session_root or bash_session_non_root"`: 8 passed (both new Docker tests; each fails on `main`).
- `pytest --runslow tests/tools/test_sandbox_docker_and_local.py -k "test_exec_input_binary or test_exec_input_large or test_read_and_write_large_file_binary"`: 12 passed (stdin contract).
- `pytest tests/tools/sandbox_tools_utils tests/util/sandbox/test_framework_directory.py`: 103 passed; with `--runtrio`: 52 passed.
- Not run: k8s and proxmox providers (no cluster or host).

### Validation of the timeout fix

Codex ran the following against commit `a481cd878` on macOS with Docker Desktop. The new regression test failed on the unfixed PR for both default-user and root execution, with the planted timeout running instead of the requested command. After the fix it passes on Debian and Alpine, including command lookup through the supplied PATH and literal argument preservation.

The local OpenAI SDK could not import a module required by the unrelated automatic retry fixture. These runs used a temporary pytest launcher, `/tmp/inspect-review-5285/run_review_tests.py`, which adds the existing `real_retry_wait` marker to collected tests and invokes `pytest.main`; this opts out of retry-backoff monkeypatching without changing product code or test assertions. Commands below used the prefix `PYTHONPATH=/Users/ericpatey/code/inspect_ai/src .venv/bin/python /tmp/inspect-review-5285/run_review_tests.py`:

- `--runslow tests/tools/test_sandbox_docker_and_local.py -k 'timeout or test_exec_input_binary or test_exec_input_large' -q --tb=short`: 173 passed, 186 skipped, 5 xfailed, 4 failed. The selector matched the full module because tests carry timeout metadata. All four failures were macOS argument-size limits in `test_exec_large_command`, independently reproduced on the unchanged PR checkout. Coverage includes root, non-root Debian, non-root Alpine, local execution, binary/large stdin, and timeout process/child cleanup.
- `--runslow --runtrio tests/tools/test_sandbox_docker_and_local.py::test_docker_timeout_ignores_untrusted_path tests/tools/test_sandbox_docker_and_local.py::test_exec_timeout tests/tools/test_sandbox_docker_and_local.py::test_exec_timeout_kills_process tests/tools/test_sandbox_docker_and_local.py::test_exec_timeout_kills_child_processes -q --tb=short`: 18 passed, 22 skipped (asyncio variants and the Docker-specific regression on local).
- `--runslow tests/tools/sandbox_tools_utils/test_sandbox_tools.py -k 'former_staging or without_gzip' -q --tb=short`, additionally setting `INSPECT_SANDBOX_TOOLS_INSTALL_STATE=clean`: 2 passed, 13 deselected; archive injection and the missing-gzip fallback both worked.
- Ruff format/check and mypy passed for the changed Python files; the suppressions ledger and `git diff --check` also passed. No new full `make check` or `make test` run was performed for this follow-up.
- Kubernetes and Proxmox were not exercised by Codex.

- CI follow-up in `4eb84df56`: corrected error classification for the absolute timeout path, including Docker’s missing-path diagnostic and GNU/BusyBox reporter names. Using the same launcher/prefix above, `--runslow tests/util/sandbox/test_sandbox_exec_failure_classification.py -q --tb=short` passed 46 tests (12 skipped); `--runtrio tests/util/sandbox/test_sandbox_exec_failure_classification.py -q --tb=short` passed 12 (46 skipped). Ruff and mypy passed for both changed files. Current `main` was merged in `9e369af0d`; the changelog placement and submodule pointer were verified.

### Agent review
- Author: Claude Fable 5.1 (Claude Code), directed by @craig-meridian. Reviewer: Claude Fable 5.1 subagents in fresh contexts, 3 passes on successive revisions.
- Findings: 20 across the 3 passes. 11 fixed, most notably the stdin EPIPE case that would have disabled the fallback. 6 dismissed: rename and docstring rewrite are required by the behaviour change; shared Docker-test boilerplate matches the file's style; a verdict during extraction loses its message but is unreachable for a non-root agent against a root-owned dir in sticky `/var/tmp`; fallback size versus the k8s stdin ceiling is a rare intersection; the verdict unit test models a provider that returns rather than raises.
- The original external digest-check comment is addressed by streaming the archive instead of checking a staged file.
- Additional reviewer: GPT-6 via Codex, 1 review pass independent of the original authoring conversation. Finding: 1 P1, confirmed with the actual Docker provider against the PR and its base: a planted timeout ran as UID 0 during extraction on the PR, versus UID 1000 during file transfer on the base. Fixed in `a481cd878`; no findings dismissed in this pass.
- Codex also authored the timeout fix and regression test, then validated them in the same conversation. No separate fresh-context review of that follow-up fix was performed.


- CI caught two failures missed by Codex’s initial validation: missing-wrapper and unlaunchable-shell classification still expected the former timeout name. Codex corrected the classifier and fixtures in `4eb84df56`, added negative matching coverage, and ran the real-container error scenarios. This follow-up was authored and checked in the same context.
