### PR TITLE
docs: drop duplicated words in user-facing messages and docstrings

### DIFF
--- a/src/inspect_ai/_util/error.py
+++ b/src/inspect_ai/_util/error.py
@@ -57,7 +57,7 @@ def module_max_version_error(feature: str, package: str, max_version: str) -> Ex
     return PrerequisiteError(
         f"[bold]ERROR[/bold]: {feature} supports only version {max_version} and earlier of package {package} "
         f"(you have version {version(package)} installed).\n\n"
-        f"Install the older version with with:\n\n[bold]pip install {package}=={max_version}[/bold]"
+        f"Install the older version with:\n\n[bold]pip install {package}=={max_version}[/bold]"
     )
 
 

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -126,7 +126,7 @@ async def agent_bridge(
           an updated state based on traffic over the bridge.
        filter: Filter for bridge model generation.
        retry_refusals: Should refusals be retried? (pass number of times to retry)
-       compaction: Compact the conversation when it it is close to overflowing
+       compaction: Compact the conversation when it is close to overflowing
           the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
        web_search: Configuration for mapping model internal
           web_search tools to Inspect. By default (in-process bridges), will map

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -82,7 +82,7 @@ async def sandbox_agent_bridge(
             or model spec string) is used instead. Checked before the fallback ``model``.
         filter: Filter for bridge model generation.
         retry_refusals: Should refusals be retried? (pass number of times to retry)
-        compaction: Compact the conversation when it it is close to overflowing
+        compaction: Compact the conversation when it is close to overflowing
             the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
         sandbox: Sandbox to run model proxy server within.
         port: Port to run proxy server on.

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -104,7 +104,7 @@ def react(
           the loop so if you only want to send a message back when the model fails
           to call tools you need to code that behavior explicitly.
        retry_refusals: Should refusals be retried? (pass number of times to retry)
-       compaction: Compact the conversation when it it is close to overflowing
+       compaction: Compact the conversation when it is close to overflowing
           the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
        truncation: Truncate the conversation history in the event of a context
           window overflow. Defaults to "disabled" which does no truncation. Pass

--- a/src/inspect_ai/util/_panel.py
+++ b/src/inspect_ai/util/_panel.py
@@ -5,7 +5,7 @@ from typing_extensions import Self
 
 
 class InputPanel(Container):
-    """Base class for for Inspect input panels."""
+    """Base class for Inspect input panels."""
 
     DEFAULT_TITLE = "Panel"
 


### PR DESCRIPTION
Five files carried doubled words:

- `_util/error.py`: the `PrerequisiteError` message users are told to run — "Install the older version **with with**:"
- `util/_panel.py`: "Base class **for for** Inspect input panels"
- `agent/_react.py`, `agent/_bridge/bridge.py`, `agent/_bridge/sandbox/bridge.py`: the `compaction` option description — "**when when** it is close to overflowing"

The docs-file-only link exemption in CONTRIBUTING.md covers trivial typo fixes; flagging that `error.py` is a code file, so happy to spin it off into an accepted issue if preferred.