### PR TITLE
docs(deepagents): point the checkpointing link at the real doc

### DIFF
--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -317,7 +317,7 @@ Pydantic AI's `PatchToolCallsCapability` detects orphaned tool calls (calls with
 
 #### Checkpointing integration
 
-The separate [Inspect Checkpointing design](../design/checkpointing.md) proposes mid-sample durability for long-running evals. `deepagent()` is a primary consumer of this capability — deep agent evals are exactly the ones that run for hours or days and need crash recovery.
+The separate [Inspect Checkpointing docs](../docs/checkpointing.qmd) proposes mid-sample durability for long-running evals. `deepagent()` is a primary consumer of this capability — deep agent evals are exactly the ones that run for hours or days and need crash recovery.
 
 **Inspect status:** The checkpointing design is proceeding in parallel. `deepagent()` should accept a `checkpoint=CheckpointConfig(...)` parameter, consistent with `react()`. The integration is straightforward — checkpoints fire at turn boundaries in the agent loop, which `deepagent()` inherits from `react()`.
 


### PR DESCRIPTION
`design/deepagents.md` links `../design/checkpointing.md`, which doesn't exist (and never has, per git log). The checkpointing documentation lives at `docs/checkpointing.qmd` ("Agent Checkpointing" — the mid-sample durability doc the sentence describes). Trivial docs-file link fix, per the direct-contribution exemption in CONTRIBUTING.md.