### PR TITLE
Make run configuration readable and applicable from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
 - Scoring: `math()` now raises an error when no reference answer can be parsed instead of silently excluding the sample from metrics.
 - Scoring: `choice()` now raises an error for samples without answer options instead of silently scoring them incorrect.
+- Evaluation: Read, validate, and apply run configuration files from Python, with optional deferred model initialization and CLI-compatible overrides.
 
 ## 0.3.263 (03 September 2026)
 

--- a/docs/reference/inspect_ai.qmd
+++ b/docs/reference/inspect_ai.qmd
@@ -10,6 +10,12 @@ description: Tasks, evaluation, and scoring.
 ### eval_set
 ### score
 
+## Run Configuration
+
+### RunConfig
+### read_run_config
+### merge_run_config_params
+
 ## Tasks
 
 ### Task

--- a/docs/tasks.qmd
+++ b/docs/tasks.qmd
@@ -615,6 +615,23 @@ inspect eval --run-config run.yaml
 
 See [Exporting Run Config](eval-logs.qmd#exporting-run-config) for details.
 
+#### Python API
+
+Use `read_run_config()` to read and validate the same YAML or JSON file from Python. It returns a `RunConfig` without instantiating models or loading tasks and solvers, so inspecting a configuration does not require model API credentials. Local paths, `file://` URIs, and remote filesystem URLs (such as `s3://bucket/run.yaml`) are supported.
+
+``` python
+from inspect_ai import eval, merge_run_config_params, read_run_config
+
+config = read_run_config("run.yaml")
+params = config.to_params(resolve_models=False)
+params = merge_run_config_params(params, {"temperature": 0.9, "limit": 10})
+eval(**params)
+```
+
+`to_params()` converts the configuration to `eval()` keyword arguments. By default it instantiates models assigned to roles, matching the CLI. With `resolve_models=False`, role values remain `ModelConfig` objects, which `eval()` resolves when the evaluation runs. The main model is represented by its name and separate configuration arguments in either mode. You can also validate an in-memory dictionary with `RunConfig.model_validate(data)`.
+
+`merge_run_config_params()` follows CLI precedence: task arguments, model arguments, and model roles merge by key, while other values replace the configured value. Overrides of `None`, empty dictionaries, and `score=True` are ignored to match CLI defaults; this is not a general-purpose dictionary merge.
+
 ### Scorer Override {#scorer-override}
 
 The scorer can only be overridden with `task_with()` during a live eval; there is no `eval()` parameter or CLI flag for it:

--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -6,6 +6,11 @@ from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
 from inspect_ai._eval.evalset import eval_set, task_identifier
 from inspect_ai._eval.list import list_tasks
 from inspect_ai._eval.registry import task, task_source
+from inspect_ai._eval.run_config import (
+    RunConfig,
+    merge_run_config_params,
+    read_run_config,
+)
 from inspect_ai._eval.score import score, score_async
 from inspect_ai._eval.task import (
     Epochs,
@@ -36,6 +41,9 @@ __all__ = [
     "eval_retry",
     "eval_retry_async",
     "eval_set",
+    "RunConfig",
+    "read_run_config",
+    "merge_run_config_params",
     "task_identifier",
     "list_tasks",
     "score",

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1643,7 +1643,7 @@ def eval_set_command(
 
 
 def parse_run_config(config: str) -> dict[str, Any]:
-    run_config: RunConfigInput = read_run_config(config)
+    run_config = read_run_config(config)
     return run_config.to_params()
 
 

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -7,13 +7,6 @@ from collections.abc import Callable, Iterator
 from typing import Any, Literal, TextIO, cast
 
 import click
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationError,
-    field_validator,
-)
 from typing_extensions import Unpack
 
 from inspect_ai import Epochs, eval, eval_retry
@@ -23,7 +16,14 @@ from inspect_ai._eval.handoff import (
     set_ctl_pointer_armed,
     set_launch_handoff_listener,
 )
-from inspect_ai._util.config import parse_cli_args, resolve_args
+from inspect_ai._eval.run_config import RunConfigInput as RunConfigInput
+from inspect_ai._eval.run_config import SolverInput as SolverInput
+from inspect_ai._eval.run_config import TaskInput as TaskInput
+from inspect_ai._eval.run_config import (
+    merge_run_config_params as merge_run_config_params,
+)
+from inspect_ai._eval.run_config import read_run_config
+from inspect_ai._util.config import parse_cli_args
 from inspect_ai._util.constants import (
     ALL_LOG_LEVELS,
     DEFAULT_BATCH_SIZE,
@@ -46,17 +46,15 @@ from inspect_ai._util.generate_config_args import (
 from inspect_ai._util.samples import parse_sample_id, parse_samples_limit
 from inspect_ai.log import IncompleteAction
 from inspect_ai.log._file import log_file_info
-from inspect_ai.log._log import EvalConfig, EvalLog
-from inspect_ai.model import GenerateConfig, GenerateConfigArgs, Model
+from inspect_ai.log._log import EvalLog
+from inspect_ai.model import GenerateConfigArgs, Model
 from inspect_ai.model._generate_config import (  # noqa: F811
     ResponseSchema,
 )
-from inspect_ai.model._model_config import ModelConfig, model_config_to_model
 from inspect_ai.scorer._reducer import create_reducers
 from inspect_ai.solver._solver import SolverSpec
 from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
 from inspect_ai.util._limit import TokenLimit
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 from .common import (
     CommonOptions,
@@ -1644,161 +1642,9 @@ def eval_set_command(
     ctx.exit(0 if success else 1)
 
 
-class TaskInput(BaseModel):
-    task: str
-    args: dict[str, Any] = Field(default_factory=dict)
-
-
-class SolverInput(BaseModel):
-    solver: str
-    args: dict[str, Any] = Field(default_factory=dict)
-
-
-class RunConfigInput(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    task: str | TaskInput | None = None
-    model: str | ModelConfig | None = None
-    model_roles: dict[str, ModelConfig | list[ModelConfig]] = Field(
-        default_factory=dict
-    )
-    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
-    eval_config: EvalConfig = Field(default_factory=EvalConfig)
-    solver: str | SolverInput | None = None
-    tags: list[str] = Field(default_factory=list)
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    sandbox: str | SandboxEnvironmentSpec | None = None
-
-    @field_validator("generate_config", mode="before")
-    @classmethod
-    def check_generate_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown generate_config fields: {unknown}")
-        return v
-
-    @field_validator("eval_config", mode="before")
-    @classmethod
-    def check_eval_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown eval_config fields: {unknown}")
-        return v
-
-    def to_params(self) -> dict[str, Any]:
-        params: dict[str, Any] = {}
-
-        # Task
-        if self.task is not None:
-            if isinstance(self.task, str):
-                params["tasks"] = self.task
-            else:
-                params["tasks"] = self.task.task
-                if self.task.args:
-                    params["task_args"] = self.task.args
-
-        # Model
-        if self.model is not None:
-            if isinstance(self.model, str):
-                params["model"] = self.model
-            else:
-                params["model"] = self.model.model
-                if self.model.base_url is not None:
-                    params["model_base_url"] = self.model.base_url
-                if self.model.args:
-                    params["model_args"] = self.model.args
-                model_gc = self.model.config.model_dump(exclude_none=True)
-                if model_gc:
-                    params.update(model_gc)
-
-        # Top-level generate_config overrides any model-level config
-        top_gc = self.generate_config.model_dump(exclude_none=True)
-        if top_gc:
-            params.update(top_gc)
-
-        # Model roles
-        if self.model_roles:
-            params["model_roles"] = {
-                role: [model_config_to_model(m) for m in mc]
-                if isinstance(mc, list)
-                else model_config_to_model(mc)
-                for role, mc in self.model_roles.items()
-            }
-
-        # Solver
-        if self.solver is not None:
-            if isinstance(self.solver, str):
-                params["solver"] = SolverSpec(self.solver, {}, {})
-            else:
-                params["solver"] = SolverSpec(
-                    self.solver.solver, self.solver.args, self.solver.args
-                )
-
-        # Eval config — combine epochs + epochs_reducer into Epochs
-        ec = self.eval_config.model_dump(exclude_none=True)
-        epochs = ec.pop("epochs", None)
-        epochs_reducer = ec.pop("epochs_reducer", None)
-        if epochs is not None:
-            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
-        params.update(ec)
-
-        # Tags and metadata
-        if self.tags:
-            params["tags"] = self.tags
-        if self.metadata:
-            params["metadata"] = self.metadata
-
-        # Sandbox
-        if self.sandbox is not None:
-            if isinstance(self.sandbox, str):
-                params["sandbox"] = parse_sandbox(self.sandbox)
-            else:
-                params["sandbox"] = self.sandbox
-
-        return params
-
-
 def parse_run_config(config: str) -> dict[str, Any]:
-    from jsonschema import Draft7Validator
-
-    config_dict = resolve_args(config)
-    try:
-        run_config = RunConfigInput.model_validate(config_dict)
-    except ValidationError as ex:
-        # Surface a more readable error via Draft7Validator. Fall back to
-        # pydantic's message when the JSON schema doesn't capture the
-        # failure (e.g. custom field_validators on generate_config/eval_config).
-        schema = RunConfigInput.model_json_schema()
-        errors = list(Draft7Validator(schema).iter_errors(config_dict))
-        if errors:
-            message = "\n".join(
-                [f"Invalid run config '{config}':"]
-                + [f" - {error.message}" for error in errors]
-            )
-        else:
-            message = f"Invalid run config '{config}': {ex}"
-        raise PrerequisiteError(message)
+    run_config: RunConfigInput = read_run_config(config)
     return run_config.to_params()
-
-
-def merge_run_config_params(
-    run_params: dict[str, Any], cli_params: dict[str, Any]
-) -> dict[str, Any]:
-    params = dict(run_params)
-    for key, value in cli_params.items():
-        if value is None or value == {}:
-            continue
-        if key == "score" and value is True:
-            continue
-        if key in ("task_args", "model_args") and key in params:
-            params[key] = params[key] | value
-        elif key == "model_roles" and key in params:
-            params[key] = params[key] | value
-        else:
-            params[key] = value
-    return params
 
 
 _SINGLE_MODEL_OPTION_NAMES = {"model", "model_base_url", "model_config", "m"}

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -9,7 +9,7 @@ from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.flag_values import int_bool_or_str_value, int_or_bool_value
 from inspect_ai.model import GenerateConfig, Model, ModelRoles, get_model
 from inspect_ai.util._limit import TokenLimit, parse_token_limit
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+from inspect_ai.util._sandbox.environment import parse_sandbox as parse_sandbox
 
 
 def int_or_bool_flag_callback(
@@ -390,14 +390,3 @@ class SectionedCommand(click.Command):
             if records:
                 with formatter.section(title):
                     formatter.write_dl(records)
-
-
-def parse_sandbox(sandbox: str | None) -> SandboxEnvironmentSpec | None:
-    if sandbox is not None:
-        parts = sandbox.split(":", maxsplit=1)
-        if len(parts) == 1:
-            return SandboxEnvironmentSpec(sandbox)
-        else:
-            return SandboxEnvironmentSpec(parts[0], parts[1])
-    else:
-        return None

--- a/src/inspect_ai/_eval/run_config.py
+++ b/src/inspect_ai/_eval/run_config.py
@@ -1,0 +1,234 @@
+from copy import deepcopy
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from inspect_ai._eval.task import Epochs
+from inspect_ai._util.config import resolve_args
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.log._log import EvalConfig
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._model_config import ModelConfig, model_config_to_model
+from inspect_ai.scorer._reducer import create_reducers
+from inspect_ai.solver._solver import SolverSpec
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec, parse_sandbox
+
+
+class TaskInput(BaseModel):
+    task: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class SolverInput(BaseModel):
+    solver: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunConfig(BaseModel):
+    """Configuration for an evaluation run.
+
+    Uses the same schema as the CLI's ``--run-config`` YAML or JSON file.
+    All fields are optional. Validation does not instantiate models or load
+    tasks and solvers; call ``to_params()`` to prepare evaluation arguments.
+    """
+
+    model_config = ConfigDict(extra="forbid", title="RunConfigInput")
+
+    task: str | TaskInput | None = None
+    """Task name or path, optionally with task arguments."""
+    model: str | ModelConfig | None = None
+    """Model name or model configuration."""
+    model_roles: dict[str, ModelConfig | list[ModelConfig]] = Field(
+        default_factory=dict
+    )
+    """Model configurations assigned to named roles."""
+    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
+    """Generation settings, overriding settings in the main model configuration."""
+    eval_config: EvalConfig = Field(default_factory=EvalConfig)
+    """Evaluation settings."""
+    solver: str | SolverInput | None = None
+    """Solver name or path, optionally with solver arguments."""
+    tags: list[str] = Field(default_factory=list)
+    """Tags for the evaluation."""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Metadata for the evaluation."""
+    sandbox: str | SandboxEnvironmentSpec | None = None
+    """Sandbox specification or ``type[:config]`` shorthand."""
+
+    @field_validator("generate_config", mode="before")
+    @classmethod
+    def check_generate_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown generate_config fields: {unknown}")
+        return v
+
+    @field_validator("eval_config", mode="before")
+    @classmethod
+    def check_eval_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown eval_config fields: {unknown}")
+        return v
+
+    def to_params(self, resolve_models: bool = True) -> dict[str, Any]:
+        """Convert the configuration to keyword arguments for ``eval()``.
+
+        Args:
+            resolve_models: Instantiate models for model roles (the CLI default).
+                If False, retain their ``ModelConfig`` objects, which ``eval()``
+                accepts and resolves when running the evaluation. The main model
+                is always represented by its name and separate configuration args.
+
+        Returns:
+            Evaluation keyword arguments, with generation settings flattened.
+        """
+        params: dict[str, Any] = {}
+
+        # Task
+        if self.task is not None:
+            if isinstance(self.task, str):
+                params["tasks"] = self.task
+            else:
+                params["tasks"] = self.task.task
+                if self.task.args:
+                    params["task_args"] = self.task.args
+
+        # Model
+        if self.model is not None:
+            if isinstance(self.model, str):
+                params["model"] = self.model
+            else:
+                params["model"] = self.model.model
+                if self.model.base_url is not None:
+                    params["model_base_url"] = self.model.base_url
+                if self.model.args:
+                    params["model_args"] = self.model.args
+                model_gc = self.model.config.model_dump(exclude_none=True)
+                if model_gc:
+                    params.update(model_gc)
+
+        # Top-level generate_config overrides any model-level config
+        top_gc = self.generate_config.model_dump(exclude_none=True)
+        if top_gc:
+            params.update(top_gc)
+
+        # Model roles
+        if self.model_roles:
+            if resolve_models:
+                params["model_roles"] = {
+                    role: [model_config_to_model(m) for m in mc]
+                    if isinstance(mc, list)
+                    else model_config_to_model(mc)
+                    for role, mc in self.model_roles.items()
+                }
+            else:
+                params["model_roles"] = deepcopy(self.model_roles)
+
+        # Solver
+        if self.solver is not None:
+            if isinstance(self.solver, str):
+                params["solver"] = SolverSpec(self.solver, {}, {})
+            else:
+                params["solver"] = SolverSpec(
+                    self.solver.solver, self.solver.args, self.solver.args
+                )
+
+        # Eval config — combine epochs + epochs_reducer into Epochs
+        ec = self.eval_config.model_dump(exclude_none=True)
+        epochs = ec.pop("epochs", None)
+        epochs_reducer = ec.pop("epochs_reducer", None)
+        if epochs is not None:
+            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
+        params.update(ec)
+
+        # Tags and metadata
+        if self.tags:
+            params["tags"] = self.tags
+        if self.metadata:
+            params["metadata"] = self.metadata
+
+        # Sandbox
+        if self.sandbox is not None:
+            if isinstance(self.sandbox, str):
+                params["sandbox"] = parse_sandbox(self.sandbox)
+            else:
+                params["sandbox"] = self.sandbox
+
+        return params
+
+
+RunConfigInput = RunConfig
+
+
+def read_run_config(config: str) -> RunConfig:
+    """Read and validate an evaluation run configuration without resolving models.
+
+    Args:
+        config: YAML or JSON configuration file (local path, file URI, or remote
+            filesystem URL such as ``s3://bucket/run.yaml``).
+
+    Returns:
+        Validated configuration. Call ``to_params()`` to prepare eval arguments.
+
+    Raises:
+        PrerequisiteError: The file does not exist or fails schema validation.
+        ValueError: The file cannot be parsed as a configuration object.
+    """
+    from jsonschema import Draft7Validator
+
+    config_dict = resolve_args(config)
+    try:
+        run_config = RunConfig.model_validate(config_dict)
+    except ValidationError as ex:
+        # Surface a more readable error via Draft7Validator. Fall back to
+        # pydantic's message when the JSON schema doesn't capture the
+        # failure (e.g. custom field_validators on generate_config/eval_config).
+        schema = RunConfig.model_json_schema()
+        errors = list(Draft7Validator(schema).iter_errors(config_dict))
+        if errors:
+            message = "\n".join(
+                [f"Invalid run config '{config}':"]
+                + [f" - {error.message}" for error in errors]
+            )
+        else:
+            message = f"Invalid run config '{config}': {ex}"
+        raise PrerequisiteError(message)
+    return run_config
+
+
+def merge_run_config_params(
+    run_params: dict[str, Any], cli_params: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge evaluation overrides using the CLI's run-configuration precedence.
+
+    Args:
+        run_params: Base evaluation arguments, typically from ``RunConfig.to_params``.
+        cli_params: Overrides. ``None``, empty dictionaries, and ``score=True``
+            are ignored, matching CLI defaults. Task arguments, model arguments,
+            and model roles merge by key; all other supplied values replace.
+
+    Returns:
+        Merged arguments in a new dictionary, without modifying either input.
+    """
+    params = dict(run_params)
+    for key, value in cli_params.items():
+        if value is None or value == {}:
+            continue
+        if key == "score" and value is True:
+            continue
+        if key in ("task_args", "model_args") and key in params:
+            params[key] = params[key] | value
+        elif key == "model_roles" and key in params:
+            params[key] = params[key] | value
+        else:
+            params[key] = value
+    return params

--- a/src/inspect_ai/_eval/run_config.py
+++ b/src/inspect_ai/_eval/run_config.py
@@ -38,7 +38,7 @@ class RunConfig(BaseModel):
     tasks and solvers; call ``to_params()`` to prepare evaluation arguments.
     """
 
-    model_config = ConfigDict(extra="forbid", title="RunConfigInput")
+    model_config = ConfigDict(extra="forbid")
 
     task: str | TaskInput | None = None
     """Task name or path, optionally with task arguments."""
@@ -169,11 +169,11 @@ class RunConfig(BaseModel):
 RunConfigInput = RunConfig
 
 
-def read_run_config(config: str) -> RunConfig:
+def read_run_config(path: str) -> RunConfig:
     """Read and validate an evaluation run configuration without resolving models.
 
     Args:
-        config: YAML or JSON configuration file (local path, file URI, or remote
+        path: YAML or JSON configuration file (local path, file URI, or remote
             filesystem URL such as ``s3://bucket/run.yaml``).
 
     Returns:
@@ -185,7 +185,7 @@ def read_run_config(config: str) -> RunConfig:
     """
     from jsonschema import Draft7Validator
 
-    config_dict = resolve_args(config)
+    config_dict = resolve_args(path)
     try:
         run_config = RunConfig.model_validate(config_dict)
     except ValidationError as ex:
@@ -196,23 +196,23 @@ def read_run_config(config: str) -> RunConfig:
         errors = list(Draft7Validator(schema).iter_errors(config_dict))
         if errors:
             message = "\n".join(
-                [f"Invalid run config '{config}':"]
+                [f"Invalid run config '{path}':"]
                 + [f" - {error.message}" for error in errors]
             )
         else:
-            message = f"Invalid run config '{config}': {ex}"
+            message = f"Invalid run config '{path}': {ex}"
         raise PrerequisiteError(message)
     return run_config
 
 
 def merge_run_config_params(
-    run_params: dict[str, Any], cli_params: dict[str, Any]
+    run_params: dict[str, Any], overrides: dict[str, Any]
 ) -> dict[str, Any]:
     """Merge evaluation overrides using the CLI's run-configuration precedence.
 
     Args:
         run_params: Base evaluation arguments, typically from ``RunConfig.to_params``.
-        cli_params: Overrides. ``None``, empty dictionaries, and ``score=True``
+        overrides: Overrides. ``None``, empty dictionaries, and ``score=True``
             are ignored, matching CLI defaults. Task arguments, model arguments,
             and model roles merge by key; all other supplied values replace.
 
@@ -220,7 +220,7 @@ def merge_run_config_params(
         Merged arguments in a new dictionary, without modifying either input.
     """
     params = dict(run_params)
-    for key, value in cli_params.items():
+    for key, value in overrides.items():
         if value is None or value == {}:
             continue
         if key == "score" and value is True:

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -76,6 +76,7 @@ from inspect_ai._util.working import (
     sample_working_time,
 )
 from inspect_ai.model._generate_overrides import generate_config_override_for_attempt
+from inspect_ai.model._model_config import ModelConfig
 from inspect_ai.model._retry import model_retry_config
 from inspect_ai.tool import Tool, ToolChoice, ToolFunction, ToolInfo
 from inspect_ai.tool._mcp._remote import is_mcp_server_tool
@@ -2771,10 +2772,12 @@ def active_model() -> Model | None:
 
 # Mapping (not dict) so that pre-typed user dicts like dict[str, list[str]]
 # type-check — dict is invariant in its value type, Mapping is covariant
-ModelRoles: TypeAlias = Mapping[str, str | Model | Sequence[str | Model]]
+ModelRoles: TypeAlias = Mapping[
+    str, str | Model | ModelConfig | Sequence[str | Model | ModelConfig]
+]
 """Assignment of models to named roles (e.g. the `model_roles` argument to `eval()` or `Task`).
 
-Maps a role name to a model (name or `Model` instance) or to a list of
+Maps a role name to a model (name, `Model`, or `ModelConfig` instance) or to a list of
 models. Assigned roles are looked up with `get_model(role=...)` or
 `model_roles()` (to *reference* a role, e.g. from a scorer, see `ModelRole`).
 """

--- a/src/inspect_ai/model/_model_config.py
+++ b/src/inspect_ai/model/_model_config.py
@@ -5,6 +5,9 @@ from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
 
+# imported as a module (not `from ._model import Model`) so this file can be
+# imported by _model.py without a cycle; with annotations deferred above, the
+# alias is only ever dereferenced by get_type_hints(), never at import time
 import inspect_ai.model as model_module
 from inspect_ai.model._generate_config import GenerateConfig
 

--- a/src/inspect_ai/model/_model_config.py
+++ b/src/inspect_ai/model/_model_config.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from inspect import isgenerator
 from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
 
+import inspect_ai.model as model_module
 from inspect_ai.model._generate_config import GenerateConfig
-from inspect_ai.model._model import Model, get_model
 
 
 class ModelConfig(BaseModel):
@@ -24,7 +26,7 @@ class ModelConfig(BaseModel):
 
 
 def model_roles_to_model_roles_config(
-    model_roles: dict[str, Model | list[Model]] | None,
+    model_roles: dict[str, model_module.Model | list[model_module.Model]] | None,
 ) -> dict[str, ModelConfig | list[ModelConfig]] | None:
     if model_roles is not None:
         return {
@@ -39,7 +41,7 @@ def model_roles_to_model_roles_config(
 
 def model_roles_config_to_model_roles(
     model_config: dict[str, ModelConfig | list[ModelConfig]] | None,
-) -> dict[str, Model | list[Model]] | None:
+) -> dict[str, model_module.Model | list[model_module.Model]] | None:
     if model_config is not None:
         return {
             k: [model_config_to_model(mc) for mc in v]
@@ -51,7 +53,7 @@ def model_roles_config_to_model_roles(
         return None
 
 
-def model_to_model_config(model: Model) -> ModelConfig:
+def model_to_model_config(model: model_module.Model) -> ModelConfig:
     return ModelConfig(
         model=str(model),
         config=model.config,
@@ -60,7 +62,9 @@ def model_to_model_config(model: Model) -> ModelConfig:
     )
 
 
-def model_config_to_model(model_config: ModelConfig) -> Model:
+def model_config_to_model(model_config: ModelConfig) -> model_module.Model:
+    from inspect_ai.model._model import get_model
+
     return get_model(
         model=model_config.model,
         config=model_config.config,

--- a/src/inspect_ai/model/_util.py
+++ b/src/inspect_ai/model/_util.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.model._model import Model, ModelRoles, get_model
+from inspect_ai.model._model_config import ModelConfig, model_config_to_model
 from inspect_ai.model._model_info import _get_model_info_direct
 
 if TYPE_CHECKING:
@@ -17,14 +18,14 @@ def resolve_model_roles(
     if model_roles is not None:
         resolved_model_roles: dict[str, Model | list[Model]] = {}
         for k, v in model_roles.items():
-            if isinstance(v, str | Model):
+            if isinstance(v, str | Model | ModelConfig):
                 resolved_model_roles[k] = _resolve_role_model(k, v)
             else:
                 # guard against untyped values (e.g. CLI YAML parsing can
                 # yield None or numeric scalars) so they get a clean error
                 # rather than a TypeError/AttributeError downstream
                 if not isinstance(v, Sequence) or not all(
-                    isinstance(m, str | Model) for m in v
+                    isinstance(m, str | Model | ModelConfig) for m in v
                 ):
                     raise PrerequisiteError(
                         f"Model role '{k}' has an invalid value ({v!r}): "
@@ -46,13 +47,16 @@ def resolve_model_roles(
         return None
 
 
-def _resolve_role_model(role: str, model: str | Model) -> Model:
+def _resolve_role_model(role: str, model: str | Model | ModelConfig) -> Model:
     # memoize=False for strings / copy for Model instances so that each role
     # gets a distinct Model instance; otherwise roles sharing the same model
     # collapse onto one object and per-role usage is misattributed (see #4450)
-    resolved = (
-        get_model(model, memoize=False) if isinstance(model, str) else copy(model)
-    )
+    if isinstance(model, ModelConfig):
+        resolved = model_config_to_model(model)
+    else:
+        resolved = (
+            get_model(model, memoize=False) if isinstance(model, str) else copy(model)
+        )
     resolved._set_role(role)
     return resolved
 

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -593,6 +593,17 @@ A tuple, e.g. ("docker", "compose.yaml"), is equivalent to SandboxEnvironmentSpe
 """
 
 
+def parse_sandbox(sandbox: str | None) -> SandboxEnvironmentSpec | None:
+    if sandbox is not None:
+        parts = sandbox.split(":", maxsplit=1)
+        if len(parts) == 1:
+            return SandboxEnvironmentSpec(sandbox)
+        else:
+            return SandboxEnvironmentSpec(parts[0], parts[1])
+    else:
+        return None
+
+
 def resolve_sandbox_environment(
     sandbox: SandboxEnvironmentType | None,
 ) -> SandboxEnvironmentSpec | None:

--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -181,6 +181,113 @@ def test_eval_log_run_config_round_trip() -> None:
     assert grader_config.config.max_tokens == 500
 
 
+def test_run_config_repeated_eval_preserves_task_defaults_and_logs(
+    tmp_path: Path,
+) -> None:
+    from inspect_ai._cli.eval import RunConfigInput, merge_run_config_params
+
+    task_instance = Task(
+        config=GenerateConfig(temperature=0.6, seed=42),
+        epochs=2,
+        score_on_error=True,
+        metadata={"task": "default"},
+    )
+    config = RunConfigInput.model_validate(
+        {
+            "model": "mockllm/model",
+            "generate_config": {"temperature": 0},
+            "eval_config": {"score_on_error": False},
+        }
+    )
+    before = config.model_dump()
+    params = merge_run_config_params(
+        config.to_params(), {"temperature": None, "score_on_error": None}
+    )
+    first = eval(task_instance, log_dir=str(tmp_path), **params)[0]
+    second = eval(
+        task_instance,
+        model="mockllm/model",
+        log_dir=str(tmp_path),
+        temperature=None,
+        score_on_error=None,
+    )[0]
+    assert first.status == second.status == "success"
+    assert first.plan.config.temperature == 0
+    assert first.eval.config.score_on_error is False
+    assert second.plan.config.temperature == 0.6
+    assert second.eval.config.score_on_error is True
+    assert first.plan.config.seed == second.plan.config.seed == 42
+    assert first.eval.config.epochs == second.eval.config.epochs == 2
+    assert task_instance.config.temperature == 0.6
+    assert task_instance.score_on_error is True
+    assert config.model_dump() == before
+    for original in (first, second):
+        persisted = read_eval_log(original.location)
+        assert persisted.plan.config == original.plan.config
+        assert persisted.eval.config == original.eval.config
+        exported = eval_log_to_run_config_dict(persisted)
+        assert (
+            exported["generate_config"]["temperature"]
+            == original.plan.config.temperature
+        )
+        assert (
+            exported["eval_config"]["score_on_error"]
+            == original.eval.config.score_on_error
+        )
+
+
+def test_eval_log_export_omits_operational_fields_and_keeps_falsey_values() -> None:
+    log = _make_log()
+    operational = {
+        "log_samples": False,
+        "log_realtime": False,
+        "log_images": False,
+        "log_model_api": False,
+        "log_buffer": 0,
+        "log_shared": 0,
+        "score_display": False,
+        "sandbox_cleanup": False,
+        "sandbox_prebuilt": False,
+        "max_samples": 1,
+        "max_dataset_memory": 2,
+        "max_tasks": 3,
+        "max_subprocesses": 4,
+        "max_sandboxes": 5,
+    }
+    scientific = {
+        "limit": 0,
+        "score_on_error": False,
+        "continue_on_fail": False,
+        "sample_shuffle": False,
+    }
+    log.eval.config = EvalConfig.model_validate(operational | scientific)
+    log.eval.task_file = "tasks.py"
+    log.eval.task_registry_name = "registered_task"
+    log.eval.task_args = {"value": None}
+    log.eval.tags = ["tag", "tag"]
+    log.eval.metadata = {"value": None}
+    log.eval.model_base_url = "https://example.test"
+    log.eval.model_args = {"value": None}
+    log.eval.model_generate_config = GenerateConfig(temperature=0)
+    exported = eval_log_to_run_config_dict(log)
+    assert exported["eval_config"] == scientific
+    assert exported["task"] == {
+        "task": "tasks.py@registered_task",
+        "args": {"value": None},
+    }
+    assert exported["model"] == {
+        "model": "mockllm/model",
+        "base_url": "https://example.test",
+        "args": {"value": None},
+        "config": {"temperature": 0.0},
+    }
+    assert exported["tags"] == ["tag", "tag"]
+    assert exported["metadata"] == {"value": None}
+    assert "solver" not in exported
+    assert "sandbox" not in exported
+    assert "model_roles" not in exported
+
+
 def test_sandbox_string_config() -> None:
     log = _make_log(SandboxEnvironmentSpec(type="docker", config="compose.yaml"))
     d = eval_log_to_run_config_dict(log)

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -1,23 +1,30 @@
+import json
 import os
 import tempfile
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
-from inspect_ai import Task, eval, task
+from inspect_ai import Epochs, Task, eval, task
 from inspect_ai._cli.eval import (
     RunConfigInput,
     eval_command,
     eval_retry_command,
     eval_set_command,
+    merge_run_config_params,
+    parse_run_config,
 )
 from inspect_ai._util.error import PrerequisiteError
-from inspect_ai.log import EvalLog
+from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._file import list_eval_logs, read_eval_log
-from inspect_ai.model import get_model
-from inspect_ai.solver import solver
+from inspect_ai.model import GenerateConfig, Model, get_model
+from inspect_ai.solver import SolverSpec, solver
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 
 def run_eval_cli(args: list[str], env: dict[str, str | None] | None = None) -> Result:
@@ -78,6 +85,593 @@ def test_run_config_rejects_unknown_generate_config_field():
 def test_run_config_rejects_unknown_eval_config_field():
     with pytest.raises(ValidationError, match="[Uu]nknown"):
         RunConfigInput.model_validate({"eval_config": {"limit": 10, "bad_field": 1}})
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({}, {}),
+        ({"task": None, "model": None, "solver": None, "sandbox": None}, {}),
+        ({"tags": [], "metadata": {}, "model_roles": {}}, {}),
+        ({"task": "task_ref"}, {"tasks": "task_ref"}),
+        ({"task": {"task": "task_ref", "args": {}}}, {"tasks": "task_ref"}),
+        (
+            {"task": {"task": "task_ref", "args": {"value": None}}},
+            {"tasks": "task_ref", "task_args": {"value": None}},
+        ),
+        ({"model": "mockllm/model"}, {"model": "mockllm/model"}),
+        (
+            {"model": {"model": "mockllm/model", "base_url": "", "args": {"x": 0}}},
+            {"model": "mockllm/model", "model_base_url": "", "model_args": {"x": 0}},
+        ),
+        ({"tags": ["one", "one"]}, {"tags": ["one", "one"]}),
+        (
+            {"metadata": {"nested": {"x": False}}},
+            {"metadata": {"nested": {"x": False}}},
+        ),
+        ({"eval_config": {"epochs_reducer": ["mean"]}}, {}),
+        (
+            {"generate_config": {"temperature": None}, "eval_config": {"limit": None}},
+            {},
+        ),
+    ],
+)
+def test_run_config_to_params_mapping(
+    config: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    assert RunConfigInput.model_validate(config).to_params() == expected
+
+
+@pytest.mark.parametrize("structured", [False, True])
+def test_run_config_solver_and_sandbox_mapping(structured: bool) -> None:
+    config = RunConfigInput.model_validate(
+        {
+            "solver": {"solver": "solver_ref", "args": {"x": None}}
+            if structured
+            else "solver_ref",
+            "sandbox": {"type": "docker", "config": "file://compose.yaml"}
+            if structured
+            else "docker:file://compose.yaml",
+        }
+    )
+    params = config.to_params()
+    spec = params["solver"]
+    assert isinstance(spec, SolverSpec)
+    assert spec.solver == "solver_ref"
+    assert spec.args == ({"x": None} if structured else {})
+    assert spec.args_passed == spec.args
+    assert params["sandbox"] == SandboxEnvironmentSpec("docker", "file://compose.yaml")
+
+
+def test_run_config_generate_config_all_fields() -> None:
+    values = {
+        "max_retries": 0,
+        "timeout": 1,
+        "attempt_timeout": 2,
+        "stream_idle_timeout": 3,
+        "max_connections": 4,
+        "adaptive_connections": False,
+        "system_message": "system",
+        "max_tokens": 5,
+        "top_p": 0.5,
+        "temperature": 0.0,
+        "stop_seqs": [],
+        "best_of": 1,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "logit_bias": {1: 0.5},
+        "seed": 0,
+        "top_k": 2,
+        "num_choices": 1,
+        "logprobs": False,
+        "top_logprobs": 0,
+        "prompt_logprobs": 1,
+        "parallel_tool_calls": False,
+        "internal_tools": False,
+        "max_tool_output": 10,
+        "cache_prompt": False,
+        "fallback_models": [],
+        "verbosity": "low",
+        "effort": "high",
+        "reasoning_effort": "low",
+        "reasoning_mode": "standard",
+        "reasoning_tokens": 10,
+        "reasoning_summary": "none",
+        "reasoning_history": "none",
+        "response_schema": {"name": "response", "json_schema": {"type": "object"}},
+        "extra_headers": {},
+        "extra_body": {"nested": {"x": 1}},
+        "modalities": ["image"],
+        "cache": False,
+        "batch": False,
+    }
+    assert set(values) == set(GenerateConfig.model_fields)
+    expected = GenerateConfig.model_validate(values).model_dump(exclude_none=True)
+    for config in (
+        {"generate_config": values},
+        {"model": {"model": "mockllm/model", "config": values}},
+    ):
+        params = RunConfigInput.model_validate(config).to_params()
+        params.pop("model", None)
+        assert params == expected
+
+
+def test_run_config_eval_config_all_fields() -> None:
+    values = {
+        "limit": [1, 3],
+        "sample_id": ["one", 2],
+        "sample_shuffle": False,
+        "approval": {"approvers": []},
+        "notification": False,
+        "fail_on_error": 0.5,
+        "continue_on_fail": False,
+        "retry_on_error": 0,
+        "score_on_error": False,
+        "message_limit": 1,
+        "token_limit": 2,
+        "token_limit_type": "output",
+        "turn_limit": 3,
+        "time_limit": 4,
+        "working_limit": 5,
+        "cost_limit": 0.0,
+        "max_samples": 1,
+        "max_dataset_memory": 2,
+        "max_tasks": 3,
+        "max_subprocesses": 4,
+        "max_sandboxes": 5,
+        "sandbox_cleanup": False,
+        "sandbox_prebuilt": False,
+        "log_samples": False,
+        "log_realtime": False,
+        "log_images": False,
+        "log_model_api": False,
+        "log_buffer": 0,
+        "log_shared": 0,
+        "score_display": False,
+        "acp_server": False,
+    }
+    assert set(values) == set(EvalConfig.model_fields) - {"epochs", "epochs_reducer"}
+    expected = EvalConfig.model_validate(values).model_dump(exclude_none=True)
+    assert (
+        RunConfigInput.model_validate({"eval_config": values}).to_params() == expected
+    )
+
+
+@pytest.mark.parametrize("reducers", [None, [], ["mean", "max"]])
+@pytest.mark.parametrize("count", [0, 2])
+def test_run_config_epochs_mapping(count: int, reducers: list[str] | None) -> None:
+    params = RunConfigInput.model_validate(
+        {"eval_config": {"epochs": count, "epochs_reducer": reducers}}
+    ).to_params()
+    assert set(params) == {"epochs"}
+    epochs = params["epochs"]
+    assert isinstance(epochs, Epochs)
+    assert epochs.epochs == count
+    assert (None if epochs.reducer is None else len(epochs.reducer)) == (
+        None if reducers is None else len(reducers)
+    )
+
+
+def test_run_config_generation_precedence_replaces_nested_values() -> None:
+    params = RunConfigInput.model_validate(
+        {
+            "model": {
+                "model": "mockllm/model",
+                "config": {
+                    "temperature": 0.8,
+                    "seed": 42,
+                    "extra_body": {"keep": True, "nested": {"a": 1}},
+                    "extra_headers": {"x": "old"},
+                },
+            },
+            "generate_config": {
+                "temperature": 0,
+                "seed": None,
+                "extra_body": {"nested": {"b": 2}},
+                "extra_headers": {},
+            },
+        }
+    ).to_params()
+    assert params == {
+        "model": "mockllm/model",
+        "temperature": 0.0,
+        "seed": 42,
+        "extra_body": {"nested": {"b": 2}},
+        "extra_headers": {},
+    }
+
+
+def test_run_config_model_roles_list_and_repeated_conversion() -> None:
+    config = RunConfigInput.model_validate(
+        {
+            "model_roles": {
+                "single": {
+                    "model": "mockllm/single",
+                    "base_url": "https://example.test",
+                    "args": {"foo": "bar"},
+                    "config": {"temperature": 0},
+                },
+                "group": [
+                    {"model": "mockllm/first"},
+                    {"model": "mockllm/second", "config": {"seed": 0}},
+                ],
+                "empty": [],
+            }
+        }
+    )
+    before = config.model_dump()
+    first = config.to_params()["model_roles"]
+    second = config.to_params()["model_roles"]
+    assert isinstance(first["single"], Model)
+    assert first["single"].api.base_url == "https://example.test"
+    assert first["single"].model_args == {"foo": "bar"}
+    assert first["single"].config.temperature == 0
+    assert [str(model) for model in first["group"]] == [
+        "mockllm/first",
+        "mockllm/second",
+    ]
+    assert first["group"][1].config.seed == 0
+    assert first["empty"] == []
+    assert first["single"] is not second["single"]
+    assert first["group"][0] is not second["group"][0]
+    assert config.model_dump() == before
+
+
+@pytest.mark.parametrize("section", ["task", "solver", "model"])
+def test_run_config_nested_unknown_fields_are_ignored(section: str) -> None:
+    name = "mockllm/model" if section == "model" else "reference"
+    config = RunConfigInput.model_validate({section: {section: name, "typo": 1}})
+    assert "typo" not in config.model_dump()[section]
+
+
+@pytest.mark.parametrize(
+    "section", ["generate_config", "eval_config", "tags", "metadata", "model_roles"]
+)
+def test_run_config_nonnullable_sections(section: str) -> None:
+    with pytest.raises(ValidationError):
+        RunConfigInput.model_validate({section: None})
+
+
+@pytest.mark.parametrize("suffix", [".yaml", ".json"])
+@pytest.mark.parametrize("uri", [False, True])
+def test_parse_run_config_files(tmp_path: Path, suffix: str, uri: bool) -> None:
+    path = tmp_path / f"run{suffix}"
+    data = {
+        "task": {"task": "task_ref", "args": {"value": None}},
+        "generate_config": {"temperature": 0},
+    }
+    path.write_text(json.dumps(data) if suffix == ".json" else yaml.safe_dump(data))
+    assert parse_run_config(path.as_uri() if uri else str(path)) == {
+        "tasks": "task_ref",
+        "task_args": {"value": None},
+        "temperature": 0.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        ({"typo": 1}, "Additional properties are not allowed"),
+        ({"task": 42}, "not valid under any of the given schemas"),
+        ({"generate_config": {"typo": 1}}, "Unknown generate_config fields"),
+        ({"eval_config": {"max_messages": 3}}, "Unknown eval_config fields"),
+    ],
+)
+def test_parse_run_config_validation_errors(
+    tmp_path: Path, data: dict[str, Any], message: str
+) -> None:
+    path = tmp_path / "invalid.yaml"
+    path.write_text(yaml.safe_dump(data))
+    with pytest.raises(PrerequisiteError) as exc:
+        parse_run_config(str(path))
+    assert f"Invalid run config '{path}':" in str(exc.value.message)
+    assert message in str(exc.value.message)
+
+
+@pytest.mark.parametrize("content", ["", "[]", "null", "not-an-object"])
+def test_parse_run_config_nonobject_errors(tmp_path: Path, content: str) -> None:
+    path = tmp_path / "invalid.yaml"
+    path.write_text(content)
+    with pytest.raises(ValueError, match="The config is not a valid object"):
+        parse_run_config(str(path))
+
+
+def test_parse_run_config_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "missing.yaml"
+    with pytest.raises(PrerequisiteError) as exc:
+        parse_run_config(str(path))
+    assert exc.value.message == f"The config file {path} does not exist."
+
+
+@pytest.mark.parametrize(
+    "value, overrides",
+    [
+        (None, False),
+        ({}, False),
+        ([], True),
+        ((), True),
+        ("", True),
+        (False, True),
+        (0, True),
+        (True, True),
+    ],
+)
+def test_merge_run_config_empty_and_falsey_values(value: Any, overrides: bool) -> None:
+    assert merge_run_config_params({"key": "run"}, {"key": value}) == {
+        "key": value if overrides else "run"
+    }
+    assert merge_run_config_params({}, {"key": value}) == (
+        {"key": value} if overrides else {}
+    )
+
+
+@pytest.mark.parametrize("run", [{}, {"score": True}, {"score": False}])
+@pytest.mark.parametrize("cli", [None, True, False])
+def test_merge_run_config_score_default(run: dict[str, Any], cli: bool | None) -> None:
+    assert merge_run_config_params(run, {"score": cli}) == (
+        {"score": False} if cli is False else run
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "task_args",
+        "model_args",
+        "model_roles",
+        "metadata",
+        "extra_body",
+        "extra_headers",
+    ],
+)
+def test_merge_run_config_shallow_merge_and_replacement(key: str) -> None:
+    run = {key: {"keep": 1, "nested": {"old": 2, "shared": 3}}}
+    cli = {key: {"nested": {"new": 4}}}
+    before_run, before_cli = deepcopy(run), deepcopy(cli)
+    result = merge_run_config_params(run, cli)
+    expected: dict[str, Any] = {"nested": {"new": 4}}
+    if key in ("task_args", "model_args", "model_roles"):
+        expected["keep"] = 1
+    assert result == {key: expected}
+    assert result is not run
+    assert run == before_run
+    assert cli == before_cli
+    assert merge_run_config_params(run, cli) == result
+
+
+@pytest.mark.parametrize("constructed", [False, True])
+@pytest.mark.parametrize("args", [{}, {"color": None}, {"color": "blue"}])
+def test_run_config_task_factory_vs_constructed_task(
+    constructed: bool, args: dict[str, Any]
+) -> None:
+    params = RunConfigInput.model_validate(
+        {
+            "task": {"task": "eval_config_characterization_task", "args": args},
+            "model": "mockllm/model",
+            "eval_config": {"epochs": 2},
+            "generate_config": {"temperature": 0},
+        }
+    ).to_params()
+    if constructed:
+        params["tasks"] = eval_config_characterization_task(color="constructed")
+    log = eval(**params)[0]
+    assert log.status == "success"
+    assert log.eval.task_args["color"] == (
+        "constructed" if constructed else args.get("color", "red")
+    )
+    assert log.eval.config.epochs == 2
+    assert log.plan.config.temperature == 0
+
+
+@pytest.mark.parametrize("source", ["environment", "run_config", "flag"])
+@pytest.mark.parametrize(
+    "name, option, envvar, value, config, expected",
+    [
+        (
+            "m",
+            "-M",
+            "INSPECT_EVAL_MODEL_ARGS",
+            "foo=env",
+            {"model": {"model": "mockllm/model", "args": {"foo": "run"}}},
+            ("foo=env",),
+        ),
+        (
+            "t",
+            "-T",
+            "INSPECT_EVAL_TASK_ARGS",
+            "color=env",
+            {"task": {"task": "eval_config_task", "args": {"color": "run"}}},
+            ("color=env",),
+        ),
+        (
+            "model_role",
+            "--model-role",
+            "INSPECT_EVAL_MODEL_ROLE",
+            "grader=mockllm/env",
+            {"model_roles": {"grader": {"model": "mockllm/run"}}},
+            ("grader=mockllm/env",),
+        ),
+        (
+            "model_spec",
+            "--model-spec",
+            "INSPECT_EVAL_MODEL_SPEC",
+            "mockllm/env",
+            {"model": "mockllm/run"},
+            ("mockllm/env",),
+        ),
+        (
+            "no_sandbox_cleanup",
+            "--no-sandbox-cleanup",
+            "INSPECT_EVAL_NO_SANDBOX_CLEANUP",
+            "true",
+            {"eval_config": {"sandbox_cleanup": True}},
+            True,
+        ),
+        (
+            "s",
+            "-S",
+            "INSPECT_EVAL_SOLVER_ARGS",
+            "shape=env",
+            {"solver": "eval_config_solver"},
+            ("shape=env",),
+        ),
+        (
+            "solver_config",
+            "--solver-config",
+            "INSPECT_EVAL_SOLVER_CONFIG",
+            "solver.yaml",
+            {"solver": "eval_config_solver"},
+            "solver.yaml",
+        ),
+        (
+            "temperature",
+            "--temperature",
+            "INSPECT_EVAL_TEMPERATURE",
+            "0.8",
+            {"generate_config": {"temperature": 0}},
+            0.8,
+        ),
+        (
+            "limit",
+            "--limit",
+            "INSPECT_EVAL_LIMIT",
+            "3",
+            {"eval_config": {"limit": 1}},
+            "3",
+        ),
+    ],
+)
+def test_run_config_cli_environment_key_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    name: str,
+    option: str,
+    envvar: str,
+    value: str,
+    config: dict[str, Any],
+    expected: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def capture(**params: Any) -> None:
+        captured.update(params)
+
+    monkeypatch.setattr("inspect_ai._cli.eval._eval_command_impl", capture)
+    path = tmp_path / "run.yaml"
+    path.write_text(yaml.safe_dump({} if source == "environment" else config))
+    args = ["--run-config", str(path)]
+    if source == "flag":
+        args.extend([option] if name == "no_sandbox_cleanup" else [option, value])
+    result = run_eval_cli(args, env={envvar: value, "TERM_PROGRAM": "xterm"})
+    assert_cli_success(result)
+    if source == "run_config":
+        expected = () if isinstance(expected, tuple) else None
+    assert captured[name] == expected
+
+
+@pytest.mark.parametrize(
+    "field, envvar",
+    [
+        ("log_samples", "INSPECT_EVAL_NO_LOG_SAMPLES"),
+        ("log_realtime", "INSPECT_EVAL_NO_LOG_REALTIME"),
+        ("score_display", "INSPECT_EVAL_SCORE_DISPLAY"),
+        ("fail_on_error", "INSPECT_EVAL_NO_FAIL_ON_ERROR"),
+    ],
+)
+def test_run_config_cli_unmapped_negated_env_overrides_config(
+    tmp_path: Path, field: str, envvar: str
+) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "task": "tests/test_eval_config.py@eval_config_characterization_task",
+                "model": "mockllm/model",
+                "eval_config": {field: True},
+            }
+        )
+    )
+    result = run_eval_cli(
+        ["--run-config", str(path), "--log-dir", str(tmp_path / "logs")],
+        env={envvar: "true", "TERM_PROGRAM": "xterm"},
+    )
+    assert_cli_success(result)
+    log = read_eval_log(list_eval_logs(str(tmp_path / "logs"))[0])
+    assert getattr(log.eval.config, field) is False
+
+
+def test_merge_run_config_replaces_role_lists_and_solver() -> None:
+    old = get_model("mockllm/old")
+    new = get_model("mockllm/new")
+    old_solver = SolverSpec("old", {"keep": 1}, {})
+    new_solver = SolverSpec("new", {"replace": 2}, {})
+    run = {"model_roles": {"keep": old, "replace": [old]}, "solver": old_solver}
+    result = merge_run_config_params(
+        run, {"model_roles": {"replace": [new]}, "solver": new_solver}
+    )
+    assert result["model_roles"] == {"keep": old, "replace": [new]}
+    assert result["solver"] is new_solver
+    assert run["model_roles"] == {"keep": old, "replace": [old]}
+    assert run["solver"] is old_solver
+
+
+def test_run_config_nested_model_generation_unknown_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="Unknown GenerateConfig field"):
+        RunConfigInput.model_validate(
+            {
+                "model": {
+                    "model": "mockllm/model",
+                    "config": {"temperature": 0, "typo": 1},
+                },
+            }
+        )
+
+
+def test_run_config_cli_model_config_merges_and_common_env_survives(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "task": "tests/test_eval_config.py@eval_config_task",
+                "model": {
+                    "model": "mockllm/model",
+                    "args": {"keep": True, "foo": "run"},
+                },
+                "metadata": {"keep": True, "shared": "run"},
+                "tags": ["run"],
+            }
+        )
+    )
+    result = run_eval_cli(
+        [
+            "--run-config",
+            str(path),
+            "--model-config",
+            config_path("model.yaml"),
+            "--metadata",
+            "shared=cli",
+            "--tags",
+            "cli",
+        ],
+        env={"INSPECT_LOG_DIR": str(tmp_path / "logs"), "TERM_PROGRAM": "xterm"},
+    )
+    assert_cli_success(result)
+    log = read_eval_log(list_eval_logs(str(tmp_path / "logs"))[0])
+    assert log.eval.model_args == {"keep": True, "foo": "bar"}
+    assert log.eval.metadata == {"shared": "cli"}
+    assert log.eval.tags == ["cli"]
+
+
+def test_eval_set_rejects_run_config(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text("{}")
+    result = run_eval_set_cli(["--run-config", str(path)])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, PrerequisiteError)
+    assert result.exception.message == "--run-config is only supported by inspect eval."
 
 
 def test_eval_config_task():
@@ -714,6 +1308,16 @@ def eval_config_solver(shape="square"):
         return await generate(state)
 
     return solve
+
+
+@task
+def eval_config_characterization_task(color: str | None = "red") -> Task:
+    return Task(
+        metadata={"color": color},
+        config=GenerateConfig(temperature=0.6, seed=42),
+        epochs=3,
+        score_on_error=True,
+    )
 
 
 @task

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,228 @@
+import json
+from pathlib import Path
+from typing import Any, get_type_hints
+from unittest.mock import patch
+
+import pytest
+
+from inspect_ai import RunConfig, Task, eval, merge_run_config_params, read_run_config
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.file import file
+from inspect_ai.dataset import Sample
+from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles
+from inspect_ai.model._util import resolve_model_roles
+
+
+@pytest.mark.parametrize("location", ["path", "uri", "remote"])
+def test_read_run_config_without_resolving_models(
+    tmp_path: Path, location: str
+) -> None:
+    content = json.dumps(
+        {
+            "task": "not_installed/task",
+            "solver": "not_installed/solver",
+            "model": {"model": "not_installed/main"},
+            "model_roles": {
+                "grader": {"model": "not_installed/grader"},
+                "panel": [
+                    {"model": "not_installed/a"},
+                    {"model": "not_installed/b"},
+                ],
+            },
+        }
+    )
+    if location == "remote":
+        config_file = "memory://run-config-api/run.json"
+        with file(config_file, "w") as stream:
+            stream.write(content)
+    else:
+        path = tmp_path / ("run.json" if location == "uri" else "run config.json")
+        path.write_text(content)
+        config_file = path.as_uri() if location == "uri" else str(path)
+
+    with patch(
+        "inspect_ai.model._model.get_model",
+        side_effect=AssertionError("Models must not be instantiated"),
+    ):
+        config = read_run_config(config_file)
+        assert isinstance(config, RunConfig)
+        params = config.to_params(resolve_models=False)
+
+    assert params["tasks"] == "not_installed/task"
+    assert params["model"] == "not_installed/main"
+    assert params["model_roles"] == config.model_roles
+    assert isinstance(params["model_roles"]["grader"], ModelConfig)
+    assert all(
+        isinstance(model, ModelConfig) for model in params["model_roles"]["panel"]
+    )
+    assert RunConfig.model_validate_json(config.model_dump_json()) == config
+
+
+def test_read_run_config_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text("task: example/task\ngenerate_config:\n  temperature: 0.25\n")
+    config = read_run_config(str(path))
+    assert config.task == "example/task"
+    assert config.generate_config.temperature == 0.25
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        ({"unknown": True}, "Additional properties are not allowed"),
+        ({"generate_config": {"unknown": True}}, "Unknown generate_config fields"),
+        ({"eval_config": {"unknown": True}}, "Unknown eval_config fields"),
+    ],
+)
+def test_read_run_config_validation_errors(
+    tmp_path: Path, data: dict[str, Any], message: str
+) -> None:
+    path = tmp_path / "run.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(PrerequisiteError, match=message) as error:
+        read_run_config(str(path))
+    assert f"Invalid run config '{path}':" in str(error.value)
+
+
+def test_read_run_config_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(PrerequisiteError, match="does not exist"):
+        read_run_config(str(tmp_path / "missing.yaml"))
+
+
+def test_run_config_resolves_models_only_on_conversion() -> None:
+    config = RunConfig.model_validate(
+        {
+            "model_roles": {
+                "grader": {"model": "mockllm/grader", "config": {"temperature": 0.2}},
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            }
+        }
+    )
+    params = config.to_params()
+    assert isinstance(params["model_roles"]["grader"], Model)
+    assert params["model_roles"]["grader"].config.temperature == 0.2
+    assert all(isinstance(model, Model) for model in params["model_roles"]["panel"])
+    assert isinstance(config.model_roles["grader"], ModelConfig)
+
+
+def test_run_config_deferred_roles_are_independent() -> None:
+    config = RunConfig.model_validate(
+        {
+            "model_roles": {
+                "grader": {
+                    "model": "mockllm/grader",
+                    "config": {"temperature": 0.2},
+                    "args": {"nested": {"values": [1]}},
+                },
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            }
+        }
+    )
+    expected = config.model_copy(deep=True).model_roles
+    first = config.to_params(resolve_models=False)["model_roles"]
+    second = config.to_params(resolve_models=False)["model_roles"]
+
+    first["grader"].model = "mockllm/changed"
+    first["grader"].config.temperature = 0.9
+    first["grader"].args["nested"]["values"].append(2)
+    first["panel"][0].config.temperature = 0.8
+    first["panel"].append(ModelConfig(model="mockllm/c"))
+
+    assert config.model_roles == expected
+    assert second == expected
+    second["panel"].clear()
+    assert len(first["panel"]) == 3
+    assert config.model_roles == expected
+
+
+@pytest.mark.parametrize(
+    "function, annotation, expected",
+    [
+        (
+            "model_roles_to_model_roles_config",
+            "model_roles",
+            dict[str, Model | list[Model]] | None,
+        ),
+        (
+            "model_roles_config_to_model_roles",
+            "return",
+            dict[str, Model | list[Model]] | None,
+        ),
+        ("model_to_model_config", "model", Model),
+        ("model_config_to_model", "return", Model),
+    ],
+)
+def test_model_config_helper_type_hints(
+    function: str, annotation: str, expected: Any
+) -> None:
+    from inspect_ai.model import _model_config
+
+    assert get_type_hints(getattr(_model_config, function))[annotation] == expected
+
+
+def test_run_config_merge_public_api() -> None:
+    base = {"task_args": {"a": 1, "b": 2}, "score": False, "tags": ["base"]}
+    overrides = {"task_args": {"b": None}, "score": True, "tags": []}
+    assert merge_run_config_params(base, overrides) == {
+        "task_args": {"a": 1, "b": None},
+        "score": False,
+        "tags": [],
+    }
+    assert base == {"task_args": {"a": 1, "b": 2}, "score": False, "tags": ["base"]}
+    assert overrides == {"task_args": {"b": None}, "score": True, "tags": []}
+
+
+def test_model_roles_accept_deferred_configs() -> None:
+    assert get_type_hints(eval)["model_roles"] == ModelRoles | None
+    config = ModelConfig(model="mockllm/grader", config=GenerateConfig(temperature=0.2))
+    roles: ModelRoles = {"grader": config, "other": config, "panel": [config]}
+    resolved = resolve_model_roles(roles)
+    assert resolved is not None
+    grader = resolved["grader"]
+    assert isinstance(grader, Model)
+    assert grader.config.temperature == 0.2
+    assert resolved["grader"] is not resolved["other"]
+    assert isinstance(resolved["panel"], Model)
+
+
+def test_run_config_deferred_models_eval_and_log(tmp_path: Path) -> None:
+    config = RunConfig.model_validate(
+        {
+            "model": "mockllm/model",
+            "model_roles": {
+                "grader": {"model": "mockllm/grader", "config": {"temperature": 0.2}},
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            },
+        }
+    )
+    logs = eval(
+        Task(dataset=[Sample(input="Hello")]),
+        **config.to_params(resolve_models=False),
+        log_dir=str(tmp_path),
+        display="none",
+    )
+    assert logs[0].status == "success"
+    assert logs[0].eval.model_roles == config.model_roles
+
+
+def test_run_config_cli_compatibility_imports(tmp_path: Path) -> None:
+    from inspect_ai._cli.eval import (
+        RunConfigInput,
+        SolverInput,
+        TaskInput,
+        parse_run_config,
+    )
+    from inspect_ai._cli.eval import merge_run_config_params as cli_merge
+    from inspect_ai._cli.util import parse_sandbox as cli_sandbox
+    from inspect_ai._eval.run_config import SolverInput as SharedSolverInput
+    from inspect_ai._eval.run_config import TaskInput as SharedTaskInput
+    from inspect_ai.util._sandbox.environment import parse_sandbox
+
+    assert RunConfigInput is RunConfig
+    assert TaskInput is SharedTaskInput
+    assert SolverInput is SharedSolverInput
+    assert cli_merge is merge_run_config_params
+    assert cli_sandbox is parse_sandbox
+    path = tmp_path / "run.yaml"
+    path.write_text("task: example/task\ngenerate_config:\n  temperature: 0.25\n")
+    assert parse_run_config(str(path)) == read_run_config(str(path)).to_params()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -9,7 +9,7 @@ from inspect_ai import RunConfig, Task, eval, merge_run_config_params, read_run_
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import file
 from inspect_ai.dataset import Sample
-from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles
+from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles, get_model
 from inspect_ai.model._util import resolve_model_roles
 
 
@@ -172,17 +172,24 @@ def test_run_config_merge_public_api() -> None:
     assert overrides == {"task_args": {"b": None}, "score": True, "tags": []}
 
 
-def test_model_roles_accept_deferred_configs() -> None:
+def test_model_roles_accept_deferred_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     assert get_type_hints(eval)["model_roles"] == ModelRoles | None
-    config = ModelConfig(model="mockllm/grader", config=GenerateConfig(temperature=0.2))
+    # a provider get_model memoizes (mockllm never is), so a deferred config
+    # that resolved to the shared instance would show up here (#4450)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    config = ModelConfig(model="openai/gpt-4o", config=GenerateConfig(temperature=0.2))
     roles: ModelRoles = {"grader": config, "other": config, "panel": [config]}
     resolved = resolve_model_roles(roles)
     assert resolved is not None
     grader = resolved["grader"]
     assert isinstance(grader, Model)
     assert grader.config.temperature == 0.2
+    assert grader.role == "grader"
     assert resolved["grader"] is not resolved["other"]
     assert isinstance(resolved["panel"], Model)
+    shared = get_model("openai/gpt-4o")
+    assert shared is not grader
+    assert shared.role is None
 
 
 def test_run_config_deferred_models_eval_and_log(tmp_path: Path) -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The run-config file format (`--run-config`, `inspect log export-config`) is parsed, validated and merged entirely inside `_cli/eval.py`. Python callers (`eval()`, `eval_set()`, Inspect Flow, external runners such as Hawk) have no supported way to read or apply the same file, and `RunConfigInput.to_params()` eagerly constructs model-role clients, so merely inspecting a config needs API credentials.

This is the first of two changes for #4784 (task default run configs). The second, `@task(default_config=...)`, depends on being able to read and merge a run config outside the CLI.

### What is the new behavior?

Schema, parsing and merging move from `_cli/eval.py` into `_eval/run_config.py`, with a small public API exported from `inspect_ai`:

- `read_run_config(path)` reads and validates a YAML/JSON file (local path, `file://` URI, or remote filesystem URL) into a `RunConfig` **without** instantiating models, tasks or solvers.
- `RunConfig.to_params(resolve_models=True)` converts to `eval()` keyword arguments. `resolve_models=False` leaves role values as `ModelConfig` for `eval()` to resolve at run time.
- `merge_run_config_params(base, overrides)` applies overrides with CLI precedence: task args, model args and model roles merge by key; other values replace; `None`, empty dicts and `score=True` are ignored to match CLI defaults.

The CLI now calls this module. Its behaviour is unchanged, and the private names existing integrations import (`RunConfigInput`, `parse_run_config`, `merge_run_config_params` from `_cli/eval.py`) still resolve.

**Approach.** Existing behaviour was pinned first: 111 characterisation cases (parsing, validation, conversions, merge behaviour, CLI/environment precedence, task construction forms, export/replay) were added and passing *before* the extraction, then the CLI was cut over. Baseline quirks the characterisation found (negated-environment precedence, reducers dropped without epochs, nested unknown fields ignored, falsey merge behaviour) are pinned as they are, not fixed here.

Docs: new "Python API" subsection under Run Config File in `tasks.qmd`, plus reference entries.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. CLI behaviour is preserved exactly (see characterisation tests). Two internal fixes surfaced by review are included: deferred role conversion now deep-copies shared role lists/configs, and four model-config helpers regained runtime type-hint resolution.

### Other information:

- Full suite at the time: 11600 passed, 4943 skipped. Focused config/model-role suites: 185 passed, 7 skipped (live-provider).
- Whole-repo mypy (1455 files), ruff and the suppression gate pass.
- Follow-up PR (task defaults) is prepared on top of this branch.

### Agent review
- Authoring passes (previous session, before opening): a fresh-context subagent review of the extraction found two defects (deferred role conversion shared mutable role lists/configs; four model-config helpers lost runtime type-hint resolution), both fixed with regression tests before the CLI cutover. A separate file-only pass reported only baseline quirks, which the characterisation tests pin unchanged. The handover notes do not record which model ran those passes.
- Post-open pass: automated external review (Claude, meridianlabs-ai/inspect_ai#456), fresh context, 1 pass, verdict "ready to approve". 7 non-blocking findings: 6 addressed in `2bfdd41ce` and `476eda346` (`read_run_config(path)`, `merge_run_config_params(..., overrides)`, redundant CLI annotation, comment on the `_model_config` import alias, memoized-provider test for the distinct-instance guarantee, legacy `RunConfigInput` schema title dropped); 1 left for maintainers: whether `merge_run_config_params` should ignore `score=True` for non-CLI callers, or stay private until #5294 shows what it needs. Its CLI semantics are unchanged and documented either way.

**Rebased on `main` 2026-09-11** (picks up #5290, which merged, and the 2026-09-10 main commits). Changelog entry verified under `## Unreleased`.

*Posted by [Claude Code](https://claude.com/claude-code) on Matt's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

