### PR TITLE
docs(docker): drop duplicated 'the' in the x-local hint message

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -148,7 +148,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                                 + f"the image '{image}' for service '{name}' is not present in the Docker image store and could not be pulled."
                             )
                         logger.error(
-                            f"Failed to pull docker image '{image}' from remote registry. If this is a locally built image add 'x-local: true' to the the service definition to prevent this error."
+                            f"Failed to pull docker image '{image}' from remote registry. If this is a locally built image add 'x-local: true' to the service definition to prevent this error."
                         )
 
         except BaseException as ex:


### PR DESCRIPTION
The user-facing `logger.error` hint in `util/_sandbox/docker/docker.py` (shown when the x-local flag is missing) reads "add 'x-local: true' to **the the** service definition". Docs/message-only.