### PR TITLE
Run checkpoint slow tests in parallel without deleting peer sandboxes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -668,7 +668,7 @@ jobs:
           uv pip install .[dev]
 
       - name: Run slow tests
-        run: uv run pytest --runslow -m slow tests/${{ matrix.area }}/
+        run: uv run pytest --runslow -m slow tests/${{ matrix.area }}/ -n logical
 
       - name: Minimize uv cache
         if: ${{ !cancelled() }}

--- a/tests/checkpoint/docker_projects.py
+++ b/tests/checkpoint/docker_projects.py
@@ -1,0 +1,103 @@
+"""Track Docker projects across checkpoint tests' killed child processes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import inspect_ai.util._sandbox.docker.docker as docker_provider
+from inspect_ai.util._sandbox.docker.util import ComposeProject, is_inspect_project
+
+PROJECTS_DIR_ENV = "INSPECT_TEST_CHECKPOINT_PROJECTS_DIR"
+
+
+class DockerProjects:
+    """Projects created by one test body, including all samples and attempts."""
+
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def container_ids(self) -> list[str]:
+        """Return this test's containers, including stopped containers."""
+        ids: list[str] = []
+        for record in sorted(self.directory.iterdir()):
+            name = record.name
+            if not is_inspect_project(name):
+                raise ValueError(f"Invalid checkpoint test project record: {record}")
+            result = subprocess.run(
+                [
+                    "docker",
+                    "ps",
+                    "-aq",
+                    "--filter",
+                    f"label=com.docker.compose.project={name}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=60,
+            )
+            ids.extend(result.stdout.split())
+        return ids
+
+    def cleanup(self) -> None:
+        """Remove only containers belonging to this test's recorded projects."""
+        ids = self.container_ids()
+        if ids:
+            subprocess.run(
+                ["docker", "rm", "-f", *ids],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=60,
+            )
+
+
+@contextmanager
+def record_docker_projects() -> Iterator[None]:
+    """Record projects before startup when a parent test requests tracking.
+
+    One empty file per exact project name survives SIGKILL without buffered
+    writes or concurrent appends. Recording before startup also covers failed
+    hydration and sibling samples that never reach the harness's crash tool.
+    Cleanup belongs to the parent test, which outlives every child attempt.
+    """
+    directory = os.environ.get(PROJECTS_DIR_ENV)
+    if directory is None:
+        yield
+        return
+
+    startup: Callable[[ComposeProject], None] = getattr(
+        docker_provider, "project_startup"
+    )
+
+    def record(project: ComposeProject) -> None:
+        (Path(directory) / project.name).touch()
+        startup(project)
+
+    with patch.object(docker_provider, "project_startup", record):
+        yield
+
+
+@contextmanager
+def checkpoint_docker_projects(tmp_path: Path) -> Iterator[DockerProjects]:
+    """Track and clean all sandboxes created during one checkpoint test attempt.
+
+    Enter inside the test body so flaky-retry attempts each get a fresh scope.
+    Child harnesses inherit the directory and install their own recorder.
+    """
+    with TemporaryDirectory(prefix="docker-projects-", dir=tmp_path) as directory:
+        projects = DockerProjects(Path(directory))
+        with (
+            patch.dict(os.environ, {PROJECTS_DIR_ENV: directory}),
+            record_docker_projects(),
+        ):
+            try:
+                yield projects
+            finally:
+                projects.cleanup()

--- a/tests/checkpoint/hydrate_interrupt_harness.py
+++ b/tests/checkpoint/hydrate_interrupt_harness.py
@@ -32,6 +32,7 @@ import sys
 import anyio
 
 import inspect_ai.util._checkpoint._resume_copy as resume_copy
+from checkpoint.docker_projects import record_docker_projects
 from checkpoint.resume_kill_harness import crash_signal, run_eval
 
 _original_copy_payload_data = resume_copy._copy_payload_data
@@ -61,7 +62,8 @@ HOOK_NEVER_FIRED_EXIT_CODE = 17
 
 def main() -> None:
     resume_copy._copy_payload_data = _interrupting_copy_payload_data
-    run_eval(sys.argv[1], sys.argv[2])
+    with record_docker_projects():
+        run_eval(sys.argv[1], sys.argv[2])
     # only a run that returned normally without the hook firing is the
     # "seam moved" case; an exception before any copy propagates with its
     # traceback so the test reports the real cause

--- a/tests/checkpoint/resume_kill_harness.py
+++ b/tests/checkpoint/resume_kill_harness.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import anyio
 
+from checkpoint.docker_projects import record_docker_projects
 from inspect_ai import Task, eval, eval_retry, task
 from inspect_ai.agent import react
 from inspect_ai.dataset import Sample
@@ -389,7 +390,8 @@ def run_eval(log_dir: str, retry_from: str | None = None) -> None:
 def main() -> None:
     log_dir = sys.argv[1]
     retry_from = sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] else None
-    run_eval(log_dir, retry_from)
+    with record_docker_projects():
+        run_eval(log_dir, retry_from)
 
 
 if __name__ == "__main__":

--- a/tests/checkpoint/resume_kill_thinking_harness.py
+++ b/tests/checkpoint/resume_kill_thinking_harness.py
@@ -42,6 +42,7 @@ from pathlib import Path
 
 import anyio
 
+from checkpoint.docker_projects import record_docker_projects
 from inspect_ai import Task, eval, eval_retry, task
 from inspect_ai._util.file import local_path
 from inspect_ai.agent import react
@@ -181,7 +182,8 @@ def run_eval(log_dir: str, retry_from: str | None = None) -> None:
 def main() -> None:
     log_dir = sys.argv[1]
     retry_from = sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] else None
-    run_eval(log_dir, retry_from)
+    with record_docker_projects():
+        run_eval(log_dir, retry_from)
 
 
 if __name__ == "__main__":

--- a/tests/checkpoint/resume_scoring_kill_harness.py
+++ b/tests/checkpoint/resume_scoring_kill_harness.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import anyio
 
+from checkpoint.docker_projects import record_docker_projects
 from inspect_ai import Task, eval, eval_retry, task
 from inspect_ai.agent import react
 from inspect_ai.dataset import Sample
@@ -258,7 +259,8 @@ def run_eval(log_dir: str, retry_from: str | None = None) -> None:
 def main() -> None:
     log_dir = sys.argv[1]
     retry_from = sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] else None
-    run_eval(log_dir, retry_from)
+    with record_docker_projects():
+        run_eval(log_dir, retry_from)
 
 
 if __name__ == "__main__":

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -49,8 +49,15 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 import pytest
+from pytest_mock import MockerFixture
 from test_helpers.utils import flaky_retry, skip_if_no_anthropic, skip_if_no_docker
 
+import inspect_ai.util._sandbox.docker.docker as docker_provider
+from checkpoint.docker_projects import (
+    PROJECTS_DIR_ENV,
+    DockerProjects,
+    checkpoint_docker_projects,
+)
 from checkpoint.hydrate_interrupt_harness import HOOK_NEVER_FIRED_EXIT_CODE
 from checkpoint.resume_kill_harness import (
     B_CONTENT,
@@ -86,6 +93,7 @@ from inspect_ai.util._checkpoint._snapshot import (
     STRATEGY_RESTIC,
     snapshot_strategy_name,
 )
+from inspect_ai.util._sandbox.docker.util import ComposeProject
 
 
 def assert_spans_balanced(events: list[Event]) -> None:
@@ -166,51 +174,94 @@ def _run_interrupted_attempt(
         )
 
 
-def _project_prefix(task_name: str) -> str:
-    """Compose-project name prefix for evals of `task_name`.
-
-    Mirrors `task_project_name` in inspect's docker provider
-    (`inspect-{task[:12].rstrip('_')}-i{suffix}`), minus the random suffix.
-    """
-    return f"inspect-{task_name[:12].rstrip('_')}-"
-
-
-def _inspect_projects(prefix: str) -> set[str]:
-    """Names of this harness's docker compose projects currently known to docker.
-
-    Must be scoped to this test's own task (`prefix`): docker state is
-    machine-global, and under xdist a global before/after diff sweeps up —
-    and force-removes — live containers belonging to concurrently running
-    tests on other workers (#264).
-    """
-    result = subprocess.run(
-        ["docker", "compose", "ls", "--all", "--format", "json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return set()
+@skip_if_no_docker
+@pytest.mark.slow
+def test_checkpoint_cleanup_preserves_peer_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup after a killed child must leave a same-task peer alive."""
+    tests_dir = Path(__file__).parent.parent
+    peer_directory = tmp_path / "peer-projects"
+    peer_directory.mkdir(exist_ok=True)
+    peer = DockerProjects(peer_directory)
     try:
-        projects = json.loads(result.stdout or "[]")
-    except json.JSONDecodeError:
-        return set()
-    return {p.get("Name", "") for p in projects if p.get("Name", "").startswith(prefix)}
+        with checkpoint_docker_projects(tmp_path) as owned:
+            for name in ("owned", "peer"):
+                cancel_file = tmp_path / f"{name}-cancels.txt"
+                cancel_file.unlink(missing_ok=True)
+                with monkeypatch.context() as env:
+                    env.setenv(CANCEL_FILE_ENV, str(cancel_file))
+                    env.setenv(TARGET_ENV, "1")
+                    if name == "peer":
+                        env.setenv(PROJECTS_DIR_ENV, str(peer_directory))
+                    _run_interrupted_attempt(str(tmp_path / name), None, tests_dir)
+
+            owned_ids = owned.container_ids()
+            peer_ids = peer.container_ids()
+            assert len(owned_ids) == len(peer_ids) == 1
+            assert set(owned_ids).isdisjoint(peer_ids)
+            owned.cleanup()
+            assert owned.container_ids() == []
+            assert peer.container_ids() == peer_ids
+            subprocess.run(
+                ["docker", "exec", peer_ids[0], "true"],
+                capture_output=True,
+                check=True,
+                timeout=60,
+            )
+    finally:
+        peer.cleanup()
 
 
-def _project_container_ids(name: str) -> list[str]:
-    """Container ids belonging to a compose project."""
-    return subprocess.run(
-        ["docker", "ps", "-aq", "--filter", f"label=com.docker.compose.project={name}"],
-        capture_output=True,
-        text=True,
-    ).stdout.split()
+def test_checkpoint_project_tracking_cleans_failed_startup(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """A failure during startup must not leave an unrecorded sandbox."""
+    startup = mocker.patch.object(
+        docker_provider, "project_startup", side_effect=RuntimeError("startup failed")
+    )
+    docker_run = mocker.patch(
+        "checkpoint.docker_projects.subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, stdout="owned-container\n"),
+    )
+    project = ComposeProject(
+        name="inspect-resume_decod-i123456",
+        config=None,
+        sample_id="resume",
+        epoch=1,
+        env=None,
+    )
+    with pytest.raises(RuntimeError, match="startup failed"):
+        with checkpoint_docker_projects(tmp_path):
+            getattr(docker_provider, "project_startup")(project)
+
+    startup.assert_called_once_with(project)
+    assert docker_run.call_args_list[0].args[0] == [
+        "docker",
+        "ps",
+        "-aq",
+        "--filter",
+        f"label=com.docker.compose.project={project.name}",
+    ]
+    assert docker_run.call_args_list[1].args[0] == [
+        "docker",
+        "rm",
+        "-f",
+        "owned-container",
+    ]
 
 
-def _force_remove_project(name: str) -> None:
-    """Best-effort force-remove the containers of a leaked compose project."""
-    ids = _project_container_ids(name)
-    if ids:
-        subprocess.run(["docker", "rm", "-f", *ids], capture_output=True)
+def test_checkpoint_project_query_failure_is_not_an_empty_sandbox(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """Docker query failures must not satisfy the SIGINT no-leak assertion."""
+    (tmp_path / "inspect-resume_decod-i123456").touch()
+    mocker.patch(
+        "checkpoint.docker_projects.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, ["docker", "ps"]),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        DockerProjects(tmp_path).container_ids()
 
 
 def _assert_snapshot_dir_hidden(container_id: str, strategy: str) -> None:
@@ -349,9 +400,7 @@ def test_checkpoint_resume_restores_assistant_internal(
     crash_file.unlink(missing_ok=True)
     shutil.rmtree(log_dir, ignore_errors=True)
 
-    prefix = _project_prefix("resume_thinking_task")
-    projects_before = _inspect_projects(prefix)
-    try:
+    with checkpoint_docker_projects(tmp_path):
         _run_interrupted_attempt(
             log_dir, None, tests_dir, harness_name="resume_kill_thinking_harness.py"
         )
@@ -366,9 +415,6 @@ def test_checkpoint_resume_restores_assistant_internal(
         resume = eval_retry(
             read_eval_log(killed_log), log_dir=log_dir, display="plain"
         )[0]
-    finally:
-        for name in _inspect_projects(prefix) - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1
@@ -404,9 +450,7 @@ def test_checkpoint_resume_carries_budget_usage(
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
 
-    prefix = _project_prefix("resume_decode_task")
-    projects_before = _inspect_projects(prefix)
-    try:
+    with checkpoint_docker_projects(tmp_path):
         _run_interrupted_attempt(log_dir, None, tests_dir)
 
         killed_log = _latest_log(log_dir)
@@ -417,9 +461,6 @@ def test_checkpoint_resume_carries_budget_usage(
 
         reset_generates()
         resume = eval_retry(read_eval_log(killed_log), log_dir=log_dir)[0]
-    finally:
-        for name in _inspect_projects(prefix) - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1
@@ -466,21 +507,12 @@ def test_checkpoint_resume_rehydrated_event_layout(
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
 
-    # A hard kill skips sandbox teardown, so each killed attempt leaks its
-    # sandbox container. Track this harness's projects before/after and
-    # force-remove the ones this test leaks (the final resume cleans up its
-    # own).
-    prefix = _project_prefix("resume_decode_task")
-    projects_before = _inspect_projects(prefix)
-    try:
+    with checkpoint_docker_projects(tmp_path) as projects:
         # --- attempt #0: fresh eval, interrupted at turn 2 (after ck1/ck2) --
         _run_interrupted_attempt(log_dir, None, tests_dir, interrupt)
 
-        leaked = [
-            cid
-            for name in _inspect_projects(prefix) - projects_before
-            for cid in _project_container_ids(name)
-        ]
+        assert list(projects.directory.iterdir()), "child recorded no sandbox projects"
+        leaked = projects.container_ids()
         if interrupt == "SIGKILL":
             # The hard kill leaves the attempt's sandbox container running —
             # probe it for the snapshot dir's location and permissions.
@@ -495,9 +527,6 @@ def test_checkpoint_resume_rehydrated_event_layout(
         # --- final resume: runs in this process, to completion --------------
         reset_generates()
         resume = eval_retry(read_eval_log(_latest_log(log_dir)), log_dir=log_dir)[0]
-    finally:
-        for name in _inspect_projects(prefix) - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1
@@ -709,9 +738,7 @@ def test_checkpoint_resume_survives_interrupted_hydration(
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
 
-    prefix = _project_prefix("resume_decode_task")
-    projects_before = _inspect_projects(prefix)
-    try:
+    with checkpoint_docker_projects(tmp_path):
         # --- attempt #0: fresh eval, hard-killed at turn 2 (ck1/ck2) -----
         _run_interrupted_attempt(log_dir, None, tests_dir)
         source_log = _latest_log(log_dir)
@@ -729,9 +756,6 @@ def test_checkpoint_resume_survives_interrupted_hydration(
         # --- final resume: from the source log, in-process, to completion
         reset_generates()
         resume = eval_retry(read_eval_log(source_log), log_dir=log_dir)[0]
-    finally:
-        for name in _inspect_projects(prefix) - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1
@@ -797,9 +821,7 @@ def test_checkpoint_retry_preserves_queued_sample_checkpoints(
 
     tests_dir = Path(__file__).parent.parent
 
-    prefix = _project_prefix("resume_two_sample_task")
-    projects_before = _inspect_projects(prefix)
-    try:
+    with checkpoint_docker_projects(tmp_path):
         # --- attempt #0: both samples in flight, killed once B checkpointed
         _run_interrupted_attempt(log_dir, None, tests_dir)
         first_log = _latest_log(log_dir)
@@ -830,9 +852,6 @@ def test_checkpoint_retry_preserves_queued_sample_checkpoints(
         resume = eval_retry(read_eval_log(second_log), log_dir=log_dir, max_samples=1)[
             0
         ]
-    finally:
-        for name in _inspect_projects(prefix) - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 2

--- a/tests/checkpoint/test_checkpoint_scoring_resume_e2e.py
+++ b/tests/checkpoint/test_checkpoint_scoring_resume_e2e.py
@@ -22,7 +22,6 @@ inside the sandbox, which only works with a Linux container.
 
 from __future__ import annotations
 
-import json
 import os
 import signal
 import subprocess
@@ -32,6 +31,7 @@ from pathlib import Path
 import pytest
 from test_helpers.utils import skip_if_no_docker
 
+from checkpoint.docker_projects import checkpoint_docker_projects
 from checkpoint.resume_scoring_kill_harness import (
     ANSWER,
     BUDGET_ENV,
@@ -76,48 +76,6 @@ def _run_killed_attempt(log_dir: str, retry_from: str | None, tests_dir: Path) -
     )
 
 
-# compose-project name prefix for the harness's `resume_scoring_task` evals
-# (mirrors `task_project_name`: `inspect-{task[:12].rstrip('_')}-i{suffix}`)
-_PROJECT_PREFIX = "inspect-resume_scori-"
-
-
-def _inspect_projects() -> set[str]:
-    """Names of this harness's docker compose projects currently known to docker.
-
-    Must be scoped to this test's own task: docker state is machine-global,
-    and under xdist a global before/after diff sweeps up — and force-removes —
-    live containers belonging to concurrently running tests on other workers
-    (meridianlabs-ai/actions#264).
-    """
-    result = subprocess.run(
-        ["docker", "compose", "ls", "--all", "--format", "json"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return set()
-    try:
-        projects = json.loads(result.stdout or "[]")
-    except json.JSONDecodeError:
-        return set()
-    return {
-        p.get("Name", "")
-        for p in projects
-        if p.get("Name", "").startswith(_PROJECT_PREFIX)
-    }
-
-
-def _force_remove_project(name: str) -> None:
-    """Best-effort force-remove the containers of a leaked compose project."""
-    ids = subprocess.run(
-        ["docker", "ps", "-aq", "--filter", f"label=com.docker.compose.project={name}"],
-        capture_output=True,
-        text=True,
-    ).stdout.split()
-    if ids:
-        subprocess.run(["docker", "rm", "-f", *ids], capture_output=True)
-
-
 @skip_if_no_docker
 @pytest.mark.slow
 def test_checkpoint_scoring_phase_resume_over_budget(
@@ -142,15 +100,11 @@ def test_checkpoint_scoring_phase_resume_over_budget(
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
 
-    projects_before = _inspect_projects()
-    try:
+    with checkpoint_docker_projects(tmp_path):
         _run_killed_attempt(log_dir, None, tests_dir)
 
         reset_generates()
         resume = eval_retry(read_eval_log(_latest_log(log_dir)), log_dir=log_dir)[0]
-    finally:
-        for name in _inspect_projects() - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1
@@ -185,20 +139,13 @@ def test_checkpoint_scoring_phase_resume(
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
 
-    # A hard kill skips sandbox teardown, so the killed attempt leaks its
-    # sandbox container. Track inspect projects before/after and force-remove
-    # the ones this test leaks (the final resume cleans up its own).
-    projects_before = _inspect_projects()
-    try:
+    with checkpoint_docker_projects(tmp_path):
         # --- attempt #0: fresh eval; agent completes, scorer hard-kills ------
         _run_killed_attempt(log_dir, None, tests_dir)
 
         # --- final resume: runs in this process, scoring-phase only ----------
         reset_generates()
         resume = eval_retry(read_eval_log(_latest_log(log_dir)), log_dir=log_dir)[0]
-    finally:
-        for name in _inspect_projects() - projects_before:
-            _force_remove_project(name)
 
     assert resume.status == "success"
     assert resume.samples is not None and len(resume.samples) == 1


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Parallel checkpoint tests discover Docker projects by a shared task-name prefix. Their leak assertions can see a peer's containers, and cleanup can delete a peer's live sandbox. The scheduled parallel suite hits this race; Build's checkpoint slow-tests job currently runs serially.

Fixes https://github.com/meridianlabs-ai/inspect_ai/issues/444

### What is the new behavior?

Each checkpoint test records the exact projects created by its child processes and in-process resumes, before sandbox startup. Assertions and cleanup use only those project identities. Both checkpoint e2e files share this helper, and each flaky-retry attempt gets a fresh tracking directory.

The regression test leaves two same-task sandboxes alive after killing their child processes, cleans one owner's sandbox, and verifies the peer still executes commands. Additional tests cover cleanup after failed startup and propagation of Docker query errors. Existing SIGINT/SIGKILL and checkpoint-resume assertions remain in place.

Build's checkpoint slow-tests job now uses `-n logical` with the existing worksteal scheduler.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test and CI changes only.

### Other information:

- `uv run make check`: passed, including mypy and the suppression gate.
- `uv run make test`: running; result will be added when complete.

### Slow tests

- Before: `uv run pytest --runslow -m slow tests/checkpoint/ -n 4` produced 1 failed, 19 passed, 11 skipped in 176.30s. `test_checkpoint_resume_rehydrated_event_layout[SIGKILL-restic]` could not find its killed child's sandbox.
- After: the same command passed 21 tests, with 11 skipped, in 121.48s. This includes the new Docker ownership regression. Ten skips require trio; one requires the API-test flag.
- `uv run pytest --runslow tests/checkpoint/ -n 8`: running; result will be added when complete.
- No live-provider or separate trio run was performed locally. The sibling slow-tool jobs are unchanged.
- A dispatch of the scheduled suite against this PR ref will provide broader integration proof.

### Agent review

Authored with Codex.

- Reviewer: Codex (GPT-6), 1 independent pass in a fresh context without the authoring conversation; whether the author used a different model is unknown.
- Scope: all eight changed files at `f63db42`, tracing Docker project ownership, startup/cleanup ordering, child-process tracking, retry isolation, and CI configuration.
- Findings: no actionable defects found; no fixes or dismissed findings.
- Validation: `python -m pytest --runslow tests/checkpoint/test_checkpoint_e2e.py tests/checkpoint/test_checkpoint_scoring_resume_e2e.py -n 4 -q --tb=short -x` — 13 passed, 1 skipped (live Anthropic API), in 136 seconds. Both new helper unit tests also passed separately. The review run used an isolated checkout and OpenAI SDK 3.8.0 after the installed SDK failed during fixture setup.
- CI at the reviewed commit: checkpoint slow tests passed with four workers (21 passed, 11 skipped); all other executed PR checks passed. `git diff --check` also passed.

