### PR TITLE
Attach a default run configuration to task definitions with @task(default_config=...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
 - Scoring: `math()` now raises an error when no reference answer can be parsed instead of silently excluding the sample from metrics.
 - Scoring: `choice()` now raises an error for samples without answer options instead of silently scoring them incorrect.
+- Evaluation: Read, validate, and apply run configuration files from Python, with optional deferred model initialization and CLI-compatible overrides.
 
 ## 0.3.263 (03 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Scoring: `math()` now raises an error when no reference answer can be parsed instead of silently excluding the sample from metrics.
 - Scoring: `choice()` now raises an error for samples without answer options instead of silently scoring them incorrect.
 - Evaluation: Read, validate, and apply run configuration files from Python, with optional deferred model initialization and CLI-compatible overrides.
+- Tasks: Attach default run configuration files to task definitions, with runtime overrides, opt-out, and configuration provenance in evaluation logs.
 
 ## 0.3.263 (03 September 2026)
 

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -690,7 +690,7 @@ This closes the round-trip: `eval → log → export-config → eval`. By defaul
 
 See [Run Config File](tasks.qmd#run-config) for the full schema that `--run-config` accepts.
 
-Logs record an optional `eval.run_config_source` identifying an applied task-default file (`task_default:<resolved-path>`) or a CLI-selected file (`cli:<path>`). Export includes the effective settings, including overrides, rather than a dependency on that file. Replaying the export with `--run-config` replaces any default attached to the task, so the original default file can change or be unavailable without affecting the replay. Operational settings such as logging and parallelism remain omitted from exported configurations.
+Logs record an optional `eval.run_config_source` identifying an applied task-default file (`task_default:<resolved-path>`) or a CLI-selected file (`cli:<path>`). A retry keeps the original run's value, since the settings it replays came from that file, but does not read the file or show the default-config notice. Export includes the effective settings, including overrides, rather than a dependency on that file. Replaying the export with `--run-config` replaces any default attached to the task, so the original default file can change or be unavailable without affecting the replay. Operational settings such as logging and parallelism remain omitted from exported configurations.
 
 ### Log Schema
 

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -690,6 +690,8 @@ This closes the round-trip: `eval → log → export-config → eval`. By defaul
 
 See [Run Config File](tasks.qmd#run-config) for the full schema that `--run-config` accepts.
 
+Logs record an optional `eval.run_config_source` identifying an applied task-default file (`task_default:<resolved-path>`) or a CLI-selected file (`cli:<path>`). Export includes the effective settings, including overrides, rather than a dependency on that file. Replaying the export with `--run-config` replaces any default attached to the task, so the original default file can change or be unavailable without affecting the replay. Operational settings such as logging and parallelism remain omitted from exported configurations.
+
 ### Log Schema
 
 Log files are stored in JSON. You can get the JSON schema for the log file format with a call to `inspect log schema`:

--- a/docs/options.qmd
+++ b/docs/options.qmd
@@ -62,6 +62,8 @@ For more detail on the different methods of configuration, see [Configuration](t
 |--|--|
 | `--run-config` | YAML or JSON file with the complete run configuration — task, model, model roles, generate config, solver, and eval config — in one place. Explicit CLI flags override values from this file. Cannot be combined with `--generate-config`, `--task-config`, or `--solver-config`. See [Run Config File](tasks.qmd#run-config). |
 
+Use `--no-default-config` to skip run configuration files attached to task definitions. The corresponding Python option is `default_config=False`, and the environment variable is `INSPECT_EVAL_NO_DEFAULT_CONFIG`. Selecting `--run-config` also replaces any attached default. See [Default Run Config](tasks.qmd#default-run-config).
+
 ## Model Provider
 
 |                    |                                              |

--- a/docs/reference/inspect_ai.qmd
+++ b/docs/reference/inspect_ai.qmd
@@ -10,6 +10,12 @@ description: Tasks, evaluation, and scoring.
 ### eval_set
 ### score
 
+## Run Configuration
+
+### RunConfig
+### read_run_config
+### merge_run_config_params
+
 ## Tasks
 
 ### Task

--- a/docs/tasks.qmd
+++ b/docs/tasks.qmd
@@ -632,6 +632,72 @@ eval(**params)
 
 `merge_run_config_params()` follows CLI precedence: task arguments, model arguments, and model roles merge by key, while other values replace the configured value. Overrides of `None`, empty dictionaries, and `score=True` are ignored to match CLI defaults; this is not a general-purpose dictionary merge.
 
+### Default Run Config {#default-run-config}
+
+A task author can attach recommended run settings to a task definition with `@task(default_config=...)`. The path is resolved relative to the Python file defining the task. Include the configuration file as package data when distributing the task.
+
+``` python
+@task(default_config="recommended.yaml")
+def my_task(category: str | None = None) -> Task:
+    return Task(dataset=load_dataset(category), scorer=match())
+```
+
+The file uses the run-config format. The `task` section may omit the task reference and provide only `args`, or it may name the task it is attached to by its registry name (`my_task` here; `my_package/my_task` for tasks registered by a package):
+
+``` yaml
+task:
+  task: my_task
+  args:
+    category: Math
+
+generate_config:
+  temperature: 0.5
+  max_tokens: 2048
+
+model_roles:
+  grader:
+    model: openai/gpt-4o
+
+eval_config:
+  epochs: 3
+  message_limit: 50
+```
+
+Naming the task documents which task the file was written for and lets the same file select that task when passed standalone via `--run-config`. It cannot redirect a run: a task default that names any other task is rejected with an error identifying both tasks.
+
+A task default cannot set the top-level `model`, including its base URL or arguments. The evaluated model remains the runner's choice. Auxiliary models belong in `model_roles`.
+
+Inspect applies the file when resolving a task function, registered task name, or source-file reference. This includes `eval()`, `eval_async()`, `eval_set()`, and their CLI equivalents. Task arguments from the file are merged before invoking the function. Supplied arguments take precedence per parameter, including `None`, `False`, zero, and empty collections. Python signature defaults fill arguments absent from both sources. Runtime settings from the file override `Task(...)` constructor values, and supplied evaluation settings take precedence over the file.
+
+``` python
+eval(my_task, model="openai/gpt-4o", task_args={"category": None}, epochs=1)
+```
+
+Direct function calls retain ordinary Python behavior and do not read the attached file. Passing a constructed task to Inspect also skips the entire attached default, so these forms differ:
+
+``` python
+eval(my_task, model="openai/gpt-4o")
+eval(my_task(category="Math"), model="openai/gpt-4o")
+```
+
+The first form applies `recommended.yaml`. The second uses only the arguments passed to `my_task`, its Python defaults, and its constructor settings before applying any evaluation overrides. Use the second form when composing tasks with `task_with()`. Parameters with no Python fallback remain required for direct calls.
+
+To resolve a task definition without applying its attached configuration, use `default_config=False` or `--no-default-config`:
+
+``` python
+eval(my_task, model="openai/gpt-4o", default_config=False)
+```
+
+``` bash
+inspect eval tasks.py@my_task --model openai/gpt-4o --no-default-config
+```
+
+An expressly selected `--run-config` replaces the attached default entirely, even if the selected file is empty. When applying a standalone run config through the Python API, pass `default_config=False` alongside the parameters returned by `to_params()`. Disabling or replacing a default skips reading it, so a missing default file does not prevent those runs.
+
+`list_tasks()` exposes the declared path through `TaskInfo.default_config`; `inspect list tasks --json` includes it in `attribs.default_config`. Discovery does not read or validate the file. Validation occurs when Inspect resolves the task for execution.
+
+Runs using a task default display its filename and record `EvalSpec.run_config_source` as `task_default:<resolved-path>`. CLI-selected files are recorded as `cli:<path>`. `inspect log export-config` exports the effective settings for replay without the attached file, and retries preserve the settings recorded in the original log.
+
 ### Scorer Override {#scorer-override}
 
 The scorer can only be overridden with `task_with()` during a live eval; there is no `eval()` parameter or CLI flag for it:

--- a/docs/tasks.qmd
+++ b/docs/tasks.qmd
@@ -615,6 +615,23 @@ inspect eval --run-config run.yaml
 
 See [Exporting Run Config](eval-logs.qmd#exporting-run-config) for details.
 
+#### Python API
+
+Use `read_run_config()` to read and validate the same YAML or JSON file from Python. It returns a `RunConfig` without instantiating models or loading tasks and solvers, so inspecting a configuration does not require model API credentials. Local paths, `file://` URIs, and remote filesystem URLs (such as `s3://bucket/run.yaml`) are supported.
+
+``` python
+from inspect_ai import eval, merge_run_config_params, read_run_config
+
+config = read_run_config("run.yaml")
+params = config.to_params(resolve_models=False)
+params = merge_run_config_params(params, {"temperature": 0.9, "limit": 10})
+eval(**params)
+```
+
+`to_params()` converts the configuration to `eval()` keyword arguments. By default it instantiates models assigned to roles, matching the CLI. With `resolve_models=False`, role values remain `ModelConfig` objects, which `eval()` resolves when the evaluation runs. The main model is represented by its name and separate configuration arguments in either mode. You can also validate an in-memory dictionary with `RunConfig.model_validate(data)`.
+
+`merge_run_config_params()` follows CLI precedence: task arguments, model arguments, and model roles merge by key, while other values replace the configured value. Overrides of `None`, empty dictionaries, and `score=True` are ignored to match CLI defaults; this is not a general-purpose dictionary merge.
+
 ### Scorer Override {#scorer-override}
 
 The scorer can only be overridden with `task_with()` during a live eval; there is no `eval()` parameter or CLI flag for it:

--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -6,6 +6,11 @@ from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
 from inspect_ai._eval.evalset import eval_set, task_identifier
 from inspect_ai._eval.list import list_tasks
 from inspect_ai._eval.registry import task, task_source
+from inspect_ai._eval.run_config import (
+    RunConfig,
+    merge_run_config_params,
+    read_run_config,
+)
 from inspect_ai._eval.score import score, score_async
 from inspect_ai._eval.task import (
     Epochs,
@@ -36,6 +41,9 @@ __all__ = [
     "eval_retry",
     "eval_retry_async",
     "eval_set",
+    "RunConfig",
+    "read_run_config",
+    "merge_run_config_params",
     "task_identifier",
     "list_tasks",
     "score",

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -312,6 +312,13 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         help="YAML or JSON file with full run configuration (task, model, model roles, generate config, solver, eval config). CLI flags override values from this file. Cannot be combined with --generate-config, --task-config, or --solver-config.",
     )
     @click.option(
+        "--no-default-config",
+        is_flag=True,
+        default=False,
+        envvar="INSPECT_EVAL_NO_DEFAULT_CONFIG",
+        help="Ignore default run configurations attached to task definitions.",
+    )
+    @click.option(
         "--model-role",
         multiple=True,
         type=str,
@@ -1088,6 +1095,7 @@ def _eval_command_impl(
     model_config: str | None,
     model_spec: tuple[str, ...] | None,
     run_config: str | None,
+    no_default_config: bool,
     model_role: tuple[str, ...] | None,
     t: tuple[str, ...] | None,
     task_config: str | None,
@@ -1221,6 +1229,7 @@ def _eval_command_impl(
         model_config=model_config,
         model_spec=model_spec,
         run_config=run_config,
+        no_default_config=no_default_config,
         model_role=model_role,
         t=t,
         task_config=task_config,
@@ -1409,6 +1418,7 @@ def eval_set_command(
     model_config: str | None,
     model_spec: tuple[str, ...] | None,
     run_config: str | None,
+    no_default_config: bool,
     model_role: tuple[str, ...] | None,
     t: tuple[str, ...] | None,
     task_config: str | None,
@@ -1559,6 +1569,7 @@ def eval_set_command(
             model_config=model_config,
             model_spec=model_spec,
             run_config=run_config,
+            no_default_config=no_default_config,
             model_role=model_role,
             t=t,
             task_config=task_config,
@@ -1729,6 +1740,7 @@ def eval_exec(
     model_config: str | None,
     model_spec: tuple[str, ...] | None,
     run_config: str | None,
+    no_default_config: bool,
     model_role: tuple[str, ...] | None,
     t: tuple[str, ...] | None,
     task_config: str | None,
@@ -1981,31 +1993,35 @@ def eval_exec(
         merge_run_config_params(run_params, cli_params) if run_params else cli_params
     )
 
+    params["default_config"] = not (no_default_config or run_config is not None)
+    from inspect_ai._eval.task_defaults import run_config_source
+
     # evaluate
-    if is_eval_set:
-        params["retry_attempts"] = retry_attempts
-        params["retry_immediate"] = retry_immediate
-        params["retry_wait"] = retry_wait
-        params["retry_connections"] = retry_connections
-        params["retry_cleanup"] = retry_cleanup
-        params["incomplete_action"] = incomplete_action
-        params["incomplete_max"] = incomplete_max
-        params["bundle_dir"] = bundle_dir
-        params["bundle_overwrite"] = bundle_overwrite
-        params["embed_viewer"] = embed_viewer
-        params["log_dir_allow_dirty"] = log_dir_allow_dirty
-        params["eval_set_id"] = eval_set_id
-        if json_output:
-            return _eval_exec_json(lambda: eval_set(**params), is_eval_set=True)
-        success, _ = eval_set(**params)
-        return success
-    else:
-        params["log_header_only"] = True  # cli invocation doesn't need full log
-        if json_output:
-            _eval_exec_json(lambda: (True, eval(**params)))
+    with run_config_source(f"cli:{run_config}" if run_config is not None else None):
+        if is_eval_set:
+            params["retry_attempts"] = retry_attempts
+            params["retry_immediate"] = retry_immediate
+            params["retry_wait"] = retry_wait
+            params["retry_connections"] = retry_connections
+            params["retry_cleanup"] = retry_cleanup
+            params["incomplete_action"] = incomplete_action
+            params["incomplete_max"] = incomplete_max
+            params["bundle_dir"] = bundle_dir
+            params["bundle_overwrite"] = bundle_overwrite
+            params["embed_viewer"] = embed_viewer
+            params["log_dir_allow_dirty"] = log_dir_allow_dirty
+            params["eval_set_id"] = eval_set_id
+            if json_output:
+                return _eval_exec_json(lambda: eval_set(**params), is_eval_set=True)
+            success, _ = eval_set(**params)
+            return success
         else:
-            eval(**params)
-        return True
+            params["log_header_only"] = True  # cli invocation doesn't need full log
+            if json_output:
+                _eval_exec_json(lambda: (True, eval(**params)))
+            else:
+                eval(**params)
+            return True
 
 
 def _eval_exec_json(

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1643,7 +1643,7 @@ def eval_set_command(
 
 
 def parse_run_config(config: str) -> dict[str, Any]:
-    run_config: RunConfigInput = read_run_config(config)
+    run_config = read_run_config(config)
     return run_config.to_params()
 
 

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -7,13 +7,6 @@ from collections.abc import Callable, Iterator
 from typing import Any, Literal, TextIO, cast
 
 import click
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationError,
-    field_validator,
-)
 from typing_extensions import Unpack
 
 from inspect_ai import Epochs, eval, eval_retry
@@ -23,7 +16,14 @@ from inspect_ai._eval.handoff import (
     set_ctl_pointer_armed,
     set_launch_handoff_listener,
 )
-from inspect_ai._util.config import parse_cli_args, resolve_args
+from inspect_ai._eval.run_config import RunConfigInput as RunConfigInput
+from inspect_ai._eval.run_config import SolverInput as SolverInput
+from inspect_ai._eval.run_config import TaskInput as TaskInput
+from inspect_ai._eval.run_config import (
+    merge_run_config_params as merge_run_config_params,
+)
+from inspect_ai._eval.run_config import read_run_config
+from inspect_ai._util.config import parse_cli_args
 from inspect_ai._util.constants import (
     ALL_LOG_LEVELS,
     DEFAULT_BATCH_SIZE,
@@ -46,17 +46,15 @@ from inspect_ai._util.generate_config_args import (
 from inspect_ai._util.samples import parse_sample_id, parse_samples_limit
 from inspect_ai.log import IncompleteAction
 from inspect_ai.log._file import log_file_info
-from inspect_ai.log._log import EvalConfig, EvalLog
-from inspect_ai.model import GenerateConfig, GenerateConfigArgs, Model
+from inspect_ai.log._log import EvalLog
+from inspect_ai.model import GenerateConfigArgs, Model
 from inspect_ai.model._generate_config import (  # noqa: F811
     ResponseSchema,
 )
-from inspect_ai.model._model_config import ModelConfig, model_config_to_model
 from inspect_ai.scorer._reducer import create_reducers
 from inspect_ai.solver._solver import SolverSpec
 from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
 from inspect_ai.util._limit import TokenLimit
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 from .common import (
     CommonOptions,
@@ -1644,161 +1642,9 @@ def eval_set_command(
     ctx.exit(0 if success else 1)
 
 
-class TaskInput(BaseModel):
-    task: str
-    args: dict[str, Any] = Field(default_factory=dict)
-
-
-class SolverInput(BaseModel):
-    solver: str
-    args: dict[str, Any] = Field(default_factory=dict)
-
-
-class RunConfigInput(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    task: str | TaskInput | None = None
-    model: str | ModelConfig | None = None
-    model_roles: dict[str, ModelConfig | list[ModelConfig]] = Field(
-        default_factory=dict
-    )
-    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
-    eval_config: EvalConfig = Field(default_factory=EvalConfig)
-    solver: str | SolverInput | None = None
-    tags: list[str] = Field(default_factory=list)
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    sandbox: str | SandboxEnvironmentSpec | None = None
-
-    @field_validator("generate_config", mode="before")
-    @classmethod
-    def check_generate_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown generate_config fields: {unknown}")
-        return v
-
-    @field_validator("eval_config", mode="before")
-    @classmethod
-    def check_eval_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown eval_config fields: {unknown}")
-        return v
-
-    def to_params(self) -> dict[str, Any]:
-        params: dict[str, Any] = {}
-
-        # Task
-        if self.task is not None:
-            if isinstance(self.task, str):
-                params["tasks"] = self.task
-            else:
-                params["tasks"] = self.task.task
-                if self.task.args:
-                    params["task_args"] = self.task.args
-
-        # Model
-        if self.model is not None:
-            if isinstance(self.model, str):
-                params["model"] = self.model
-            else:
-                params["model"] = self.model.model
-                if self.model.base_url is not None:
-                    params["model_base_url"] = self.model.base_url
-                if self.model.args:
-                    params["model_args"] = self.model.args
-                model_gc = self.model.config.model_dump(exclude_none=True)
-                if model_gc:
-                    params.update(model_gc)
-
-        # Top-level generate_config overrides any model-level config
-        top_gc = self.generate_config.model_dump(exclude_none=True)
-        if top_gc:
-            params.update(top_gc)
-
-        # Model roles
-        if self.model_roles:
-            params["model_roles"] = {
-                role: [model_config_to_model(m) for m in mc]
-                if isinstance(mc, list)
-                else model_config_to_model(mc)
-                for role, mc in self.model_roles.items()
-            }
-
-        # Solver
-        if self.solver is not None:
-            if isinstance(self.solver, str):
-                params["solver"] = SolverSpec(self.solver, {}, {})
-            else:
-                params["solver"] = SolverSpec(
-                    self.solver.solver, self.solver.args, self.solver.args
-                )
-
-        # Eval config — combine epochs + epochs_reducer into Epochs
-        ec = self.eval_config.model_dump(exclude_none=True)
-        epochs = ec.pop("epochs", None)
-        epochs_reducer = ec.pop("epochs_reducer", None)
-        if epochs is not None:
-            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
-        params.update(ec)
-
-        # Tags and metadata
-        if self.tags:
-            params["tags"] = self.tags
-        if self.metadata:
-            params["metadata"] = self.metadata
-
-        # Sandbox
-        if self.sandbox is not None:
-            if isinstance(self.sandbox, str):
-                params["sandbox"] = parse_sandbox(self.sandbox)
-            else:
-                params["sandbox"] = self.sandbox
-
-        return params
-
-
 def parse_run_config(config: str) -> dict[str, Any]:
-    from jsonschema import Draft7Validator
-
-    config_dict = resolve_args(config)
-    try:
-        run_config = RunConfigInput.model_validate(config_dict)
-    except ValidationError as ex:
-        # Surface a more readable error via Draft7Validator. Fall back to
-        # pydantic's message when the JSON schema doesn't capture the
-        # failure (e.g. custom field_validators on generate_config/eval_config).
-        schema = RunConfigInput.model_json_schema()
-        errors = list(Draft7Validator(schema).iter_errors(config_dict))
-        if errors:
-            message = "\n".join(
-                [f"Invalid run config '{config}':"]
-                + [f" - {error.message}" for error in errors]
-            )
-        else:
-            message = f"Invalid run config '{config}': {ex}"
-        raise PrerequisiteError(message)
+    run_config: RunConfigInput = read_run_config(config)
     return run_config.to_params()
-
-
-def merge_run_config_params(
-    run_params: dict[str, Any], cli_params: dict[str, Any]
-) -> dict[str, Any]:
-    params = dict(run_params)
-    for key, value in cli_params.items():
-        if value is None or value == {}:
-            continue
-        if key == "score" and value is True:
-            continue
-        if key in ("task_args", "model_args") and key in params:
-            params[key] = params[key] | value
-        elif key == "model_roles" and key in params:
-            params[key] = params[key] | value
-        else:
-            params[key] = value
-    return params
 
 
 _SINGLE_MODEL_OPTION_NAMES = {"model", "model_base_url", "model_config", "m"}

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -9,7 +9,7 @@ from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.flag_values import int_bool_or_str_value, int_or_bool_value
 from inspect_ai.model import GenerateConfig, Model, ModelRoles, get_model
 from inspect_ai.util._limit import TokenLimit, parse_token_limit
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+from inspect_ai.util._sandbox.environment import parse_sandbox as parse_sandbox
 
 
 def int_or_bool_flag_callback(
@@ -390,14 +390,3 @@ class SectionedCommand(click.Command):
             if records:
                 with formatter.section(title):
                     formatter.write_dl(records)
-
-
-def parse_sandbox(sandbox: str | None) -> SandboxEnvironmentSpec | None:
-    if sandbox is not None:
-        parts = sandbox.split(":", maxsplit=1)
-        if len(parts) == 1:
-            return SandboxEnvironmentSpec(sandbox)
-        else:
-            return SandboxEnvironmentSpec(parts[0], parts[1])
-    else:
-        return None

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -827,6 +827,7 @@ async def _eval_async_inner(
             notification,
             task_source=task_source,
             input_media_policy="trusted_pre_run",
+            sample_id=sample_id,
         )
 
         # warn and return empty string if we resolved no tasks
@@ -2030,6 +2031,7 @@ def eval_resolve_tasks(
     notification: bool | str | None = None,
     task_source: TaskSource | None = None,
     input_media_policy: InputMediaPolicy = "inline_only",
+    sample_id: str | int | list[str] | list[int] | list[str | int] | None = None,
 ) -> tuple[list[ResolvedTask], list[ApprovalPolicy] | None]:
     # resolve model roles and initialize them in the eval context -- this
     # will enable tasks that reference model roles in their initialization
@@ -2070,6 +2072,7 @@ def eval_resolve_tasks(
                     # (resolve_task_source), so don't warn for that path.
                     warn_unconsumed_task_args=(i == 0 and task_source is None),
                     input_media_policy=input_media_policy,
+                    sample_id=sample_id,
                 )
             )
 

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -111,6 +111,7 @@ from .task.enqueue import (
 from .task.images import InputMediaPolicy
 from .task.resolved import ResolvedTask, resolved_model_names, resolved_task_names
 from .task.tasks import Tasks
+from .task_defaults import with_task_defaults_async
 
 log = logging.getLogger(__name__)
 
@@ -176,6 +177,7 @@ def eval(
     eval_set_tasks: list[str] | None = None,
     scan_id: str | None = None,
     task_retry_attempts: int | None = None,
+    default_config: bool = True,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> list[EvalLog]:
     r"""Evaluate tasks using a Model.
@@ -310,6 +312,8 @@ def eval(
         eval_set_tasks: Names of every task in the eval set, so `task:id` sample selectors resolve the same way for a retried subset of tasks (this is passed from `eval_set()` and should not be specified directly).
         scan_id: Override the scan-dir identifier (defaults to `eval_set_id` or `run_id`). Set by `eval_retry` to reuse the original eval's scan dir.
         task_retry_attempts: Number of times to retry tasks (defaults to 0)
+        default_config: Apply run configuration files attached to task
+            definitions via `@task(default_config=...)` (defaults to True).
         **kwargs: Model generation options.
 
     Returns:
@@ -332,6 +336,7 @@ def eval(
                 model_args=model_args,
                 model_roles=model_roles,
                 task_args=task_args,
+                default_config=default_config,
                 sandbox=sandbox,
                 sandbox_cleanup=sandbox_cleanup,
                 sandbox_prebuilt=sandbox_prebuilt,
@@ -413,6 +418,7 @@ def eval(
 _eval_async_running = False
 
 
+@with_task_defaults_async
 async def eval_async(
     tasks: Tasks,
     model: str | Model | list[str] | list[Model] | None | NotGiven = NOT_GIVEN,
@@ -472,6 +478,7 @@ async def eval_async(
     eval_set_tasks: list[str] | None = None,
     scan_id: str | None = None,
     task_retry_attempts: int | None = None,
+    default_config: bool = True,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> list[EvalLog]:
     r"""Evaluate tasks using a Model (async).
@@ -576,6 +583,8 @@ async def eval_async(
         eval_set_tasks: Names of every task in the eval set, so `task:id` sample selectors resolve the same way for a retried subset of tasks (this is passed from `eval_set()` and should not be specified directly).
         scan_id: Override the scan-dir identifier (defaults to `eval_set_id` or `run_id`). Set by `eval_retry` to reuse the original eval's scan dir.
         task_retry_attempts: Number of times to retry tasks (defaults to 0)
+        default_config: Apply run configuration files attached to task
+            definitions via `@task(default_config=...)` (defaults to True).
         **kwargs: Model generation options.
 
     Returns:
@@ -612,6 +621,7 @@ async def eval_async(
                 model_args=model_args,
                 model_roles=model_roles,
                 task_args=task_args,
+                default_config=default_config,
                 sandbox=sandbox,
                 sandbox_cleanup=sandbox_cleanup,
                 sandbox_prebuilt=sandbox_prebuilt,
@@ -744,6 +754,7 @@ async def _eval_async_inner(
     eval_set_tasks: list[str] | None = None,
     scan_id: str | None = None,
     task_retry_attempts: int | None = None,
+    default_config: bool = True,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> list[EvalLog]:
     from inspect_ai.hooks._hooks import emit_run_end, emit_run_start

--- a/src/inspect_ai/_eval/eval_set_manifest.py
+++ b/src/inspect_ai/_eval/eval_set_manifest.py
@@ -29,6 +29,7 @@ from inspect_ai._eval.task.run import plan_agent_name, resolve_plan
 from inspect_ai._eval.task.task import resolve_epochs, resolve_task_epochs
 from inspect_ai._eval.task.util import resolve_task_sample_ids, sample_id_filter
 from inspect_ai.dataset import Dataset
+from inspect_ai.log._log import EvalConfig
 from inspect_ai.model._model import ModelName
 from inspect_ai.model._model_config import model_args_for_log
 
@@ -278,6 +279,7 @@ def build_eval_set_capture(
         resolve_solver,
         task_identifier,
     )
+    from inspect_ai._eval.task_defaults import resolve_task_eval_config
 
     solver = resolve_solver(eval_set_args.solver)
     eval_epochs = resolve_epochs(epochs)
@@ -286,6 +288,11 @@ def build_eval_set_capture(
     task_names = resolved_task_names(resolved_tasks)
     for task in resolved_tasks:
         epoch_count = resolve_task_epochs(task.task, eval_epochs).epochs
+        # selection mirrors log_samples_complete (eval-set level wins, then
+        # the task default)
+        selection = resolve_task_eval_config(
+            task.run_config, EvalConfig(limit=limit, sample_id=sample_id)
+        )
 
         args_full = getattr(task.task, TASK_ALL_PARAMS_ATTR, None)
 
@@ -314,7 +321,11 @@ def build_eval_set_capture(
                 sequence=task.sequence,
                 identifier=task_identifier(task, eval_set_args),
                 samples=samples_selected(
-                    task.task.dataset, limit, sample_id, task.task.name, task_names
+                    task.task.dataset,
+                    selection.limit,
+                    selection.sample_id,
+                    task.task.name,
+                    task_names,
                 ),
                 epochs=epoch_count,
             )

--- a/src/inspect_ai/_eval/eval_set_overrides.py
+++ b/src/inspect_ai/_eval/eval_set_overrides.py
@@ -421,6 +421,7 @@ NOT_OVERRIDABLE: dict[str, str] = {
     "model_args": "part of task identity",
     "model_roles": "part of task identity",
     "task_args": "part of task identity",
+    "default_config": "part of task identity (decides whether a task's attached default applies, and that default sets identity-bearing values)",
     "solver": "part of task identity",
     "message_limit": "part of task identity",
     "token_limit": "part of task identity",

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -768,6 +768,7 @@ def eval_set(
             sample_shuffle,
             notification=notification,
             input_media_policy="trusted_pre_run",
+            sample_id=sample_id,
         )
         if len(capture_tasks) == 0:
             raise PrerequisiteError(
@@ -858,6 +859,7 @@ def eval_set(
                 sample_shuffle,
                 notification=notification,
                 input_media_policy="trusted_pre_run",
+                sample_id=sample_id,
             )
             if len(resolved) == 0:
                 raise PrerequisiteError(
@@ -1020,6 +1022,7 @@ def eval_set(
             sample_shuffle,
             notification=notification,
             input_media_policy="trusted_pre_run",
+            sample_id=sample_id,
         )
 
         # fail with a legible error if no tasks were found (matches `eval`)

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -142,6 +142,7 @@ from .task.scan import scan_context
 from .task.task import PreviousTask, resolve_epochs, resolve_task_epochs
 from .task.task_source import TaskSource
 from .task.tasks import Tasks
+from .task_defaults import resolve_task_eval_config, with_task_defaults
 
 if TYPE_CHECKING:
     from inspect_ai._control.eval_state import DeferredStatsProvider
@@ -224,6 +225,7 @@ def _overridden_epochs(
     return epochs
 
 
+@with_task_defaults
 def eval_set(
     tasks: Tasks,
     log_dir: str | None = None,
@@ -291,6 +293,7 @@ def eval_set(
     log_dir_allow_dirty: bool | None = None,
     eval_set_id: str | None = None,
     embed_viewer: bool = False,
+    default_config: bool = True,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> tuple[bool, list[EvalLog]]:
     r"""Evaluate a set of tasks.
@@ -451,6 +454,8 @@ def eval_set(
             for tasks in this eval set (defaults to False).
         eval_set_id: ID for the eval set. If not specified, a unique ID will be generated.
         embed_viewer: If True, embed a log viewer into the log directory.
+        default_config: Apply run configuration files attached to task
+            definitions via `@task(default_config=...)` (defaults to True).
         **kwargs: Model generation options.
 
     Returns:
@@ -522,6 +527,7 @@ def eval_set(
             model_args=model_args,
             model_roles=model_roles,
             task_args=task_args,
+            default_config=default_config,
             sandbox=sandbox,
             sandbox_cleanup=sandbox_cleanup,
             sandbox_prebuilt=sandbox_prebuilt,
@@ -1057,15 +1063,25 @@ def eval_set(
         # for those that haven't run, schedule them into models => tasks groups
         # (exclude logs where sample_shuffle changed with a limit -- a different
         # shuffle selects a different subset of samples so the log can't be reused)
-        reusable_logs = [
-            log
-            for log in all_logs
-            if not shuffle_changed(sample_shuffle, log.header.eval.config, limit)
-        ]
-        log_task_identifiers = [log.task_identifier for log in reusable_logs]
         all_tasks = [
             (task_identifier(task, eval_set_args), task) for task in resolved_tasks
         ]
+        tasks_by_identifier = dict(all_tasks)
+
+        def log_reusable(log: Log) -> bool:
+            # compare against the selection the task actually ran with, which
+            # a task default may have set where this call left it unset
+            task = tasks_by_identifier.get(log.task_identifier)
+            selection = resolve_task_eval_config(
+                task.run_config if task else {},
+                EvalConfig(sample_shuffle=sample_shuffle, limit=limit),
+            )
+            return not shuffle_changed(
+                selection.sample_shuffle, log.header.eval.config, selection.limit
+            )
+
+        reusable_logs = [log for log in all_logs if log_reusable(log)]
+        log_task_identifiers = [log.task_identifier for log in reusable_logs]
         pending_tasks = [
             task[1] for task in all_tasks if task[0] not in log_task_identifiers
         ]
@@ -1837,8 +1853,17 @@ def log_samples_complete(
         return False
     epoch_count = epochs.epochs
 
+    # the log ran with the task default's sample selection where the eval-set
+    # call left it unset, so plan against the same selection
+    selection = resolve_task_eval_config(
+        task.run_config, EvalConfig(limit=limit, sample_id=sample_id)
+    )
     count = samples_selected(
-        task.task.dataset, limit, sample_id, task.task.name, task_names
+        task.task.dataset,
+        selection.limit,
+        selection.sample_id,
+        task.task.name,
+        task_names,
     )
     planned = count * epoch_count
 

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -15,6 +15,7 @@ from inspect_ai._eval.task.resolved import ResolvedTask
 from inspect_ai._eval.task.util import split_spec, task_file, task_run_dir
 from inspect_ai._util.decorator import parse_decorators
 from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.file import local_path
 from inspect_ai._util.logger import warn_once
 from inspect_ai._util.module import load_module
 from inspect_ai._util.path import chdir_python, cwd_relative_path
@@ -28,6 +29,7 @@ from inspect_ai._util.registry import (
 )
 from inspect_ai.agent._agent import Agent
 from inspect_ai.agent._as_solver import as_solver
+from inspect_ai.log._log import EvalConfig
 from inspect_ai.model import Model
 from inspect_ai.scorer._metric import Metric, MetricSpec, metric_create
 from inspect_ai.scorer._scorer import Scorer, ScorerSpec, scorer_create
@@ -49,13 +51,23 @@ from inspect_ai.util._sandbox.environment import (
 from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
 
 from .list import task_files
-from .registry import task_create, task_source_create
+from .registry import task_source_create
 from .task import PreviousTask, Task, TaskInfo
-from .task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from .task.constants import (
+    TASK_DEFAULT_CONFIG_ATTR,
+    TASK_DEFAULT_CONFIG_SOURCE_ATTR,
+    TASK_FILE_ATTR,
+    TASK_RUN_DIR_ATTR,
+)
 from .task.hf import task_create_from_hf
 from .task.run import eval_log_sample_source
 from .task.task_source import TaskSource
 from .task.tasks import Tasks
+from .task_defaults import (
+    create_task_with_defaults,
+    current_run_config_source,
+    resolve_task_eval_config,
+)
 
 logger = getLogger(__name__)
 
@@ -98,14 +110,18 @@ def resolve_tasks(
             "`inspect eval` instead."
         )
 
-    def as_resolved_tasks(tasks: list[Task]) -> list[ResolvedTask]:
+    def as_resolved_tasks(
+        tasks: list[Task], loaded: bool = False
+    ) -> list[ResolvedTask]:
         # shuffle data in tasks if requested
-        if sample_shuffle:
-            for task in tasks:
-                if not task.dataset.shuffled:
-                    task.dataset.shuffle(
-                        None if sample_shuffle is True else sample_shuffle
-                    )
+        for task in tasks:
+            params = getattr(task, TASK_DEFAULT_CONFIG_ATTR, {}) if loaded else {}
+            selection = resolve_task_eval_config(
+                params, EvalConfig(sample_shuffle=sample_shuffle)
+            )
+            shuffle = selection.sample_shuffle
+            if shuffle and not task.dataset.shuffled:
+                task.dataset.shuffle(None if shuffle is True else shuffle)
 
         return [
             ResolvedTask(
@@ -119,6 +135,15 @@ def resolve_tasks(
                 checkpoint=task.checkpoint,
                 sequence=sequence,
                 input_media_policy=input_media_policy,
+                run_config_source=current_run_config_source()
+                or (
+                    getattr(task, TASK_DEFAULT_CONFIG_SOURCE_ATTR, None)
+                    if loaded
+                    else None
+                ),
+                run_config=getattr(task, TASK_DEFAULT_CONFIG_ATTR, {})
+                if loaded
+                else {},
             )
             for sequence, task in enumerate(tasks)
         ]
@@ -126,7 +151,7 @@ def resolve_tasks(
     # an empty list is equivalent to None (load tasks from cwd) — but it
     # must short-circuit before any tasks[0] access below
     if isinstance(tasks, list) and len(tasks) == 0:
-        return as_resolved_tasks(load_tasks(None, task_args))
+        return as_resolved_tasks(load_tasks(None, task_args), loaded=True)
 
     # reflect resolved tasks right back
     if isinstance(tasks, ResolvedTask):
@@ -180,7 +205,9 @@ def resolve_tasks(
         tasks = [tasks]
 
     # done! let's load the tasks
-    return as_resolved_tasks(load_tasks(cast(list[str] | None, tasks), task_args))
+    return as_resolved_tasks(
+        load_tasks(cast(list[str] | None, tasks), task_args), loaded=True
+    )
 
 
 def refers_to_task_source(tasks: Tasks) -> bool:
@@ -303,7 +330,9 @@ def resolve_previous_tasks(
                 loaded_task = previous_task.task
             else:
                 loaded_task_args = previous_task.task_args
-                loaded_task = load_tasks([previous_task.task], loaded_task_args)[0]
+                loaded_task = load_tasks(
+                    [previous_task.task], loaded_task_args, default_config=False
+                )[0]
             if sample_shuffle is not None:
                 if not loaded_task.dataset.shuffled:
                     loaded_task.dataset.shuffle(
@@ -342,8 +371,16 @@ def resolve_previous_task(
         copy.deepcopy(prior_stats.role_usage) if prior_stats.role_usage else None
     )
 
+    # a task the framework constructed with an attached default keeps it
+    # (eval_set resumes with current settings); a task reloaded for
+    # eval_retry has none, and eval_retry replays the logged settings as
+    # explicit arguments instead
     return ResolvedTask(
         task=loaded_task,
+        run_config=getattr(loaded_task, TASK_DEFAULT_CONFIG_ATTR, {}),
+        run_config_source=current_run_config_source()
+        or getattr(loaded_task, TASK_DEFAULT_CONFIG_SOURCE_ATTR, None)
+        or previous_task.log.eval.run_config_source,
         task_args=loaded_task_args,
         task_file=previous_task.log.eval.task_file,
         model=previous_task.model or loaded_task.model or model,
@@ -470,35 +507,87 @@ def resolve_task_file_sandbox(
     return SandboxEnvironmentSpec(sandbox.type, file_path.as_posix())
 
 
+def task_default_factories(tasks: Tasks) -> list[Callable[..., Any]]:
+    """Discover attachments without invoking factories or reading their files.
+
+    Preconstructed, retried, and already-resolved tasks deliberately bypass
+    discovery. File discovery follows the same registration paths as loading.
+    """
+    if tasks is None or tasks == []:
+        tasks = [Path.cwd().as_posix()]
+    entries = tasks if isinstance(tasks, list) else [tasks]
+    factories: list[Callable[..., Any]] = []
+    for entry in entries:
+        if isinstance(entry, (Task, PreviousTask, ResolvedTask, TaskSource)):
+            continue
+        if isinstance(entry, TaskInfo):
+            entry = f"{entry.file}@{entry.name}"
+        if callable(entry):
+            if registry_info(entry).type == "task":
+                factories.append(entry)
+            continue
+        if not isinstance(entry, str) or entry.startswith("hf/"):
+            continue
+        factory = registry_lookup("task", entry)
+        if factory is not None:
+            factories.append(cast(Callable[..., Any], factory))
+            continue
+        if refers_to_task_source(entry):
+            continue
+        path, name = split_spec(entry)
+        if name is not None:
+            load_file_tasks(Path(local_path(path)).absolute())
+            names = [name]
+        else:
+            root = Path.cwd()
+            target = (
+                [] if Path(local_path(path)).resolve() == root else [local_path(path)]
+            )
+            names = []
+            for source in sorted(task_files(target, root)):
+                with chdir_python(source.parent.as_posix()):
+                    names.extend(_load_task_specs(source))
+        for name in names:
+            factory = registry_lookup("task", name)
+            if factory is not None:
+                factories.append(cast(Callable[..., Any], factory))
+    return factories
+
+
 def load_tasks(
-    task_specs: list[str] | None, task_args: dict[str, Any] = {}
+    task_specs: list[str] | None,
+    task_args: dict[str, Any] = {},
+    default_config: bool = True,
 ) -> list[Task]:
     """Load one more more tasks (if no tasks are specified, load from the current working directory"""
     # load tasks
     return [
         spec
         for task_spec in (task_specs if task_specs else [Path.cwd().as_posix()])
-        for spec in load_task_spec(task_spec, task_args)
+        for spec in load_task_spec(task_spec, task_args, default_config)
     ]
 
 
-def load_task_spec(task_spec: str, task_args: dict[str, Any] = {}) -> list[Task]:
+def load_task_spec(
+    task_spec: str, task_args: dict[str, Any] = {}, default_config: bool = True
+) -> list[Task]:
     # task in a python package
     if registry_lookup("task", task_spec) is not None:
         # create the task from a python package
-        return [task_create(task_spec, **task_args)]
+        return [create_task_with_defaults(task_spec, task_args, default_config)]
     elif task_spec.startswith("hf/"):
         # load task from huggingface
         return task_create_from_hf(task_spec, **task_args)
     else:
         # load tasks from glob
-        return create_tasks([task_spec], task_args)
+        return create_tasks([task_spec], task_args, default_config=default_config)
 
 
 def create_tasks(
     globs: list[str],
     task_args: dict[str, Any] = {},
     root_dir: Path | None = None,
+    default_config: bool = True,
 ) -> list[Task]:
     tasks: list[Task] = []
 
@@ -511,9 +600,11 @@ def create_tasks(
         # so the task is registered before we create it)
         spec_split = split_spec(glob)
         if spec_split[1] is not None:
-            task_path = Path(spec_split[0])
+            task_path = Path(local_path(spec_split[0]))
             load_file_tasks(task_path.absolute())
-            tasks.extend(create_file_tasks(task_path, [spec_split[1]], task_args))
+            tasks.extend(
+                create_file_tasks(task_path, [spec_split[1]], task_args, default_config)
+            )
         else:
             # if the glob is the root dir then set it to empty (will result in
             # enumeration of the root dir)
@@ -521,7 +612,7 @@ def create_tasks(
             files = task_files(target, root_dir)
             files = sorted(files, key=lambda f: f.as_posix())
             for file in files:
-                tasks.extend(create_file_tasks(file, None, task_args))
+                tasks.extend(create_file_tasks(file, None, task_args, default_config))
     return tasks
 
 
@@ -534,6 +625,7 @@ def create_file_tasks(
     file: Path,
     task_specs: list[str] | list[RegistryInfo] | None = None,
     task_args: dict[str, Any] = {},
+    default_config: bool = True,
 ) -> list[Task]:
     run_dir = file.parent.resolve().as_posix()
     with chdir_python(file.parent.as_posix()):
@@ -551,7 +643,7 @@ def create_file_tasks(
             # create the task from the loaded source file and
             # note that it was loaded from this directory
             # (will be used later to ensure it runs in the directory)
-            task = task_create(task_spec, **task_args)
+            task = create_task_with_defaults(task_spec, task_args, default_config)
             setattr(task, TASK_FILE_ATTR, file.as_posix())
             setattr(task, TASK_RUN_DIR_ATTR, run_dir)
             tasks.append(task)

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -93,6 +93,7 @@ def resolve_tasks(
     eval_checkpoint: CheckpointConfig | None = None,
     warn_unconsumed_task_args: bool = False,
     input_media_policy: InputMediaPolicy = "inline_only",
+    sample_id: str | int | list[str] | list[int] | list[str | int] | None = None,
 ) -> list[ResolvedTask]:
     # A TaskSource drives a run dynamically and is handled by eval() (which
     # resolves its initial_tasks() and pulls next_tasks()); it isn't a concrete,
@@ -116,8 +117,10 @@ def resolve_tasks(
         # shuffle data in tasks if requested
         for task in tasks:
             params = getattr(task, TASK_DEFAULT_CONFIG_ATTR, {}) if loaded else {}
+            # an explicit sample_id replaces the file's shuffle, the same rule
+            # eval_run applies when it slices and logs the selection
             selection = resolve_task_eval_config(
-                params, EvalConfig(sample_shuffle=sample_shuffle)
+                params, EvalConfig(sample_shuffle=sample_shuffle, sample_id=sample_id)
             )
             shuffle = selection.sample_shuffle
             if shuffle and not task.dataset.shuffled:

--- a/src/inspect_ai/_eval/registry.py
+++ b/src/inspect_ai/_eval/registry.py
@@ -117,11 +117,16 @@ def task(func: TaskType) -> TaskType: ...
 
 @overload
 def task(
-    *, name: str | None = ..., **attribs: Any
+    *, name: str | None = ..., default_config: str | None = ..., **attribs: Any
 ) -> Callable[[TaskType], TaskType]: ...
 
 
-def task(*args: Any, name: str | None = None, **attribs: Any) -> Any:
+def task(
+    *args: Any,
+    name: str | None = None,
+    default_config: str | None = None,
+    **attribs: Any,
+) -> Any:
     r"""Decorator for registering tasks.
 
     Args:
@@ -131,11 +136,17 @@ def task(*args: Any, name: str | None = None, **attribs: Any) -> Any:
         Optional name for task. If the decorator has no name
         argument then the name of the function
         will be used to automatically assign a name.
+      default_config (str | None):
+        Optional path to a run configuration file, relative to the
+        task's source file, applied when the framework constructs
+        the task (e.g. `inspect eval`). Not read on direct calls.
       **attribs: (dict[str,Any]): Additional task attributes.
 
     Returns:
         Task with registry attributes.
     """
+    if default_config is not None:
+        attribs = attribs | {"default_config": default_config}
 
     def create_task_wrapper(task_type: TaskType) -> TaskType:
         # Get the name and parameters of the task

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -100,6 +100,7 @@ from .task.sandbox import (
 from .task.task import Task
 from .task.task_source import TaskSource
 from .task.util import resolve_task_sample_ids, slice_dataset, task_run_dir
+from .task_defaults import resolve_task_eval_config
 
 log = logging.getLogger(__name__)
 
@@ -239,7 +240,9 @@ async def eval_run(
                 # rebinds below — nested state (dataset, config, reducer list
                 # contents) is still shared, so don't write to it in place.
                 task = copy(resolved_task.task)
-                task_eval_config = eval_config.model_copy()
+                task_eval_config = resolve_task_eval_config(
+                    resolved_task.run_config, eval_config
+                )
 
                 # sample_ids can be specified per task
                 task_eval_config.sample_id = resolve_task_sample_ids(
@@ -386,9 +389,10 @@ async def eval_run(
                     task_registry_name=resolved_task.task.registry_name,
                     task_display_name=resolved_task.task.display_name,
                     task_id=resolved_task.id,
+                    run_config_source=resolved_task.run_config_source,
                     eval_set_id=eval_set_id,
                     run_id=run_id,
-                    solver=eval_solver_spec,
+                    solver=eval_solver_spec or resolved_task.run_config.get("solver"),
                     tags=merged_tags,
                     model=resolved_task.model,
                     model_roles=resolved_task.model_roles,

--- a/src/inspect_ai/_eval/run_config.py
+++ b/src/inspect_ai/_eval/run_config.py
@@ -21,7 +21,7 @@ from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec, parse_s
 
 
 class TaskInput(BaseModel):
-    task: str
+    task: str | None = None
     args: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -98,7 +98,8 @@ class RunConfig(BaseModel):
             if isinstance(self.task, str):
                 params["tasks"] = self.task
             else:
-                params["tasks"] = self.task.task
+                if self.task.task is not None:
+                    params["tasks"] = self.task.task
                 if self.task.args:
                     params["task_args"] = self.task.args
 

--- a/src/inspect_ai/_eval/run_config.py
+++ b/src/inspect_ai/_eval/run_config.py
@@ -1,0 +1,234 @@
+from copy import deepcopy
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from inspect_ai._eval.task import Epochs
+from inspect_ai._util.config import resolve_args
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.log._log import EvalConfig
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._model_config import ModelConfig, model_config_to_model
+from inspect_ai.scorer._reducer import create_reducers
+from inspect_ai.solver._solver import SolverSpec
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec, parse_sandbox
+
+
+class TaskInput(BaseModel):
+    task: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class SolverInput(BaseModel):
+    solver: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunConfig(BaseModel):
+    """Configuration for an evaluation run.
+
+    Uses the same schema as the CLI's ``--run-config`` YAML or JSON file.
+    All fields are optional. Validation does not instantiate models or load
+    tasks and solvers; call ``to_params()`` to prepare evaluation arguments.
+    """
+
+    model_config = ConfigDict(extra="forbid", title="RunConfigInput")
+
+    task: str | TaskInput | None = None
+    """Task name or path, optionally with task arguments."""
+    model: str | ModelConfig | None = None
+    """Model name or model configuration."""
+    model_roles: dict[str, ModelConfig | list[ModelConfig]] = Field(
+        default_factory=dict
+    )
+    """Model configurations assigned to named roles."""
+    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
+    """Generation settings, overriding settings in the main model configuration."""
+    eval_config: EvalConfig = Field(default_factory=EvalConfig)
+    """Evaluation settings."""
+    solver: str | SolverInput | None = None
+    """Solver name or path, optionally with solver arguments."""
+    tags: list[str] = Field(default_factory=list)
+    """Tags for the evaluation."""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Metadata for the evaluation."""
+    sandbox: str | SandboxEnvironmentSpec | None = None
+    """Sandbox specification or ``type[:config]`` shorthand."""
+
+    @field_validator("generate_config", mode="before")
+    @classmethod
+    def check_generate_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown generate_config fields: {unknown}")
+        return v
+
+    @field_validator("eval_config", mode="before")
+    @classmethod
+    def check_eval_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown eval_config fields: {unknown}")
+        return v
+
+    def to_params(self, resolve_models: bool = True) -> dict[str, Any]:
+        """Convert the configuration to keyword arguments for ``eval()``.
+
+        Args:
+            resolve_models: Instantiate models for model roles (the CLI default).
+                If False, retain their ``ModelConfig`` objects, which ``eval()``
+                accepts and resolves when running the evaluation. The main model
+                is always represented by its name and separate configuration args.
+
+        Returns:
+            Evaluation keyword arguments, with generation settings flattened.
+        """
+        params: dict[str, Any] = {}
+
+        # Task
+        if self.task is not None:
+            if isinstance(self.task, str):
+                params["tasks"] = self.task
+            else:
+                params["tasks"] = self.task.task
+                if self.task.args:
+                    params["task_args"] = self.task.args
+
+        # Model
+        if self.model is not None:
+            if isinstance(self.model, str):
+                params["model"] = self.model
+            else:
+                params["model"] = self.model.model
+                if self.model.base_url is not None:
+                    params["model_base_url"] = self.model.base_url
+                if self.model.args:
+                    params["model_args"] = self.model.args
+                model_gc = self.model.config.model_dump(exclude_none=True)
+                if model_gc:
+                    params.update(model_gc)
+
+        # Top-level generate_config overrides any model-level config
+        top_gc = self.generate_config.model_dump(exclude_none=True)
+        if top_gc:
+            params.update(top_gc)
+
+        # Model roles
+        if self.model_roles:
+            if resolve_models:
+                params["model_roles"] = {
+                    role: [model_config_to_model(m) for m in mc]
+                    if isinstance(mc, list)
+                    else model_config_to_model(mc)
+                    for role, mc in self.model_roles.items()
+                }
+            else:
+                params["model_roles"] = deepcopy(self.model_roles)
+
+        # Solver
+        if self.solver is not None:
+            if isinstance(self.solver, str):
+                params["solver"] = SolverSpec(self.solver, {}, {})
+            else:
+                params["solver"] = SolverSpec(
+                    self.solver.solver, self.solver.args, self.solver.args
+                )
+
+        # Eval config — combine epochs + epochs_reducer into Epochs
+        ec = self.eval_config.model_dump(exclude_none=True)
+        epochs = ec.pop("epochs", None)
+        epochs_reducer = ec.pop("epochs_reducer", None)
+        if epochs is not None:
+            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
+        params.update(ec)
+
+        # Tags and metadata
+        if self.tags:
+            params["tags"] = self.tags
+        if self.metadata:
+            params["metadata"] = self.metadata
+
+        # Sandbox
+        if self.sandbox is not None:
+            if isinstance(self.sandbox, str):
+                params["sandbox"] = parse_sandbox(self.sandbox)
+            else:
+                params["sandbox"] = self.sandbox
+
+        return params
+
+
+RunConfigInput = RunConfig
+
+
+def read_run_config(config: str) -> RunConfig:
+    """Read and validate an evaluation run configuration without resolving models.
+
+    Args:
+        config: YAML or JSON configuration file (local path, file URI, or remote
+            filesystem URL such as ``s3://bucket/run.yaml``).
+
+    Returns:
+        Validated configuration. Call ``to_params()`` to prepare eval arguments.
+
+    Raises:
+        PrerequisiteError: The file does not exist or fails schema validation.
+        ValueError: The file cannot be parsed as a configuration object.
+    """
+    from jsonschema import Draft7Validator
+
+    config_dict = resolve_args(config)
+    try:
+        run_config = RunConfig.model_validate(config_dict)
+    except ValidationError as ex:
+        # Surface a more readable error via Draft7Validator. Fall back to
+        # pydantic's message when the JSON schema doesn't capture the
+        # failure (e.g. custom field_validators on generate_config/eval_config).
+        schema = RunConfig.model_json_schema()
+        errors = list(Draft7Validator(schema).iter_errors(config_dict))
+        if errors:
+            message = "\n".join(
+                [f"Invalid run config '{config}':"]
+                + [f" - {error.message}" for error in errors]
+            )
+        else:
+            message = f"Invalid run config '{config}': {ex}"
+        raise PrerequisiteError(message)
+    return run_config
+
+
+def merge_run_config_params(
+    run_params: dict[str, Any], cli_params: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge evaluation overrides using the CLI's run-configuration precedence.
+
+    Args:
+        run_params: Base evaluation arguments, typically from ``RunConfig.to_params``.
+        cli_params: Overrides. ``None``, empty dictionaries, and ``score=True``
+            are ignored, matching CLI defaults. Task arguments, model arguments,
+            and model roles merge by key; all other supplied values replace.
+
+    Returns:
+        Merged arguments in a new dictionary, without modifying either input.
+    """
+    params = dict(run_params)
+    for key, value in cli_params.items():
+        if value is None or value == {}:
+            continue
+        if key == "score" and value is True:
+            continue
+        if key in ("task_args", "model_args") and key in params:
+            params[key] = params[key] | value
+        elif key == "model_roles" and key in params:
+            params[key] = params[key] | value
+        else:
+            params[key] = value
+    return params

--- a/src/inspect_ai/_eval/run_config.py
+++ b/src/inspect_ai/_eval/run_config.py
@@ -38,7 +38,7 @@ class RunConfig(BaseModel):
     tasks and solvers; call ``to_params()`` to prepare evaluation arguments.
     """
 
-    model_config = ConfigDict(extra="forbid", title="RunConfigInput")
+    model_config = ConfigDict(extra="forbid")
 
     task: str | TaskInput | None = None
     """Task name or path, optionally with task arguments."""
@@ -169,11 +169,11 @@ class RunConfig(BaseModel):
 RunConfigInput = RunConfig
 
 
-def read_run_config(config: str) -> RunConfig:
+def read_run_config(path: str) -> RunConfig:
     """Read and validate an evaluation run configuration without resolving models.
 
     Args:
-        config: YAML or JSON configuration file (local path, file URI, or remote
+        path: YAML or JSON configuration file (local path, file URI, or remote
             filesystem URL such as ``s3://bucket/run.yaml``).
 
     Returns:
@@ -185,7 +185,7 @@ def read_run_config(config: str) -> RunConfig:
     """
     from jsonschema import Draft7Validator
 
-    config_dict = resolve_args(config)
+    config_dict = resolve_args(path)
     try:
         run_config = RunConfig.model_validate(config_dict)
     except ValidationError as ex:
@@ -196,23 +196,23 @@ def read_run_config(config: str) -> RunConfig:
         errors = list(Draft7Validator(schema).iter_errors(config_dict))
         if errors:
             message = "\n".join(
-                [f"Invalid run config '{config}':"]
+                [f"Invalid run config '{path}':"]
                 + [f" - {error.message}" for error in errors]
             )
         else:
-            message = f"Invalid run config '{config}': {ex}"
+            message = f"Invalid run config '{path}': {ex}"
         raise PrerequisiteError(message)
     return run_config
 
 
 def merge_run_config_params(
-    run_params: dict[str, Any], cli_params: dict[str, Any]
+    run_params: dict[str, Any], overrides: dict[str, Any]
 ) -> dict[str, Any]:
     """Merge evaluation overrides using the CLI's run-configuration precedence.
 
     Args:
         run_params: Base evaluation arguments, typically from ``RunConfig.to_params``.
-        cli_params: Overrides. ``None``, empty dictionaries, and ``score=True``
+        overrides: Overrides. ``None``, empty dictionaries, and ``score=True``
             are ignored, matching CLI defaults. Task arguments, model arguments,
             and model roles merge by key; all other supplied values replace.
 
@@ -220,7 +220,7 @@ def merge_run_config_params(
         Merged arguments in a new dictionary, without modifying either input.
     """
     params = dict(run_params)
-    for key, value in cli_params.items():
+    for key, value in overrides.items():
         if value is None or value == {}:
             continue
         if key == "score" and value is True:

--- a/src/inspect_ai/_eval/task/constants.py
+++ b/src/inspect_ai/_eval/task/constants.py
@@ -1,3 +1,5 @@
 TASK_FILE_ATTR = "__task_file__"
 TASK_RUN_DIR_ATTR = "__task_run_dir__"
 TASK_ALL_PARAMS_ATTR = "__task_all_params__"
+TASK_DEFAULT_CONFIG_ATTR = "__task_default_config__"
+TASK_DEFAULT_CONFIG_SOURCE_ATTR = "__task_default_config_source__"

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -176,6 +176,7 @@ class TaskLogger:
         recorder: Recorder,
         header_only: bool,
         dynamic_dataset: bool = False,
+        run_config_source: str | None = None,
     ) -> None:
         packages = {
             PKG_NAME: importlib_metadata.version(PKG_NAME),
@@ -245,6 +246,7 @@ class TaskLogger:
             task_registry_name=task_registry_name,
             task_display_name=task_display_name,
             task_attribs=task_attribs,
+            run_config_source=run_config_source,
             task_args=task_args,
             task_args_passed=task_args_passed,
             solver=solver.solver if solver else None,

--- a/src/inspect_ai/_eval/task/resolved.py
+++ b/src/inspect_ai/_eval/task/resolved.py
@@ -26,6 +26,8 @@ class ResolvedTask:
     initial_model_usage: dict[str, ModelUsage] | None = field(default=None)
     initial_role_usage: dict[str, ModelUsage] | None = field(default=None)
     input_media_policy: InputMediaPolicy = field(default="inline_only")
+    run_config_source: str | None = None
+    run_config: dict[str, Any] = field(default_factory=dict)
 
     @property
     def has_sandbox(self) -> bool:

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1059,8 +1059,12 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
     else:
         log_location = logger.location
 
-    if logger.eval.run_config_source and logger.eval.run_config_source.startswith(
-        "task_default:"
+    # a retry or resume replays logged settings without reading the file, so
+    # the override hint would be wrong; provenance is still recorded
+    if (
+        options.sample_source is None
+        and logger.eval.run_config_source
+        and logger.eval.run_config_source.startswith("task_default:")
     ):
         config_name = logger.eval.run_config_source.removeprefix("task_default:")
         display().print(

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1059,6 +1059,15 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
     else:
         log_location = logger.location
 
+    if logger.eval.run_config_source and logger.eval.run_config_source.startswith(
+        "task_default:"
+    ):
+        config_name = logger.eval.run_config_source.removeprefix("task_default:")
+        display().print(
+            f"{task.name}: default config: {PurePath(config_name).name} "
+            "(override with flags, --run-config, or --no-default-config)"
+        )
+
     # create task profile for display
     profile = TaskProfile(
         name=options.display_name or task.name,
@@ -1127,8 +1136,9 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
             gated_sample_semaphore = PauseGatedSemaphore(
                 sample_semaphore,
                 task_id=logger.eval.task_id,
-                escape=lambda: task_cancel is not None
-                and task_cancel.cancel_type is not None,
+                escape=lambda: (
+                    task_cancel is not None and task_cancel.cancel_type is not None
+                ),
                 model=pause_model_name,
             )
 

--- a/src/inspect_ai/_eval/task/task.py
+++ b/src/inspect_ai/_eval/task/task.py
@@ -502,6 +502,12 @@ class TaskInfo(BaseModel):
     attribs: dict[str, Any]
     """Task attributes (arguments passed to `@task`)"""
 
+    @property
+    def default_config(self) -> str | None:
+        """Declared default configuration path, relative to the task source file."""
+        value = self.attribs.get("default_config")
+        return value if isinstance(value, str) else None
+
     def __str__(self) -> str:
         return f"{self.file}@{self.name}"
 

--- a/src/inspect_ai/_eval/task_defaults.py
+++ b/src/inspect_ai/_eval/task_defaults.py
@@ -1,0 +1,331 @@
+"""Framework-only task defaults, scoped to one evaluation invocation.
+
+Factories and constructed Tasks never consult this module on direct calls.
+Run-wide settings are agreed before initialization; per-task settings remain on
+ResolvedTask so heterogeneous sample selection and generation stay independent.
+"""
+
+import inspect
+import logging
+import os
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, ParamSpec, TypeVar, cast
+
+from inspect_ai._util.file import absolute_file_path, dirname, filesystem, local_path
+from inspect_ai._util.registry import registry_info, registry_lookup
+from inspect_ai.log import EvalConfig
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._model import init_model_roles, model_roles
+from inspect_ai.model._util import resolve_model_roles
+from inspect_ai.solver import SolverSpec
+
+from .run_config import RunConfig, TaskInput, merge_run_config_params, read_run_config
+from .task import Epochs, Task
+from .task.constants import TASK_DEFAULT_CONFIG_ATTR, TASK_DEFAULT_CONFIG_SOURCE_ATTR
+from .task.tasks import Tasks
+
+PER_TASK_FIELDS = frozenset(
+    {
+        "limit",
+        "sample_id",
+        "sample_shuffle",
+        "epochs",
+        "epochs_reducer",
+        "fail_on_error",
+        "continue_on_fail",
+        "retry_on_error",
+        "score_on_error",
+        "message_limit",
+        "token_limit",
+        "token_limit_type",
+        "turn_limit",
+        "time_limit",
+        "working_limit",
+        "cost_limit",
+        "max_samples",
+        "max_dataset_memory",
+    }
+)
+RUN_WIDE_FIELDS = frozenset(EvalConfig.model_fields) - PER_TASK_FIELDS
+
+logger = logging.getLogger(__name__)
+
+_source: ContextVar[str | None] = ContextVar("run_config_source", default=None)
+
+
+@dataclass(frozen=True)
+class DefaultsScope:
+    enabled: bool
+    configs: dict[str, RunConfig]
+    run_wide: dict[str, Any]
+
+
+_scope: ContextVar[DefaultsScope | None] = ContextVar(
+    "task_defaults_scope", default=None
+)
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@contextmanager
+def run_config_source(source: str | None) -> Iterator[None]:
+    """Annotate resolved tasks with an explicitly selected run configuration."""
+    token = _source.set(source)
+    try:
+        yield
+    finally:
+        _source.reset(token)
+
+
+def current_run_config_source() -> str | None:
+    """Return CLI provenance in the current evaluation scope, if any."""
+    return _source.get()
+
+
+def defaults_enabled() -> bool:
+    """Whether framework construction may load an attached configuration."""
+    scope = _scope.get()
+    return scope.enabled if scope is not None else True
+
+
+def default_config_path(factory: Callable[..., Any]) -> str | None:
+    """Resolve an attachment relative to the unwrapped factory's source file."""
+    reference = registry_info(factory).metadata.get("attribs", {}).get("default_config")
+    if reference is None:
+        return None
+    if not isinstance(reference, str):
+        raise ValueError("task default_config must be a string path")
+    if filesystem(reference).is_local() and not os.path.isabs(local_path(reference)):
+        source = inspect.getsourcefile(inspect.unwrap(factory))
+        if source is None:
+            raise ValueError(
+                f"Cannot resolve task default_config '{reference}': no source file"
+            )
+        reference = os.path.join(dirname(source), local_path(reference))
+    return absolute_file_path(reference)
+
+
+def read_task_default(path: str, factory: Callable[..., Any]) -> RunConfig:
+    """Read purely: validate forbidden selection even when explicitly null.
+
+    A task reference is allowed only when it names the attached task by its
+    registry name, so the file can document (and stand alone for) that task
+    without being able to redirect the run.
+    """
+    config = read_run_config(path)
+    if "model" in config.model_fields_set:
+        raise ValueError(f"Task default config '{path}' cannot select a model")
+    selected = config.task.task if isinstance(config.task, TaskInput) else config.task
+    if selected is not None:
+        attached = registry_info(factory).name
+        if selected != attached:
+            raise ValueError(
+                f"Task default config '{path}' names task '{selected}' "
+                f"but is attached to task '{attached}'"
+            )
+    return config
+
+
+def task_default(factory: Callable[..., Any]) -> tuple[str | None, RunConfig | None]:
+    """Return the current attachment, without reading anything when disabled."""
+    if not defaults_enabled():
+        return None, None
+    path = default_config_path(factory)
+    if path is None:
+        return None, None
+    scope = _scope.get()
+    config = scope.configs.get(path) if scope is not None else None
+    return path, config if config is not None else read_task_default(path, factory)
+
+
+@contextmanager
+def evaluation_defaults(params: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Preflight run-wide defaults before model, subprocess or server startup.
+
+    Explicit non-null arguments win. Multiple files may agree on a run-wide
+    setting; conflicting values require a caller override. Per-task defaults
+    are not broadcast into this parameter dictionary.
+    """
+    from .loader import task_default_factories
+
+    enabled = params.get("default_config", True)
+    configs: dict[str, RunConfig] = {}
+    agreed: dict[str, Any] = {}
+    sources: dict[str, str] = {}
+    if enabled:
+        for factory in task_default_factories(cast(Tasks, params.get("tasks"))):
+            path = default_config_path(factory)
+            if path is None:
+                continue
+            config = configs.setdefault(path, read_task_default(path, factory))
+            for key, value in config.eval_config.model_dump(exclude_none=True).items():
+                if key not in RUN_WIDE_FIELDS or params.get(key) is not None:
+                    continue
+                if key in agreed and agreed[key] != value:
+                    raise ValueError(
+                        f"Conflicting task default '{key}' in '{sources[key]}' and '{path}'; "
+                        f"supply an explicit {key} override"
+                    )
+                agreed[key] = value
+                sources[key] = path
+    effective = merge_run_config_params(agreed, params)
+    token = _scope.set(
+        DefaultsScope(enabled, configs, {k: effective.get(k) for k in RUN_WIDE_FIELDS})
+    )
+    try:
+        yield effective
+    finally:
+        _scope.reset(token)
+
+
+def with_task_defaults(fn: Callable[P, R]) -> Callable[P, R]:
+    """Scope synchronous eval-set discovery and apply run-wide defaults early."""
+    signature = inspect.signature(fn)
+
+    @wraps(fn)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound = signature.bind(*args, **kwargs)
+        with evaluation_defaults(dict(bound.arguments)) as params:
+            bound.arguments.update(params)
+            return fn(*bound.args, **bound.kwargs)
+
+    return wrapped
+
+
+def with_task_defaults_async(
+    fn: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    """Scope asynchronous evaluation, including dynamically enqueued tasks."""
+    signature = inspect.signature(fn)
+
+    @wraps(fn)
+    async def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound = signature.bind(*args, **kwargs)
+        with evaluation_defaults(dict(bound.arguments)) as params:
+            bound.arguments.update(params)
+            return await fn(*bound.args, **bound.kwargs)
+
+    return wrapped
+
+
+def create_task_with_defaults(
+    name: str, args: dict[str, Any], enabled: bool = True
+) -> Task:
+    """Construct a registry task with file arguments below explicit caller keys.
+
+    The argument dictionary is separate from loader controls so task factories
+    can use arbitrary parameter names. Role overrides are merged before model
+    construction, avoiding credentials or side effects for discarded defaults.
+    """
+    from .loader import solver_from_spec
+    from .registry import task_create
+
+    factory = cast(Callable[..., Any] | None, registry_lookup("task", name))
+    path, config = (
+        task_default(factory) if factory is not None and enabled else (None, None)
+    )
+    if config is None or factory is None:
+        return task_create(name, **args)
+    params = config.to_params(resolve_models=False)
+    if config.eval_config.epochs_reducer is not None and "epochs" not in params:
+        params["epochs_reducer"] = config.eval_config.epochs_reducer
+    scope = _scope.get()
+    run_wide_keys = sorted(RUN_WIDE_FIELDS & params.keys())
+    if scope is not None:
+        for key in run_wide_keys:
+            current = scope.run_wide.get(key)
+            if current is None:
+                raise ValueError(
+                    f"Task default '{path}' requires run-wide '{key}={params[key]}'; configure it before starting the run"
+                )
+    elif run_wide_keys:
+        # resolved outside eval()/eval_set() (e.g. eval_resolve_tasks from
+        # Inspect Flow): there is no run to agree these for, so drop them
+        # rather than record them in the log as if applied
+        logger.warning(
+            f"Task default '{path}' sets run-wide {run_wide_keys}, which apply "
+            "only when eval(), eval_set() or the CLI resolves the task; ignored"
+        )
+        for key in run_wide_keys:
+            params.pop(key)
+    current_roles = model_roles()
+    roles = resolve_model_roles(params.get("model_roles", {}) | current_roles)
+    init_model_roles(roles or {})
+    try:
+        task = task_create(name, **(params.get("task_args", {}) | args))
+    finally:
+        init_model_roles(current_roles)
+    generation = {k: v for k, v in params.items() if k in GenerateConfig.model_fields}
+    task.config = task.config.merge(GenerateConfig(**generation))
+    task.model_roles = (task.model_roles or {}) | (roles or {})
+    for key in PER_TASK_FIELDS - {"epochs_reducer", "token_limit_type"}:
+        if key in params and hasattr(task, key):
+            value = params[key]
+            if key == "epochs" and isinstance(value, Epochs):
+                task.epochs = value.epochs
+                if value.reducer is not None:
+                    task.epochs_reducer = value.reducer
+            else:
+                setattr(task, key, value)
+    if "token_limit_type" in params:
+        task.token_limit_type = params["token_limit_type"]
+    if "epochs_reducer" in params:
+        from inspect_ai.scorer._reducer import create_reducers
+
+        task.epochs_reducer = create_reducers(params["epochs_reducer"])
+    if "sandbox" in params:
+        task.sandbox = params["sandbox"]
+    if "solver" in params:
+        spec = cast(SolverSpec, params["solver"])
+        file, separator, solver = spec.solver.partition("@")
+        if (
+            separator
+            and not os.path.isabs(local_path(file))
+            and filesystem(file).is_local()
+        ):
+            source = inspect.getsourcefile(inspect.unwrap(factory))
+            if source is None:
+                raise ValueError(
+                    f"Cannot resolve solver '{spec.solver}' without a task source"
+                )
+            spec = SolverSpec(
+                os.path.join(dirname(source), file) + "@" + solver,
+                spec.args,
+                spec.args_passed,
+            )
+        params["solver"] = spec
+        task.solver = solver_from_spec(spec)
+    if "tags" in params:
+        task.tags = params["tags"]
+    if "metadata" in params:
+        task.metadata = (task.metadata or {}) | params["metadata"]
+    setattr(task, TASK_DEFAULT_CONFIG_ATTR, params)
+    setattr(task, TASK_DEFAULT_CONFIG_SOURCE_ATTR, f"task_default:{path}")
+    return task
+
+
+def resolve_task_eval_config(
+    params: dict[str, Any], overrides: EvalConfig
+) -> EvalConfig:
+    """Merge per-task file evaluation settings below effective call overrides.
+
+    Sample selection is one setting: an explicit sample_id replaces the file's
+    limit and shuffle, and an explicit limit or shuffle replaces the file's
+    sample_id. Otherwise a file sample_id would survive an explicit limit and
+    win in slice_dataset, a combination eval() itself rejects.
+    """
+    defaults = {k: v for k, v in params.items() if k in EvalConfig.model_fields}
+    epochs = defaults.get("epochs")
+    if isinstance(epochs, Epochs):
+        defaults["epochs"] = epochs.epochs
+    supplied = overrides.model_dump(exclude_none=True)
+    if "sample_id" in supplied:
+        defaults.pop("limit", None)
+        defaults.pop("sample_shuffle", None)
+    if "limit" in supplied or "sample_shuffle" in supplied:
+        defaults.pop("sample_id", None)
+    return EvalConfig(**merge_run_config_params(defaults, supplied))

--- a/src/inspect_ai/_eval/task_defaults.py
+++ b/src/inspect_ai/_eval/task_defaults.py
@@ -150,6 +150,8 @@ def evaluation_defaults(params: dict[str, Any]) -> Iterator[dict[str, Any]]:
     setting; conflicting values require a caller override. Per-task defaults
     are not broadcast into this parameter dictionary.
     """
+    from inspect_ai._util.dotenv import init_dotenv
+
     from .loader import task_default_factories
 
     enabled = params.get("default_config", True)
@@ -157,6 +159,10 @@ def evaluation_defaults(params: dict[str, Any]) -> Iterator[dict[str, Any]]:
     agreed: dict[str, Any] = {}
     sources: dict[str, str] = {}
     if enabled:
+        # discovery imports task modules, which eval_init would otherwise do
+        # only after loading .env; a module that reads the environment at
+        # import time must see the same variables it does on main
+        init_dotenv()
         for factory in task_default_factories(cast(Tasks, params.get("tasks"))):
             path = default_config_path(factory)
             if path is None:
@@ -234,23 +240,21 @@ def create_task_with_defaults(
     if config.eval_config.epochs_reducer is not None and "epochs" not in params:
         params["epochs_reducer"] = config.eval_config.epochs_reducer
     scope = _scope.get()
-    run_wide_keys = sorted(RUN_WIDE_FIELDS & params.keys())
-    if scope is not None:
-        for key in run_wide_keys:
-            current = scope.run_wide.get(key)
-            if current is None:
-                raise ValueError(
-                    f"Task default '{path}' requires run-wide '{key}={params[key]}'; configure it before starting the run"
-                )
-    elif run_wide_keys:
-        # resolved outside eval()/eval_set() (e.g. eval_resolve_tasks from
-        # Inspect Flow): there is no run to agree these for, so drop them
-        # rather than record them in the log as if applied
+    # run-wide keys are agreed before the run starts; a key not agreed here
+    # belongs to a task that could not take part (resolved outside eval() or
+    # eval_set(), or enqueued mid-run), so drop it rather than record it in
+    # the log as if applied
+    unagreed = [
+        key
+        for key in sorted(RUN_WIDE_FIELDS & params.keys())
+        if scope is None or scope.run_wide.get(key) is None
+    ]
+    if unagreed:
         logger.warning(
-            f"Task default '{path}' sets run-wide {run_wide_keys}, which apply "
-            "only when eval(), eval_set() or the CLI resolves the task; ignored"
+            f"Task default '{path}' sets run-wide {unagreed}, which apply only "
+            "to tasks resolved when the run starts; ignored"
         )
-        for key in run_wide_keys:
+        for key in unagreed:
             params.pop(key)
     current_roles = model_roles()
     roles = resolve_model_roles(params.get("model_roles", {}) | current_roles)

--- a/src/inspect_ai/_view/dist/assets/index.js
+++ b/src/inspect_ai/_view/dist/assets/index.js
@@ -112242,9 +112242,21 @@ var StateEventView_module_default = {
 	return changeList.join(", ");
 };
 var isPathContainer = (value) => typeof value === "object" && value !== null;
-var getChild = (container, key) => Array.isArray(container) ? container[Number(key)] : container[key];
+var getChild = (container, key) => {
+	if (Array.isArray(container)) {
+		const index = Number(key);
+		return Object.hasOwn(container, index) ? container[index] : void 0;
+	}
+	return Object.hasOwn(container, key) ? container[key] : void 0;
+};
 var setChild = (container, key, value) => {
 	if (Array.isArray(container)) container[Number(key)] = value;
+	else if (key === "__proto__") Object.defineProperty(container, key, {
+		value,
+		enumerable: true,
+		writable: true,
+		configurable: true
+	});
 	else container[key] = value;
 };
 var asArray$1 = (value) => Array.isArray(value) ? value : void 0;
@@ -118329,14 +118341,13 @@ function useTimelineConfig(t0) {
 	return rootItems;
 }
 /**
-* Merge orphaned events into a host timeline's root, preserving time order.
+* Keep orphaned events visible without distorting server-authored timelines.
 *
 * When server-provided timelines don't reference every event (e.g. scorer
-* events), the unreferenced events are collected, wrapped in their minimal
-* parent span tree, and inserted into the host timeline's root content in
-* chronological order. The host is the first timeline whose root is not a
-* branch tree, falling back to the first timeline.
-*/ function attachOrphanedEvents(timelines, events) {
+* events), a single timeline receives the orphan set in chronological order.
+* With multiple timelines, the full built timeline is appended as an Overall
+* view so no authored timeline receives another timeline's events.
+*/ function attachOrphanedEvents(timelines, events, builtTimeline) {
 	if (timelines.length === 0 || events.length === 0) return timelines;
 	const referencedUuids = /* @__PURE__ */ new Set();
 	const referencedSpanIds = /* @__PURE__ */ new Set();
@@ -118352,6 +118363,11 @@ function useTimelineConfig(t0) {
 		if (uuid && !referencedUuids.has(uuid)) orphanEvents.push(event);
 	}
 	if (orphanEvents.length === 0) return timelines;
+	if (timelines.length > 1) return [...timelines, {
+		name: "Overall",
+		description: "Full sample transcript",
+		root: builtTimeline.root
+	}];
 	const orphanContent = buildOrphanContent(orphanEvents, buildSpanLookup(events), referencedSpanIds);
 	if (orphanContent.length === 0) return timelines;
 	const hostIndex = Math.max(0, timelines.findIndex((tl) => tl.root.branches.length === 0));
@@ -118377,7 +118393,7 @@ function useTimelineConfig(t0) {
 	} : tl);
 }
 function useTimelinesArray(events, serverTimelines, options) {
-	const $ = (0, import_compiler_runtime.c)(14);
+	const $ = (0, import_compiler_runtime.c)(15);
 	const showEmptyBranches = options?.showEmptyBranches ?? false;
 	let t0;
 	if ($[0] !== events) {
@@ -118395,28 +118411,29 @@ function useTimelinesArray(events, serverTimelines, options) {
 	} else t1 = $[4];
 	const convertedTimelines = t1;
 	let t2;
-	if ($[5] !== convertedTimelines || $[6] !== events) {
-		t2 = convertedTimelines ? attachOrphanedEvents(convertedTimelines, events) : null;
-		$[5] = convertedTimelines;
-		$[6] = events;
-		$[7] = t2;
-	} else t2 = $[7];
+	if ($[5] !== builtTimeline || $[6] !== convertedTimelines || $[7] !== events) {
+		t2 = convertedTimelines ? attachOrphanedEvents(convertedTimelines, events, builtTimeline) : null;
+		$[5] = builtTimeline;
+		$[6] = convertedTimelines;
+		$[7] = events;
+		$[8] = t2;
+	} else t2 = $[8];
 	const withOrphans = t2;
 	let t3;
-	if ($[8] !== builtTimeline || $[9] !== withOrphans) {
+	if ($[9] !== builtTimeline || $[10] !== withOrphans) {
 		t3 = withOrphans ?? [builtTimeline];
-		$[8] = builtTimeline;
-		$[9] = withOrphans;
-		$[10] = t3;
-	} else t3 = $[10];
+		$[9] = builtTimeline;
+		$[10] = withOrphans;
+		$[11] = t3;
+	} else t3 = $[11];
 	const resolved = t3;
 	let t4;
-	if ($[11] !== resolved || $[12] !== showEmptyBranches) {
+	if ($[12] !== resolved || $[13] !== showEmptyBranches) {
 		t4 = showEmptyBranches ? resolved : resolved.map(filterEmptyBranches);
-		$[11] = resolved;
-		$[12] = showEmptyBranches;
-		$[13] = t4;
-	} else t4 = $[13];
+		$[12] = resolved;
+		$[13] = showEmptyBranches;
+		$[14] = t4;
+	} else t4 = $[14];
 	return t4;
 }
 //#endregion
@@ -118433,7 +118450,7 @@ function useTimelinesArray(events, serverTimelines, options) {
 var emptySourceSpans = /* @__PURE__ */ new Map();
 var emptyHighlightedKeys = /* @__PURE__ */ new Map();
 function useTranscriptTimeline(options) {
-	const $ = (0, import_compiler_runtime.c)(96);
+	const $ = (0, import_compiler_runtime.c)(101);
 	const { events: rawEvents, markerConfig: t0, timelineOptions, serverTimelines, timelineProps, activeTimelineProps } = options;
 	const markerConfig = t0 === void 0 ? defaultMarkerConfig : t0;
 	let t1;
@@ -118454,30 +118471,47 @@ function useTranscriptTimeline(options) {
 		$[3] = t2;
 	} else t2 = $[3];
 	const timelines = useTimelinesArray(events, serverTimelines, t2);
-	const { active: activeTimeline, activeIndex: activeTimelineIndex, setActive: setActiveTimeline } = useActiveTimeline(timelines, activeTimelineProps);
-	const baseTimeline = activeTimeline;
+	const { active: activeTimeline, activeIndex: activeTimelineIndex, setActive: setActiveTimelineIndex } = useActiveTimeline(timelines, activeTimelineProps);
+	const onSelectTimeline = timelineProps?.onSelect;
 	let t3;
-	if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-		t3 = [];
-		$[4] = t3;
-	} else t3 = $[4];
-	const [viewStack, setViewStack] = (0, import_react.useState)(t3);
+	if ($[4] !== activeTimelineIndex || $[5] !== onSelectTimeline || $[6] !== setActiveTimelineIndex || $[7] !== timelines.length) {
+		t3 = (index, options_0) => {
+			if (index < 0 || index >= timelines.length) return;
+			if (index === activeTimelineIndex) return;
+			if (options_0) onSelectTimeline?.(null, options_0);
+			else onSelectTimeline?.(null);
+			setActiveTimelineIndex(index);
+		};
+		$[4] = activeTimelineIndex;
+		$[5] = onSelectTimeline;
+		$[6] = setActiveTimelineIndex;
+		$[7] = timelines.length;
+		$[8] = t3;
+	} else t3 = $[8];
+	const setActiveTimeline = t3;
+	const baseTimeline = activeTimeline;
+	let t4;
+	if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
+		t4 = [];
+		$[9] = t4;
+	} else t4 = $[9];
+	const [viewStack, setViewStack] = (0, import_react.useState)(t4);
 	const [stackBase, setStackBase] = (0, import_react.useState)(baseTimeline);
 	if (stackBase !== baseTimeline) {
 		setStackBase(baseTimeline);
 		setViewStack([]);
 	}
-	let t4;
-	if ($[5] !== baseTimeline || $[6] !== viewStack) {
-		t4 = viewStack.at(-1)?.timeline ?? baseTimeline;
-		$[5] = baseTimeline;
-		$[6] = viewStack;
-		$[7] = t4;
-	} else t4 = $[7];
-	const timeline = t4;
 	let t5;
-	if ($[8] !== baseTimeline.root || $[9] !== timelineProps) {
-		t5 = (branch, label) => {
+	if ($[10] !== baseTimeline || $[11] !== viewStack) {
+		t5 = viewStack.at(-1)?.timeline ?? baseTimeline;
+		$[10] = baseTimeline;
+		$[11] = viewStack;
+		$[12] = t5;
+	} else t5 = $[12];
+	const timeline = t5;
+	let t6;
+	if ($[13] !== baseTimeline.root || $[14] !== timelineProps) {
+		t6 = (branch, label) => {
 			setViewStack((s) => [...s, {
 				label,
 				timeline: spliceToTimeline(baseTimeline.root, branch),
@@ -118485,75 +118519,75 @@ function useTranscriptTimeline(options) {
 			}]);
 			timelineProps?.onSelect(null);
 		};
-		$[8] = baseTimeline.root;
-		$[9] = timelineProps;
-		$[10] = t5;
-	} else t5 = $[10];
-	const pushView = t5;
-	let t6;
-	if ($[11] !== timelineProps || $[12] !== viewStack) {
-		t6 = () => {
+		$[13] = baseTimeline.root;
+		$[14] = timelineProps;
+		$[15] = t6;
+	} else t6 = $[15];
+	const pushView = t6;
+	let t7;
+	if ($[16] !== timelineProps || $[17] !== viewStack) {
+		t7 = () => {
 			const top = viewStack.at(-1);
 			if (!top) return;
 			setViewStack(_temp$48);
 			timelineProps?.onSelect(top.priorSelected);
 		};
-		$[11] = timelineProps;
-		$[12] = viewStack;
-		$[13] = t6;
-	} else t6 = $[13];
-	const popView = t6;
+		$[16] = timelineProps;
+		$[17] = viewStack;
+		$[18] = t7;
+	} else t7 = $[18];
+	const popView = t7;
 	const state = useTimeline(timeline, timelineOptions, timelineProps);
-	let t7;
-	if ($[14] !== state.rows) {
-		t7 = state.rows.filter(_temp2$35);
-		$[14] = state.rows;
-		$[15] = t7;
-	} else t7 = $[15];
-	const visibleRows = t7;
 	let t8;
-	if ($[16] !== state.node) {
-		t8 = computeTimeMapping(state.node);
-		$[16] = state.node;
-		$[17] = t8;
-	} else t8 = $[17];
-	const timeMapping = t8;
+	if ($[19] !== state.rows) {
+		t8 = state.rows.filter(_temp2$35);
+		$[19] = state.rows;
+		$[20] = t8;
+	} else t8 = $[20];
+	const visibleRows = t8;
 	let t9;
-	if ($[18] !== timeline.root) {
-		t9 = computeTimeMapping(timeline.root);
-		$[18] = timeline.root;
-		$[19] = t9;
-	} else t9 = $[19];
-	const rootTimeMapping = t9;
+	if ($[21] !== state.node) {
+		t9 = computeTimeMapping(state.node);
+		$[21] = state.node;
+		$[22] = t9;
+	} else t9 = $[22];
+	const timeMapping = t9;
 	let t10;
+	if ($[23] !== timeline.root) {
+		t10 = computeTimeMapping(timeline.root);
+		$[23] = timeline.root;
+		$[24] = t10;
+	} else t10 = $[24];
+	const rootTimeMapping = t10;
+	let t11;
 	bb0: {
 		if (!forkRelative || !showBranches) {
-			t10 = void 0;
+			t11 = void 0;
 			break bb0;
 		}
-		let t11;
-		if ($[20] !== timeMapping || $[21] !== visibleRows) {
-			t11 = computeBranchMappings(visibleRows, timeMapping);
-			$[20] = timeMapping;
-			$[21] = visibleRows;
-			$[22] = t11;
-		} else t11 = $[22];
-		t10 = t11;
+		let t12;
+		if ($[25] !== timeMapping || $[26] !== visibleRows) {
+			t12 = computeBranchMappings(visibleRows, timeMapping);
+			$[25] = timeMapping;
+			$[26] = visibleRows;
+			$[27] = t12;
+		} else t12 = $[27];
+		t11 = t12;
 	}
-	const branchMappings = t10;
-	let t11;
-	if ($[23] !== branchMappings || $[24] !== markerConfig.depth || $[25] !== markerConfig.kinds || $[26] !== timeMapping || $[27] !== visibleRows) {
-		t11 = computeRowLayouts(visibleRows, timeMapping, markerConfig.depth, markerConfig.kinds, branchMappings);
-		$[23] = branchMappings;
-		$[24] = markerConfig.depth;
-		$[25] = markerConfig.kinds;
-		$[26] = timeMapping;
-		$[27] = visibleRows;
-		$[28] = t11;
-	} else t11 = $[28];
-	const layouts = t11;
+	const branchMappings = t11;
 	let t12;
-	if ($[29] !== events || $[30] !== includeUtility || $[31] !== showBranches || $[32] !== state.rows || $[33] !== state.selected) {
+	if ($[28] !== branchMappings || $[29] !== markerConfig.depth || $[30] !== markerConfig.kinds || $[31] !== timeMapping || $[32] !== visibleRows) {
+		t12 = computeRowLayouts(visibleRows, timeMapping, markerConfig.depth, markerConfig.kinds, branchMappings);
+		$[28] = branchMappings;
+		$[29] = markerConfig.depth;
+		$[30] = markerConfig.kinds;
+		$[31] = timeMapping;
+		$[32] = visibleRows;
+		$[33] = t12;
+	} else t12 = $[33];
+	const layouts = t12;
+	let t13;
+	if ($[34] !== events || $[35] !== includeUtility || $[36] !== showBranches || $[37] !== state.rows || $[38] !== state.selected) {
 		bb1: {
 			let selection = state.selected;
 			let spans = getSelectedSpans(state.rows, selection);
@@ -118563,24 +118597,24 @@ function useTranscriptTimeline(options) {
 			}
 			const parsed = parseSelection(selection);
 			if (spans.length === 0) {
-				let t13;
-				if ($[35] !== events) {
-					t13 = {
+				let t14;
+				if ($[40] !== events) {
+					t14 = {
 						selectedEvents: events,
 						sourceSpans: emptySourceSpans,
 						branchScrollTarget: null
 					};
-					$[35] = events;
-					$[36] = t13;
-				} else t13 = $[36];
-				t12 = t13;
+					$[40] = events;
+					$[41] = t14;
+				} else t14 = $[41];
+				t13 = t14;
 				break bb1;
 			}
 			const rowKey = parsed?.rowKey ?? "";
 			const row_0 = state.rows.find((r) => r.key === rowKey);
 			if (spans.length === 1 && (row_0?.branch || (spans[0]?.branches.length ?? 0) > 0)) {
 				const collected = collectPathWithNavigators(state.rows, rowKey, events);
-				t12 = {
+				t13 = {
 					selectedEvents: collected.events,
 					sourceSpans: collected.sourceSpans,
 					branchScrollTarget: null
@@ -118593,37 +118627,37 @@ function useTranscriptTimeline(options) {
 				showBranches,
 				branchPrefix: getBranchPrefix(state.rows, selection)
 			});
-			let t13;
-			if ($[37] !== collected_0.events || $[38] !== collected_0.sourceSpans) {
-				t13 = {
+			let t14;
+			if ($[42] !== collected_0.events || $[43] !== collected_0.sourceSpans) {
+				t14 = {
 					selectedEvents: collected_0.events,
 					sourceSpans: collected_0.sourceSpans,
 					branchScrollTarget: null
 				};
-				$[37] = collected_0.events;
-				$[38] = collected_0.sourceSpans;
-				$[39] = t13;
-			} else t13 = $[39];
-			t12 = t13;
+				$[42] = collected_0.events;
+				$[43] = collected_0.sourceSpans;
+				$[44] = t14;
+			} else t14 = $[44];
+			t13 = t14;
 		}
-		$[29] = events;
-		$[30] = includeUtility;
-		$[31] = showBranches;
-		$[32] = state.rows;
-		$[33] = state.selected;
-		$[34] = t12;
-	} else t12 = $[34];
-	const { selectedEvents, sourceSpans, branchScrollTarget } = t12;
-	let t13;
-	if ($[40] !== state.rows || $[41] !== state.selected) {
-		t13 = computeMinimapSelection(state.rows, state.selected);
-		$[40] = state.rows;
-		$[41] = state.selected;
-		$[42] = t13;
-	} else t13 = $[42];
-	const minimapSelection = t13;
+		$[34] = events;
+		$[35] = includeUtility;
+		$[36] = showBranches;
+		$[37] = state.rows;
+		$[38] = state.selected;
+		$[39] = t13;
+	} else t13 = $[39];
+	const { selectedEvents, sourceSpans, branchScrollTarget } = t13;
+	let t14;
+	if ($[45] !== state.rows || $[46] !== state.selected) {
+		t14 = computeMinimapSelection(state.rows, state.selected);
+		$[45] = state.rows;
+		$[46] = state.selected;
+		$[47] = t14;
+	} else t14 = $[47];
+	const minimapSelection = t14;
 	let counts;
-	if ($[43] !== state.rows) {
+	if ($[48] !== state.rows) {
 		counts = /* @__PURE__ */ new Map();
 		for (const row_1 of state.rows) {
 			const firstSpan = row_1.spans[0];
@@ -118634,16 +118668,16 @@ function useTranscriptTimeline(options) {
 				if (compactionCount > 0) counts.set(row_1.key, compactionCount + 1);
 			}
 		}
-		$[43] = state.rows;
-		$[44] = counts;
-	} else counts = $[44];
+		$[48] = state.rows;
+		$[49] = counts;
+	} else counts = $[49];
 	const regionCounts = counts;
-	let t14;
-	if ($[45] !== layouts || $[46] !== state.rows || $[47] !== state.selected) {
+	let t15;
+	if ($[50] !== layouts || $[51] !== state.rows || $[52] !== state.selected) {
 		bb2: {
 			const rowKey_0 = parseSelection(state.selected)?.rowKey ?? "";
 			if (!state.rows.find((r_0) => r_0.key === rowKey_0)?.branch) {
-				t14 = emptyHighlightedKeys;
+				t15 = emptyHighlightedKeys;
 				break bb2;
 			}
 			const layoutByKey = /* @__PURE__ */ new Map();
@@ -118659,141 +118693,141 @@ function useTranscriptTimeline(options) {
 				keys.set(parentKey, forkMarker?.left ?? 100);
 				childKey = parentKey;
 			}
-			t14 = keys;
+			t15 = keys;
 		}
-		$[45] = layouts;
-		$[46] = state.rows;
-		$[47] = state.selected;
-		$[48] = t14;
-	} else t14 = $[48];
-	const highlightedKeys = t14;
-	let t15;
-	if ($[49] !== timeline.root.branches || $[50] !== timeline.root.content) {
-		t15 = timeline.root.content.length > 0 && (timeline.root.content.some(_temp3$29) || timeline.root.branches.length > 0);
-		$[49] = timeline.root.branches;
-		$[50] = timeline.root.content;
-		$[51] = t15;
-	} else t15 = $[51];
-	const hasTimeline = t15;
+		$[50] = layouts;
+		$[51] = state.rows;
+		$[52] = state.selected;
+		$[53] = t15;
+	} else t15 = $[53];
+	const highlightedKeys = t15;
 	let t16;
-	if ($[52] !== visibleRows) {
-		t16 = visibleRows.some(_temp4$24);
-		$[52] = visibleRows;
-		$[53] = t16;
-	} else t16 = $[53];
-	const hasAgentTimeline = t16;
+	if ($[54] !== timeline.root.branches || $[55] !== timeline.root.content) {
+		t16 = timeline.root.content.length > 0 && (timeline.root.content.some(_temp3$29) || timeline.root.branches.length > 0);
+		$[54] = timeline.root.branches;
+		$[55] = timeline.root.content;
+		$[56] = t16;
+	} else t16 = $[56];
+	const hasTimeline = t16;
 	let t17;
+	if ($[57] !== visibleRows) {
+		t17 = visibleRows.some(_temp4$24);
+		$[57] = visibleRows;
+		$[58] = t17;
+	} else t17 = $[58];
+	const hasAgentTimeline = t17;
+	let t18;
 	bb3: {
 		if (!state.selected) {
-			t17 = timeline.root.name;
+			t18 = timeline.root.name;
 			break bb3;
 		}
-		let t18;
-		if ($[54] !== state.selected) {
-			t18 = parseSelection(state.selected);
-			$[54] = state.selected;
-			$[55] = t18;
-		} else t18 = $[55];
-		const rowKey_1 = t18?.rowKey ?? state.selected;
 		let t19;
-		if ($[56] !== rowKey_1 || $[57] !== state.rows) {
-			let t20;
-			if ($[59] !== rowKey_1) {
-				t20 = (r_1) => r_1.key === rowKey_1;
-				$[59] = rowKey_1;
-				$[60] = t20;
-			} else t20 = $[60];
-			t19 = state.rows.find(t20);
-			$[56] = rowKey_1;
-			$[57] = state.rows;
-			$[58] = t19;
-		} else t19 = $[58];
-		t17 = t19?.name ?? timeline.root.name;
+		if ($[59] !== state.selected) {
+			t19 = parseSelection(state.selected);
+			$[59] = state.selected;
+			$[60] = t19;
+		} else t19 = $[60];
+		const rowKey_1 = t19?.rowKey ?? state.selected;
+		let t20;
+		if ($[61] !== rowKey_1 || $[62] !== state.rows) {
+			let t21;
+			if ($[64] !== rowKey_1) {
+				t21 = (r_1) => r_1.key === rowKey_1;
+				$[64] = rowKey_1;
+				$[65] = t21;
+			} else t21 = $[65];
+			t20 = state.rows.find(t21);
+			$[61] = rowKey_1;
+			$[62] = state.rows;
+			$[63] = t20;
+		} else t20 = $[63];
+		t18 = t20?.name ?? timeline.root.name;
 	}
-	const selectedRowName = t17;
-	let t18;
-	if ($[61] !== highlightedKeys || $[62] !== layouts || $[63] !== regionCounts || $[64] !== timeMapping) {
-		t18 = {
+	const selectedRowName = t18;
+	let t19;
+	if ($[66] !== highlightedKeys || $[67] !== layouts || $[68] !== regionCounts || $[69] !== timeMapping) {
+		t19 = {
 			layouts,
 			regionCounts,
 			highlightedKeys,
 			timeMapping
 		};
-		$[61] = highlightedKeys;
-		$[62] = layouts;
-		$[63] = regionCounts;
-		$[64] = timeMapping;
-		$[65] = t18;
-	} else t18 = $[65];
-	const swimlanes = t18;
-	let t19;
-	if ($[66] !== minimapSelection || $[67] !== rootTimeMapping) {
-		t19 = {
+		$[66] = highlightedKeys;
+		$[67] = layouts;
+		$[68] = regionCounts;
+		$[69] = timeMapping;
+		$[70] = t19;
+	} else t19 = $[70];
+	const swimlanes = t19;
+	let t20;
+	if ($[71] !== minimapSelection || $[72] !== rootTimeMapping) {
+		t20 = {
 			mapping: rootTimeMapping,
 			selection: minimapSelection
 		};
-		$[66] = minimapSelection;
-		$[67] = rootTimeMapping;
-		$[68] = t19;
-	} else t19 = $[68];
-	const minimap = t19;
-	let t20;
-	if ($[69] !== activeTimelineIndex || $[70] !== setActiveTimeline || $[71] !== timelines) {
-		t20 = {
+		$[71] = minimapSelection;
+		$[72] = rootTimeMapping;
+		$[73] = t20;
+	} else t20 = $[73];
+	const minimap = t20;
+	let t21;
+	if ($[74] !== activeTimelineIndex || $[75] !== setActiveTimeline || $[76] !== timelines) {
+		t21 = {
 			timelines,
 			activeIndex: activeTimelineIndex,
 			setActive: setActiveTimeline
 		};
-		$[69] = activeTimelineIndex;
-		$[70] = setActiveTimeline;
-		$[71] = timelines;
-		$[72] = t20;
-	} else t20 = $[72];
-	const multiTimeline = t20;
-	let t21;
-	if ($[73] !== pushView || $[74] !== state.rows) {
-		t21 = (rowKey_2, label_0) => {
+		$[74] = activeTimelineIndex;
+		$[75] = setActiveTimeline;
+		$[76] = timelines;
+		$[77] = t21;
+	} else t21 = $[77];
+	const multiTimeline = t21;
+	let t22;
+	if ($[78] !== pushView || $[79] !== state.rows) {
+		t22 = (rowKey_2, label_0) => {
 			const span_0 = state.rows.find((r_2) => r_2.key === rowKey_2)?.spans[0];
 			if (span_0 && "agent" in span_0) pushView(span_0.agent, label_0);
 		};
-		$[73] = pushView;
-		$[74] = state.rows;
-		$[75] = t21;
-	} else t21 = $[75];
-	const pushViewByRowKey = t21;
-	let t22;
-	if ($[76] !== popView || $[77] !== pushView || $[78] !== pushViewByRowKey || $[79] !== viewStack) {
-		t22 = {
+		$[78] = pushView;
+		$[79] = state.rows;
+		$[80] = t22;
+	} else t22 = $[80];
+	const pushViewByRowKey = t22;
+	let t23;
+	if ($[81] !== popView || $[82] !== pushView || $[83] !== pushViewByRowKey || $[84] !== viewStack) {
+		t23 = {
 			stack: viewStack,
 			push: pushView,
 			pushByRowKey: pushViewByRowKey,
 			pop: popView
 		};
-		$[76] = popView;
-		$[77] = pushView;
-		$[78] = pushViewByRowKey;
-		$[79] = viewStack;
-		$[80] = t22;
-	} else t22 = $[80];
-	const views = t22;
-	let t23;
-	if ($[81] !== branchScrollTarget || $[82] !== selectedEvents || $[83] !== selectedRowName || $[84] !== sourceSpans) {
-		t23 = {
+		$[81] = popView;
+		$[82] = pushView;
+		$[83] = pushViewByRowKey;
+		$[84] = viewStack;
+		$[85] = t23;
+	} else t23 = $[85];
+	const views = t23;
+	let t24;
+	if ($[86] !== branchScrollTarget || $[87] !== selectedEvents || $[88] !== selectedRowName || $[89] !== sourceSpans) {
+		t24 = {
 			events: selectedEvents,
 			sourceSpans,
 			branchScrollTarget,
 			rowName: selectedRowName
 		};
-		$[81] = branchScrollTarget;
-		$[82] = selectedEvents;
-		$[83] = selectedRowName;
-		$[84] = sourceSpans;
-		$[85] = t23;
-	} else t23 = $[85];
-	const selection_0 = t23;
-	let t24;
-	if ($[86] !== hasAgentTimeline || $[87] !== hasTimeline || $[88] !== minimap || $[89] !== multiTimeline || $[90] !== selection_0 || $[91] !== state || $[92] !== swimlanes || $[93] !== timeline || $[94] !== views) {
-		t24 = {
+		$[86] = branchScrollTarget;
+		$[87] = selectedEvents;
+		$[88] = selectedRowName;
+		$[89] = sourceSpans;
+		$[90] = t24;
+	} else t24 = $[90];
+	const selection_0 = t24;
+	let t25;
+	if ($[91] !== hasAgentTimeline || $[92] !== hasTimeline || $[93] !== minimap || $[94] !== multiTimeline || $[95] !== selection_0 || $[96] !== state || $[97] !== swimlanes || $[98] !== timeline || $[99] !== views) {
+		t25 = {
 			timeline,
 			state,
 			hasTimeline,
@@ -118804,18 +118838,18 @@ function useTranscriptTimeline(options) {
 			views,
 			selection: selection_0
 		};
-		$[86] = hasAgentTimeline;
-		$[87] = hasTimeline;
-		$[88] = minimap;
-		$[89] = multiTimeline;
-		$[90] = selection_0;
-		$[91] = state;
-		$[92] = swimlanes;
-		$[93] = timeline;
-		$[94] = views;
-		$[95] = t24;
-	} else t24 = $[95];
-	return t24;
+		$[91] = hasAgentTimeline;
+		$[92] = hasTimeline;
+		$[93] = minimap;
+		$[94] = multiTimeline;
+		$[95] = selection_0;
+		$[96] = state;
+		$[97] = swimlanes;
+		$[98] = timeline;
+		$[99] = views;
+		$[100] = t25;
+	} else t25 = $[100];
+	return t25;
 }
 function _temp4$24(row_3) {
 	if (row_3.depth < 1) return false;
@@ -121567,7 +121601,7 @@ function _temp$44() {}
 			if (deepLinkTimelineIndex < 0) return;
 			prevDeepLinkRef.current = key;
 			if (deepLinkTimelineIndex === activeTimelineIndex) return;
-			setActiveTimeline(deepLinkTimelineIndex);
+			setActiveTimeline(deepLinkTimelineIndex, { preserveDeepLink: true });
 		};
 		t9 = [
 			initialEventId,
@@ -170244,97 +170278,82 @@ var componentIcons = {
 * Renders the application content. Mounted below the config gate so it can
 * read the resolved app config.
 */ var AppContent = () => {
-	const $ = (0, import_compiler_runtime.c)(14);
-	let t0;
-	if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-		t0 = getApi();
-		$[0] = t0;
-	} else t0 = $[0];
-	const api = t0;
+	const $ = (0, import_compiler_runtime.c)(12);
 	const rehydrated = useStore(_temp5);
-	const logDir = useLogDir();
 	const setInitialState = useStore(_temp6);
-	let t1;
-	if ($[1] !== logDir || $[2] !== rehydrated || $[3] !== setInitialState) {
-		t1 = (e) => {
+	let t0;
+	if ($[0] !== rehydrated || $[1] !== setInitialState) {
+		t0 = (e) => {
 			bb6: switch (e.data.type) {
 				case "updateState":
 					if (e.data.url) {
-						const decodedUrl_0 = decodeURIComponent(e.data.url);
-						setLogRoot(resolveEmbeddedLogDir(decodedUrl_0));
-						if (!rehydrated) setInitialState(isUri(decodedUrl_0) ? basename(decodedUrl_0) : decodedUrl_0, e.data.sample_id, e.data.sample_epoch);
+						const decodedUrl = decodeURIComponent(e.data.url);
+						setLogRoot(resolveEmbeddedLogDir(decodedUrl));
+						if (!rehydrated) setInitialState(isUri(decodedUrl) ? basename(decodedUrl) : decodedUrl, e.data.sample_id, e.data.sample_epoch);
 					}
 					break bb6;
-				case "backgroundUpdate": {
-					const decodedUrl = decodeURIComponent(e.data.url);
-					const log_dir = e.data.log_dir;
-					if (!document.hasFocus()) {
-						if (log_dir === logDir) selectLogFile(decodedUrl);
-						else api.open_log_file(e.data.url, e.data.log_dir);
-					} else imperativeLogData.invalidateLogListing();
-				}
+				case "backgroundUpdate": imperativeLogData.invalidateLogListing();
 			}
 		};
-		$[1] = logDir;
-		$[2] = rehydrated;
-		$[3] = setInitialState;
-		$[4] = t1;
-	} else t1 = $[4];
-	const onMessage = t1;
+		$[0] = rehydrated;
+		$[1] = setInitialState;
+		$[2] = t0;
+	} else t0 = $[2];
+	const onMessage = t0;
+	let t1;
 	let t2;
-	let t3;
-	if ($[5] !== onMessage) {
-		t2 = () => {
+	if ($[3] !== onMessage) {
+		t1 = () => {
 			window.addEventListener("message", onMessage);
 			return () => {
 				window.removeEventListener("message", onMessage);
 			};
 		};
-		t3 = [onMessage];
-		$[5] = onMessage;
-		$[6] = t2;
-		$[7] = t3;
+		t2 = [onMessage];
+		$[3] = onMessage;
+		$[4] = t1;
+		$[5] = t2;
 	} else {
-		t2 = $[6];
-		t3 = $[7];
+		t1 = $[4];
+		t2 = $[5];
 	}
-	(0, import_react.useEffect)(t2, t3);
+	(0, import_react.useEffect)(t1, t2);
 	const embeddedDispatched = (0, import_react.useRef)(false);
+	let t3;
 	let t4;
-	let t5;
-	if ($[8] !== onMessage) {
-		t4 = () => {
+	if ($[6] !== onMessage) {
+		t3 = () => {
 			if (embeddedDispatched.current) return;
 			embeddedDispatched.current = true;
 			const embedded = readEmbeddedStartupState();
 			if (embedded) onMessage({ data: embedded });
 		};
-		t5 = [onMessage];
-		$[8] = onMessage;
-		$[9] = t4;
-		$[10] = t5;
+		t4 = [onMessage];
+		$[6] = onMessage;
+		$[7] = t3;
+		$[8] = t4;
 	} else {
-		t4 = $[9];
-		t5 = $[10];
+		t3 = $[7];
+		t4 = $[8];
 	}
-	(0, import_react.useEffect)(t4, t5);
+	(0, import_react.useEffect)(t3, t4);
 	useMountEffect(_temp7);
+	let t5;
 	let t6;
+	if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
+		t5 = /*#__PURE__*/ (0, import_jsx_runtime.jsx)(ThemePreferenceSyncController, {});
+		t6 = /*#__PURE__*/ (0, import_jsx_runtime.jsx)(FetchEngineController, {});
+		$[9] = t5;
+		$[10] = t6;
+	} else {
+		t5 = $[9];
+		t6 = $[10];
+	}
 	let t7;
 	if ($[11] === Symbol.for("react.memo_cache_sentinel")) {
-		t6 = /*#__PURE__*/ (0, import_jsx_runtime.jsx)(ThemePreferenceSyncController, {});
-		t7 = /*#__PURE__*/ (0, import_jsx_runtime.jsx)(FetchEngineController, {});
-		$[11] = t6;
-		$[12] = t7;
-	} else {
-		t6 = $[11];
-		t7 = $[12];
-	}
-	let t8;
-	if ($[13] === Symbol.for("react.memo_cache_sentinel")) {
-		t8 = /*#__PURE__*/ (0, import_jsx_runtime.jsxs)(import_jsx_runtime.Fragment, { children: [
+		t7 = /*#__PURE__*/ (0, import_jsx_runtime.jsxs)(import_jsx_runtime.Fragment, { children: [
+			t5,
 			t6,
-			t7,
 			/*#__PURE__*/ (0, import_jsx_runtime.jsx)(ComponentIconProvider, {
 				icons: componentIcons,
 				children: /*#__PURE__*/ (0, import_jsx_runtime.jsx)(ComponentStateProvider, {
@@ -170343,9 +170362,9 @@ var componentIcons = {
 				})
 			})
 		] });
-		$[13] = t8;
-	} else t8 = $[13];
-	return t8;
+		$[11] = t7;
+	} else t7 = $[11];
+	return t7;
 };
 var App = () => {
 	const $ = (0, import_compiler_runtime.c)(1);

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -4888,6 +4888,17 @@
               }
             ]
           },
+          "run_config_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Config Source"
+          },
           "run_id": {
             "title": "Run Id",
             "type": "string"

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -1042,6 +1042,9 @@ class EvalSpec(BaseModel):
     task_attribs: dict[str, Any] = Field(default_factory=dict)
     """Attributes of the @task decorator."""
 
+    run_config_source: str | None = Field(default=None)
+    """Configuration source, prefixed with `task_default:` or `cli:` when present."""
+
     task_args: dict[str, Any] = Field(default_factory=dict)
     """Arguments used for invoking the task (including defaults)."""
 

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -76,6 +76,7 @@ from inspect_ai._util.working import (
     sample_working_time,
 )
 from inspect_ai.model._generate_overrides import generate_config_override_for_attempt
+from inspect_ai.model._model_config import ModelConfig
 from inspect_ai.model._retry import model_retry_config
 from inspect_ai.tool import Tool, ToolChoice, ToolFunction, ToolInfo
 from inspect_ai.tool._mcp._remote import is_mcp_server_tool
@@ -2771,10 +2772,12 @@ def active_model() -> Model | None:
 
 # Mapping (not dict) so that pre-typed user dicts like dict[str, list[str]]
 # type-check — dict is invariant in its value type, Mapping is covariant
-ModelRoles: TypeAlias = Mapping[str, str | Model | Sequence[str | Model]]
+ModelRoles: TypeAlias = Mapping[
+    str, str | Model | ModelConfig | Sequence[str | Model | ModelConfig]
+]
 """Assignment of models to named roles (e.g. the `model_roles` argument to `eval()` or `Task`).
 
-Maps a role name to a model (name or `Model` instance) or to a list of
+Maps a role name to a model (name, `Model`, or `ModelConfig` instance) or to a list of
 models. Assigned roles are looked up with `get_model(role=...)` or
 `model_roles()` (to *reference* a role, e.g. from a scorer, see `ModelRole`).
 """

--- a/src/inspect_ai/model/_model_config.py
+++ b/src/inspect_ai/model/_model_config.py
@@ -5,6 +5,9 @@ from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
 
+# imported as a module (not `from ._model import Model`) so this file can be
+# imported by _model.py without a cycle; with annotations deferred above, the
+# alias is only ever dereferenced by get_type_hints(), never at import time
 import inspect_ai.model as model_module
 from inspect_ai.model._generate_config import GenerateConfig
 

--- a/src/inspect_ai/model/_model_config.py
+++ b/src/inspect_ai/model/_model_config.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from inspect import isgenerator
 from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
 
+import inspect_ai.model as model_module
 from inspect_ai.model._generate_config import GenerateConfig
-from inspect_ai.model._model import Model, get_model
 
 
 class ModelConfig(BaseModel):
@@ -24,7 +26,7 @@ class ModelConfig(BaseModel):
 
 
 def model_roles_to_model_roles_config(
-    model_roles: dict[str, Model | list[Model]] | None,
+    model_roles: dict[str, model_module.Model | list[model_module.Model]] | None,
 ) -> dict[str, ModelConfig | list[ModelConfig]] | None:
     if model_roles is not None:
         return {
@@ -39,7 +41,7 @@ def model_roles_to_model_roles_config(
 
 def model_roles_config_to_model_roles(
     model_config: dict[str, ModelConfig | list[ModelConfig]] | None,
-) -> dict[str, Model | list[Model]] | None:
+) -> dict[str, model_module.Model | list[model_module.Model]] | None:
     if model_config is not None:
         return {
             k: [model_config_to_model(mc) for mc in v]
@@ -51,7 +53,7 @@ def model_roles_config_to_model_roles(
         return None
 
 
-def model_to_model_config(model: Model) -> ModelConfig:
+def model_to_model_config(model: model_module.Model) -> ModelConfig:
     return ModelConfig(
         model=str(model),
         config=model.config,
@@ -60,7 +62,9 @@ def model_to_model_config(model: Model) -> ModelConfig:
     )
 
 
-def model_config_to_model(model_config: ModelConfig) -> Model:
+def model_config_to_model(model_config: ModelConfig) -> model_module.Model:
+    from inspect_ai.model._model import get_model
+
     return get_model(
         model=model_config.model,
         config=model_config.config,

--- a/src/inspect_ai/model/_util.py
+++ b/src/inspect_ai/model/_util.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.model._model import Model, ModelRoles, get_model
+from inspect_ai.model._model_config import ModelConfig, model_config_to_model
 from inspect_ai.model._model_info import _get_model_info_direct
 
 if TYPE_CHECKING:
@@ -17,14 +18,14 @@ def resolve_model_roles(
     if model_roles is not None:
         resolved_model_roles: dict[str, Model | list[Model]] = {}
         for k, v in model_roles.items():
-            if isinstance(v, str | Model):
+            if isinstance(v, str | Model | ModelConfig):
                 resolved_model_roles[k] = _resolve_role_model(k, v)
             else:
                 # guard against untyped values (e.g. CLI YAML parsing can
                 # yield None or numeric scalars) so they get a clean error
                 # rather than a TypeError/AttributeError downstream
                 if not isinstance(v, Sequence) or not all(
-                    isinstance(m, str | Model) for m in v
+                    isinstance(m, str | Model | ModelConfig) for m in v
                 ):
                     raise PrerequisiteError(
                         f"Model role '{k}' has an invalid value ({v!r}): "
@@ -46,13 +47,16 @@ def resolve_model_roles(
         return None
 
 
-def _resolve_role_model(role: str, model: str | Model) -> Model:
+def _resolve_role_model(role: str, model: str | Model | ModelConfig) -> Model:
     # memoize=False for strings / copy for Model instances so that each role
     # gets a distinct Model instance; otherwise roles sharing the same model
     # collapse onto one object and per-role usage is misattributed (see #4450)
-    resolved = (
-        get_model(model, memoize=False) if isinstance(model, str) else copy(model)
-    )
+    if isinstance(model, ModelConfig):
+        resolved = model_config_to_model(model)
+    else:
+        resolved = (
+            get_model(model, memoize=False) if isinstance(model, str) else copy(model)
+        )
     resolved._set_role(role)
     return resolved
 

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -593,6 +593,17 @@ A tuple, e.g. ("docker", "compose.yaml"), is equivalent to SandboxEnvironmentSpe
 """
 
 
+def parse_sandbox(sandbox: str | None) -> SandboxEnvironmentSpec | None:
+    if sandbox is not None:
+        parts = sandbox.split(":", maxsplit=1)
+        if len(parts) == 1:
+            return SandboxEnvironmentSpec(sandbox)
+        else:
+            return SandboxEnvironmentSpec(parts[0], parts[1])
+    else:
+        return None
+
+
 def resolve_sandbox_environment(
     sandbox: SandboxEnvironmentType | None,
 ) -> SandboxEnvironmentSpec | None:

--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -181,6 +181,113 @@ def test_eval_log_run_config_round_trip() -> None:
     assert grader_config.config.max_tokens == 500
 
 
+def test_run_config_repeated_eval_preserves_task_defaults_and_logs(
+    tmp_path: Path,
+) -> None:
+    from inspect_ai._cli.eval import RunConfigInput, merge_run_config_params
+
+    task_instance = Task(
+        config=GenerateConfig(temperature=0.6, seed=42),
+        epochs=2,
+        score_on_error=True,
+        metadata={"task": "default"},
+    )
+    config = RunConfigInput.model_validate(
+        {
+            "model": "mockllm/model",
+            "generate_config": {"temperature": 0},
+            "eval_config": {"score_on_error": False},
+        }
+    )
+    before = config.model_dump()
+    params = merge_run_config_params(
+        config.to_params(), {"temperature": None, "score_on_error": None}
+    )
+    first = eval(task_instance, log_dir=str(tmp_path), **params)[0]
+    second = eval(
+        task_instance,
+        model="mockllm/model",
+        log_dir=str(tmp_path),
+        temperature=None,
+        score_on_error=None,
+    )[0]
+    assert first.status == second.status == "success"
+    assert first.plan.config.temperature == 0
+    assert first.eval.config.score_on_error is False
+    assert second.plan.config.temperature == 0.6
+    assert second.eval.config.score_on_error is True
+    assert first.plan.config.seed == second.plan.config.seed == 42
+    assert first.eval.config.epochs == second.eval.config.epochs == 2
+    assert task_instance.config.temperature == 0.6
+    assert task_instance.score_on_error is True
+    assert config.model_dump() == before
+    for original in (first, second):
+        persisted = read_eval_log(original.location)
+        assert persisted.plan.config == original.plan.config
+        assert persisted.eval.config == original.eval.config
+        exported = eval_log_to_run_config_dict(persisted)
+        assert (
+            exported["generate_config"]["temperature"]
+            == original.plan.config.temperature
+        )
+        assert (
+            exported["eval_config"]["score_on_error"]
+            == original.eval.config.score_on_error
+        )
+
+
+def test_eval_log_export_omits_operational_fields_and_keeps_falsey_values() -> None:
+    log = _make_log()
+    operational = {
+        "log_samples": False,
+        "log_realtime": False,
+        "log_images": False,
+        "log_model_api": False,
+        "log_buffer": 0,
+        "log_shared": 0,
+        "score_display": False,
+        "sandbox_cleanup": False,
+        "sandbox_prebuilt": False,
+        "max_samples": 1,
+        "max_dataset_memory": 2,
+        "max_tasks": 3,
+        "max_subprocesses": 4,
+        "max_sandboxes": 5,
+    }
+    scientific = {
+        "limit": 0,
+        "score_on_error": False,
+        "continue_on_fail": False,
+        "sample_shuffle": False,
+    }
+    log.eval.config = EvalConfig.model_validate(operational | scientific)
+    log.eval.task_file = "tasks.py"
+    log.eval.task_registry_name = "registered_task"
+    log.eval.task_args = {"value": None}
+    log.eval.tags = ["tag", "tag"]
+    log.eval.metadata = {"value": None}
+    log.eval.model_base_url = "https://example.test"
+    log.eval.model_args = {"value": None}
+    log.eval.model_generate_config = GenerateConfig(temperature=0)
+    exported = eval_log_to_run_config_dict(log)
+    assert exported["eval_config"] == scientific
+    assert exported["task"] == {
+        "task": "tasks.py@registered_task",
+        "args": {"value": None},
+    }
+    assert exported["model"] == {
+        "model": "mockllm/model",
+        "base_url": "https://example.test",
+        "args": {"value": None},
+        "config": {"temperature": 0.0},
+    }
+    assert exported["tags"] == ["tag", "tag"]
+    assert exported["metadata"] == {"value": None}
+    assert "solver" not in exported
+    assert "sandbox" not in exported
+    assert "model_roles" not in exported
+
+
 def test_sandbox_string_config() -> None:
     log = _make_log(SandboxEnvironmentSpec(type="docker", config="compose.yaml"))
     d = eval_log_to_run_config_dict(log)

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -1,23 +1,30 @@
+import json
 import os
 import tempfile
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
-from inspect_ai import Task, eval, task
+from inspect_ai import Epochs, Task, eval, task
 from inspect_ai._cli.eval import (
     RunConfigInput,
     eval_command,
     eval_retry_command,
     eval_set_command,
+    merge_run_config_params,
+    parse_run_config,
 )
 from inspect_ai._util.error import PrerequisiteError
-from inspect_ai.log import EvalLog
+from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._file import list_eval_logs, read_eval_log
-from inspect_ai.model import get_model
-from inspect_ai.solver import solver
+from inspect_ai.model import GenerateConfig, Model, get_model
+from inspect_ai.solver import SolverSpec, solver
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 
 def run_eval_cli(args: list[str], env: dict[str, str | None] | None = None) -> Result:
@@ -78,6 +85,593 @@ def test_run_config_rejects_unknown_generate_config_field():
 def test_run_config_rejects_unknown_eval_config_field():
     with pytest.raises(ValidationError, match="[Uu]nknown"):
         RunConfigInput.model_validate({"eval_config": {"limit": 10, "bad_field": 1}})
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({}, {}),
+        ({"task": None, "model": None, "solver": None, "sandbox": None}, {}),
+        ({"tags": [], "metadata": {}, "model_roles": {}}, {}),
+        ({"task": "task_ref"}, {"tasks": "task_ref"}),
+        ({"task": {"task": "task_ref", "args": {}}}, {"tasks": "task_ref"}),
+        (
+            {"task": {"task": "task_ref", "args": {"value": None}}},
+            {"tasks": "task_ref", "task_args": {"value": None}},
+        ),
+        ({"model": "mockllm/model"}, {"model": "mockllm/model"}),
+        (
+            {"model": {"model": "mockllm/model", "base_url": "", "args": {"x": 0}}},
+            {"model": "mockllm/model", "model_base_url": "", "model_args": {"x": 0}},
+        ),
+        ({"tags": ["one", "one"]}, {"tags": ["one", "one"]}),
+        (
+            {"metadata": {"nested": {"x": False}}},
+            {"metadata": {"nested": {"x": False}}},
+        ),
+        ({"eval_config": {"epochs_reducer": ["mean"]}}, {}),
+        (
+            {"generate_config": {"temperature": None}, "eval_config": {"limit": None}},
+            {},
+        ),
+    ],
+)
+def test_run_config_to_params_mapping(
+    config: dict[str, Any], expected: dict[str, Any]
+) -> None:
+    assert RunConfigInput.model_validate(config).to_params() == expected
+
+
+@pytest.mark.parametrize("structured", [False, True])
+def test_run_config_solver_and_sandbox_mapping(structured: bool) -> None:
+    config = RunConfigInput.model_validate(
+        {
+            "solver": {"solver": "solver_ref", "args": {"x": None}}
+            if structured
+            else "solver_ref",
+            "sandbox": {"type": "docker", "config": "file://compose.yaml"}
+            if structured
+            else "docker:file://compose.yaml",
+        }
+    )
+    params = config.to_params()
+    spec = params["solver"]
+    assert isinstance(spec, SolverSpec)
+    assert spec.solver == "solver_ref"
+    assert spec.args == ({"x": None} if structured else {})
+    assert spec.args_passed == spec.args
+    assert params["sandbox"] == SandboxEnvironmentSpec("docker", "file://compose.yaml")
+
+
+def test_run_config_generate_config_all_fields() -> None:
+    values = {
+        "max_retries": 0,
+        "timeout": 1,
+        "attempt_timeout": 2,
+        "stream_idle_timeout": 3,
+        "max_connections": 4,
+        "adaptive_connections": False,
+        "system_message": "system",
+        "max_tokens": 5,
+        "top_p": 0.5,
+        "temperature": 0.0,
+        "stop_seqs": [],
+        "best_of": 1,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "logit_bias": {1: 0.5},
+        "seed": 0,
+        "top_k": 2,
+        "num_choices": 1,
+        "logprobs": False,
+        "top_logprobs": 0,
+        "prompt_logprobs": 1,
+        "parallel_tool_calls": False,
+        "internal_tools": False,
+        "max_tool_output": 10,
+        "cache_prompt": False,
+        "fallback_models": [],
+        "verbosity": "low",
+        "effort": "high",
+        "reasoning_effort": "low",
+        "reasoning_mode": "standard",
+        "reasoning_tokens": 10,
+        "reasoning_summary": "none",
+        "reasoning_history": "none",
+        "response_schema": {"name": "response", "json_schema": {"type": "object"}},
+        "extra_headers": {},
+        "extra_body": {"nested": {"x": 1}},
+        "modalities": ["image"],
+        "cache": False,
+        "batch": False,
+    }
+    assert set(values) == set(GenerateConfig.model_fields)
+    expected = GenerateConfig.model_validate(values).model_dump(exclude_none=True)
+    for config in (
+        {"generate_config": values},
+        {"model": {"model": "mockllm/model", "config": values}},
+    ):
+        params = RunConfigInput.model_validate(config).to_params()
+        params.pop("model", None)
+        assert params == expected
+
+
+def test_run_config_eval_config_all_fields() -> None:
+    values = {
+        "limit": [1, 3],
+        "sample_id": ["one", 2],
+        "sample_shuffle": False,
+        "approval": {"approvers": []},
+        "notification": False,
+        "fail_on_error": 0.5,
+        "continue_on_fail": False,
+        "retry_on_error": 0,
+        "score_on_error": False,
+        "message_limit": 1,
+        "token_limit": 2,
+        "token_limit_type": "output",
+        "turn_limit": 3,
+        "time_limit": 4,
+        "working_limit": 5,
+        "cost_limit": 0.0,
+        "max_samples": 1,
+        "max_dataset_memory": 2,
+        "max_tasks": 3,
+        "max_subprocesses": 4,
+        "max_sandboxes": 5,
+        "sandbox_cleanup": False,
+        "sandbox_prebuilt": False,
+        "log_samples": False,
+        "log_realtime": False,
+        "log_images": False,
+        "log_model_api": False,
+        "log_buffer": 0,
+        "log_shared": 0,
+        "score_display": False,
+        "acp_server": False,
+    }
+    assert set(values) == set(EvalConfig.model_fields) - {"epochs", "epochs_reducer"}
+    expected = EvalConfig.model_validate(values).model_dump(exclude_none=True)
+    assert (
+        RunConfigInput.model_validate({"eval_config": values}).to_params() == expected
+    )
+
+
+@pytest.mark.parametrize("reducers", [None, [], ["mean", "max"]])
+@pytest.mark.parametrize("count", [0, 2])
+def test_run_config_epochs_mapping(count: int, reducers: list[str] | None) -> None:
+    params = RunConfigInput.model_validate(
+        {"eval_config": {"epochs": count, "epochs_reducer": reducers}}
+    ).to_params()
+    assert set(params) == {"epochs"}
+    epochs = params["epochs"]
+    assert isinstance(epochs, Epochs)
+    assert epochs.epochs == count
+    assert (None if epochs.reducer is None else len(epochs.reducer)) == (
+        None if reducers is None else len(reducers)
+    )
+
+
+def test_run_config_generation_precedence_replaces_nested_values() -> None:
+    params = RunConfigInput.model_validate(
+        {
+            "model": {
+                "model": "mockllm/model",
+                "config": {
+                    "temperature": 0.8,
+                    "seed": 42,
+                    "extra_body": {"keep": True, "nested": {"a": 1}},
+                    "extra_headers": {"x": "old"},
+                },
+            },
+            "generate_config": {
+                "temperature": 0,
+                "seed": None,
+                "extra_body": {"nested": {"b": 2}},
+                "extra_headers": {},
+            },
+        }
+    ).to_params()
+    assert params == {
+        "model": "mockllm/model",
+        "temperature": 0.0,
+        "seed": 42,
+        "extra_body": {"nested": {"b": 2}},
+        "extra_headers": {},
+    }
+
+
+def test_run_config_model_roles_list_and_repeated_conversion() -> None:
+    config = RunConfigInput.model_validate(
+        {
+            "model_roles": {
+                "single": {
+                    "model": "mockllm/single",
+                    "base_url": "https://example.test",
+                    "args": {"foo": "bar"},
+                    "config": {"temperature": 0},
+                },
+                "group": [
+                    {"model": "mockllm/first"},
+                    {"model": "mockllm/second", "config": {"seed": 0}},
+                ],
+                "empty": [],
+            }
+        }
+    )
+    before = config.model_dump()
+    first = config.to_params()["model_roles"]
+    second = config.to_params()["model_roles"]
+    assert isinstance(first["single"], Model)
+    assert first["single"].api.base_url == "https://example.test"
+    assert first["single"].model_args == {"foo": "bar"}
+    assert first["single"].config.temperature == 0
+    assert [str(model) for model in first["group"]] == [
+        "mockllm/first",
+        "mockllm/second",
+    ]
+    assert first["group"][1].config.seed == 0
+    assert first["empty"] == []
+    assert first["single"] is not second["single"]
+    assert first["group"][0] is not second["group"][0]
+    assert config.model_dump() == before
+
+
+@pytest.mark.parametrize("section", ["task", "solver", "model"])
+def test_run_config_nested_unknown_fields_are_ignored(section: str) -> None:
+    name = "mockllm/model" if section == "model" else "reference"
+    config = RunConfigInput.model_validate({section: {section: name, "typo": 1}})
+    assert "typo" not in config.model_dump()[section]
+
+
+@pytest.mark.parametrize(
+    "section", ["generate_config", "eval_config", "tags", "metadata", "model_roles"]
+)
+def test_run_config_nonnullable_sections(section: str) -> None:
+    with pytest.raises(ValidationError):
+        RunConfigInput.model_validate({section: None})
+
+
+@pytest.mark.parametrize("suffix", [".yaml", ".json"])
+@pytest.mark.parametrize("uri", [False, True])
+def test_parse_run_config_files(tmp_path: Path, suffix: str, uri: bool) -> None:
+    path = tmp_path / f"run{suffix}"
+    data = {
+        "task": {"task": "task_ref", "args": {"value": None}},
+        "generate_config": {"temperature": 0},
+    }
+    path.write_text(json.dumps(data) if suffix == ".json" else yaml.safe_dump(data))
+    assert parse_run_config(path.as_uri() if uri else str(path)) == {
+        "tasks": "task_ref",
+        "task_args": {"value": None},
+        "temperature": 0.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        ({"typo": 1}, "Additional properties are not allowed"),
+        ({"task": 42}, "not valid under any of the given schemas"),
+        ({"generate_config": {"typo": 1}}, "Unknown generate_config fields"),
+        ({"eval_config": {"max_messages": 3}}, "Unknown eval_config fields"),
+    ],
+)
+def test_parse_run_config_validation_errors(
+    tmp_path: Path, data: dict[str, Any], message: str
+) -> None:
+    path = tmp_path / "invalid.yaml"
+    path.write_text(yaml.safe_dump(data))
+    with pytest.raises(PrerequisiteError) as exc:
+        parse_run_config(str(path))
+    assert f"Invalid run config '{path}':" in str(exc.value.message)
+    assert message in str(exc.value.message)
+
+
+@pytest.mark.parametrize("content", ["", "[]", "null", "not-an-object"])
+def test_parse_run_config_nonobject_errors(tmp_path: Path, content: str) -> None:
+    path = tmp_path / "invalid.yaml"
+    path.write_text(content)
+    with pytest.raises(ValueError, match="The config is not a valid object"):
+        parse_run_config(str(path))
+
+
+def test_parse_run_config_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "missing.yaml"
+    with pytest.raises(PrerequisiteError) as exc:
+        parse_run_config(str(path))
+    assert exc.value.message == f"The config file {path} does not exist."
+
+
+@pytest.mark.parametrize(
+    "value, overrides",
+    [
+        (None, False),
+        ({}, False),
+        ([], True),
+        ((), True),
+        ("", True),
+        (False, True),
+        (0, True),
+        (True, True),
+    ],
+)
+def test_merge_run_config_empty_and_falsey_values(value: Any, overrides: bool) -> None:
+    assert merge_run_config_params({"key": "run"}, {"key": value}) == {
+        "key": value if overrides else "run"
+    }
+    assert merge_run_config_params({}, {"key": value}) == (
+        {"key": value} if overrides else {}
+    )
+
+
+@pytest.mark.parametrize("run", [{}, {"score": True}, {"score": False}])
+@pytest.mark.parametrize("cli", [None, True, False])
+def test_merge_run_config_score_default(run: dict[str, Any], cli: bool | None) -> None:
+    assert merge_run_config_params(run, {"score": cli}) == (
+        {"score": False} if cli is False else run
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "task_args",
+        "model_args",
+        "model_roles",
+        "metadata",
+        "extra_body",
+        "extra_headers",
+    ],
+)
+def test_merge_run_config_shallow_merge_and_replacement(key: str) -> None:
+    run = {key: {"keep": 1, "nested": {"old": 2, "shared": 3}}}
+    cli = {key: {"nested": {"new": 4}}}
+    before_run, before_cli = deepcopy(run), deepcopy(cli)
+    result = merge_run_config_params(run, cli)
+    expected: dict[str, Any] = {"nested": {"new": 4}}
+    if key in ("task_args", "model_args", "model_roles"):
+        expected["keep"] = 1
+    assert result == {key: expected}
+    assert result is not run
+    assert run == before_run
+    assert cli == before_cli
+    assert merge_run_config_params(run, cli) == result
+
+
+@pytest.mark.parametrize("constructed", [False, True])
+@pytest.mark.parametrize("args", [{}, {"color": None}, {"color": "blue"}])
+def test_run_config_task_factory_vs_constructed_task(
+    constructed: bool, args: dict[str, Any]
+) -> None:
+    params = RunConfigInput.model_validate(
+        {
+            "task": {"task": "eval_config_characterization_task", "args": args},
+            "model": "mockllm/model",
+            "eval_config": {"epochs": 2},
+            "generate_config": {"temperature": 0},
+        }
+    ).to_params()
+    if constructed:
+        params["tasks"] = eval_config_characterization_task(color="constructed")
+    log = eval(**params)[0]
+    assert log.status == "success"
+    assert log.eval.task_args["color"] == (
+        "constructed" if constructed else args.get("color", "red")
+    )
+    assert log.eval.config.epochs == 2
+    assert log.plan.config.temperature == 0
+
+
+@pytest.mark.parametrize("source", ["environment", "run_config", "flag"])
+@pytest.mark.parametrize(
+    "name, option, envvar, value, config, expected",
+    [
+        (
+            "m",
+            "-M",
+            "INSPECT_EVAL_MODEL_ARGS",
+            "foo=env",
+            {"model": {"model": "mockllm/model", "args": {"foo": "run"}}},
+            ("foo=env",),
+        ),
+        (
+            "t",
+            "-T",
+            "INSPECT_EVAL_TASK_ARGS",
+            "color=env",
+            {"task": {"task": "eval_config_task", "args": {"color": "run"}}},
+            ("color=env",),
+        ),
+        (
+            "model_role",
+            "--model-role",
+            "INSPECT_EVAL_MODEL_ROLE",
+            "grader=mockllm/env",
+            {"model_roles": {"grader": {"model": "mockllm/run"}}},
+            ("grader=mockllm/env",),
+        ),
+        (
+            "model_spec",
+            "--model-spec",
+            "INSPECT_EVAL_MODEL_SPEC",
+            "mockllm/env",
+            {"model": "mockllm/run"},
+            ("mockllm/env",),
+        ),
+        (
+            "no_sandbox_cleanup",
+            "--no-sandbox-cleanup",
+            "INSPECT_EVAL_NO_SANDBOX_CLEANUP",
+            "true",
+            {"eval_config": {"sandbox_cleanup": True}},
+            True,
+        ),
+        (
+            "s",
+            "-S",
+            "INSPECT_EVAL_SOLVER_ARGS",
+            "shape=env",
+            {"solver": "eval_config_solver"},
+            ("shape=env",),
+        ),
+        (
+            "solver_config",
+            "--solver-config",
+            "INSPECT_EVAL_SOLVER_CONFIG",
+            "solver.yaml",
+            {"solver": "eval_config_solver"},
+            "solver.yaml",
+        ),
+        (
+            "temperature",
+            "--temperature",
+            "INSPECT_EVAL_TEMPERATURE",
+            "0.8",
+            {"generate_config": {"temperature": 0}},
+            0.8,
+        ),
+        (
+            "limit",
+            "--limit",
+            "INSPECT_EVAL_LIMIT",
+            "3",
+            {"eval_config": {"limit": 1}},
+            "3",
+        ),
+    ],
+)
+def test_run_config_cli_environment_key_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    name: str,
+    option: str,
+    envvar: str,
+    value: str,
+    config: dict[str, Any],
+    expected: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def capture(**params: Any) -> None:
+        captured.update(params)
+
+    monkeypatch.setattr("inspect_ai._cli.eval._eval_command_impl", capture)
+    path = tmp_path / "run.yaml"
+    path.write_text(yaml.safe_dump({} if source == "environment" else config))
+    args = ["--run-config", str(path)]
+    if source == "flag":
+        args.extend([option] if name == "no_sandbox_cleanup" else [option, value])
+    result = run_eval_cli(args, env={envvar: value, "TERM_PROGRAM": "xterm"})
+    assert_cli_success(result)
+    if source == "run_config":
+        expected = () if isinstance(expected, tuple) else None
+    assert captured[name] == expected
+
+
+@pytest.mark.parametrize(
+    "field, envvar",
+    [
+        ("log_samples", "INSPECT_EVAL_NO_LOG_SAMPLES"),
+        ("log_realtime", "INSPECT_EVAL_NO_LOG_REALTIME"),
+        ("score_display", "INSPECT_EVAL_SCORE_DISPLAY"),
+        ("fail_on_error", "INSPECT_EVAL_NO_FAIL_ON_ERROR"),
+    ],
+)
+def test_run_config_cli_unmapped_negated_env_overrides_config(
+    tmp_path: Path, field: str, envvar: str
+) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "task": "tests/test_eval_config.py@eval_config_characterization_task",
+                "model": "mockllm/model",
+                "eval_config": {field: True},
+            }
+        )
+    )
+    result = run_eval_cli(
+        ["--run-config", str(path), "--log-dir", str(tmp_path / "logs")],
+        env={envvar: "true", "TERM_PROGRAM": "xterm"},
+    )
+    assert_cli_success(result)
+    log = read_eval_log(list_eval_logs(str(tmp_path / "logs"))[0])
+    assert getattr(log.eval.config, field) is False
+
+
+def test_merge_run_config_replaces_role_lists_and_solver() -> None:
+    old = get_model("mockllm/old")
+    new = get_model("mockllm/new")
+    old_solver = SolverSpec("old", {"keep": 1}, {})
+    new_solver = SolverSpec("new", {"replace": 2}, {})
+    run = {"model_roles": {"keep": old, "replace": [old]}, "solver": old_solver}
+    result = merge_run_config_params(
+        run, {"model_roles": {"replace": [new]}, "solver": new_solver}
+    )
+    assert result["model_roles"] == {"keep": old, "replace": [new]}
+    assert result["solver"] is new_solver
+    assert run["model_roles"] == {"keep": old, "replace": [old]}
+    assert run["solver"] is old_solver
+
+
+def test_run_config_nested_model_generation_unknown_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError, match="Unknown GenerateConfig field"):
+        RunConfigInput.model_validate(
+            {
+                "model": {
+                    "model": "mockllm/model",
+                    "config": {"temperature": 0, "typo": 1},
+                },
+            }
+        )
+
+
+def test_run_config_cli_model_config_merges_and_common_env_survives(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "task": "tests/test_eval_config.py@eval_config_task",
+                "model": {
+                    "model": "mockllm/model",
+                    "args": {"keep": True, "foo": "run"},
+                },
+                "metadata": {"keep": True, "shared": "run"},
+                "tags": ["run"],
+            }
+        )
+    )
+    result = run_eval_cli(
+        [
+            "--run-config",
+            str(path),
+            "--model-config",
+            config_path("model.yaml"),
+            "--metadata",
+            "shared=cli",
+            "--tags",
+            "cli",
+        ],
+        env={"INSPECT_LOG_DIR": str(tmp_path / "logs"), "TERM_PROGRAM": "xterm"},
+    )
+    assert_cli_success(result)
+    log = read_eval_log(list_eval_logs(str(tmp_path / "logs"))[0])
+    assert log.eval.model_args == {"keep": True, "foo": "bar"}
+    assert log.eval.metadata == {"shared": "cli"}
+    assert log.eval.tags == ["cli"]
+
+
+def test_eval_set_rejects_run_config(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text("{}")
+    result = run_eval_set_cli(["--run-config", str(path)])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, PrerequisiteError)
+    assert result.exception.message == "--run-config is only supported by inspect eval."
 
 
 def test_eval_config_task():
@@ -714,6 +1308,16 @@ def eval_config_solver(shape="square"):
         return await generate(state)
 
     return solve
+
+
+@task
+def eval_config_characterization_task(color: str | None = "red") -> Task:
+    return Task(
+        metadata={"color": color},
+        config=GenerateConfig(temperature=0.6, seed=42),
+        epochs=3,
+        score_on_error=True,
+    )
 
 
 @task

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,228 @@
+import json
+from pathlib import Path
+from typing import Any, get_type_hints
+from unittest.mock import patch
+
+import pytest
+
+from inspect_ai import RunConfig, Task, eval, merge_run_config_params, read_run_config
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.file import file
+from inspect_ai.dataset import Sample
+from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles
+from inspect_ai.model._util import resolve_model_roles
+
+
+@pytest.mark.parametrize("location", ["path", "uri", "remote"])
+def test_read_run_config_without_resolving_models(
+    tmp_path: Path, location: str
+) -> None:
+    content = json.dumps(
+        {
+            "task": "not_installed/task",
+            "solver": "not_installed/solver",
+            "model": {"model": "not_installed/main"},
+            "model_roles": {
+                "grader": {"model": "not_installed/grader"},
+                "panel": [
+                    {"model": "not_installed/a"},
+                    {"model": "not_installed/b"},
+                ],
+            },
+        }
+    )
+    if location == "remote":
+        config_file = "memory://run-config-api/run.json"
+        with file(config_file, "w") as stream:
+            stream.write(content)
+    else:
+        path = tmp_path / ("run.json" if location == "uri" else "run config.json")
+        path.write_text(content)
+        config_file = path.as_uri() if location == "uri" else str(path)
+
+    with patch(
+        "inspect_ai.model._model.get_model",
+        side_effect=AssertionError("Models must not be instantiated"),
+    ):
+        config = read_run_config(config_file)
+        assert isinstance(config, RunConfig)
+        params = config.to_params(resolve_models=False)
+
+    assert params["tasks"] == "not_installed/task"
+    assert params["model"] == "not_installed/main"
+    assert params["model_roles"] == config.model_roles
+    assert isinstance(params["model_roles"]["grader"], ModelConfig)
+    assert all(
+        isinstance(model, ModelConfig) for model in params["model_roles"]["panel"]
+    )
+    assert RunConfig.model_validate_json(config.model_dump_json()) == config
+
+
+def test_read_run_config_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "run.yaml"
+    path.write_text("task: example/task\ngenerate_config:\n  temperature: 0.25\n")
+    config = read_run_config(str(path))
+    assert config.task == "example/task"
+    assert config.generate_config.temperature == 0.25
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        ({"unknown": True}, "Additional properties are not allowed"),
+        ({"generate_config": {"unknown": True}}, "Unknown generate_config fields"),
+        ({"eval_config": {"unknown": True}}, "Unknown eval_config fields"),
+    ],
+)
+def test_read_run_config_validation_errors(
+    tmp_path: Path, data: dict[str, Any], message: str
+) -> None:
+    path = tmp_path / "run.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(PrerequisiteError, match=message) as error:
+        read_run_config(str(path))
+    assert f"Invalid run config '{path}':" in str(error.value)
+
+
+def test_read_run_config_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(PrerequisiteError, match="does not exist"):
+        read_run_config(str(tmp_path / "missing.yaml"))
+
+
+def test_run_config_resolves_models_only_on_conversion() -> None:
+    config = RunConfig.model_validate(
+        {
+            "model_roles": {
+                "grader": {"model": "mockllm/grader", "config": {"temperature": 0.2}},
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            }
+        }
+    )
+    params = config.to_params()
+    assert isinstance(params["model_roles"]["grader"], Model)
+    assert params["model_roles"]["grader"].config.temperature == 0.2
+    assert all(isinstance(model, Model) for model in params["model_roles"]["panel"])
+    assert isinstance(config.model_roles["grader"], ModelConfig)
+
+
+def test_run_config_deferred_roles_are_independent() -> None:
+    config = RunConfig.model_validate(
+        {
+            "model_roles": {
+                "grader": {
+                    "model": "mockllm/grader",
+                    "config": {"temperature": 0.2},
+                    "args": {"nested": {"values": [1]}},
+                },
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            }
+        }
+    )
+    expected = config.model_copy(deep=True).model_roles
+    first = config.to_params(resolve_models=False)["model_roles"]
+    second = config.to_params(resolve_models=False)["model_roles"]
+
+    first["grader"].model = "mockllm/changed"
+    first["grader"].config.temperature = 0.9
+    first["grader"].args["nested"]["values"].append(2)
+    first["panel"][0].config.temperature = 0.8
+    first["panel"].append(ModelConfig(model="mockllm/c"))
+
+    assert config.model_roles == expected
+    assert second == expected
+    second["panel"].clear()
+    assert len(first["panel"]) == 3
+    assert config.model_roles == expected
+
+
+@pytest.mark.parametrize(
+    "function, annotation, expected",
+    [
+        (
+            "model_roles_to_model_roles_config",
+            "model_roles",
+            dict[str, Model | list[Model]] | None,
+        ),
+        (
+            "model_roles_config_to_model_roles",
+            "return",
+            dict[str, Model | list[Model]] | None,
+        ),
+        ("model_to_model_config", "model", Model),
+        ("model_config_to_model", "return", Model),
+    ],
+)
+def test_model_config_helper_type_hints(
+    function: str, annotation: str, expected: Any
+) -> None:
+    from inspect_ai.model import _model_config
+
+    assert get_type_hints(getattr(_model_config, function))[annotation] == expected
+
+
+def test_run_config_merge_public_api() -> None:
+    base = {"task_args": {"a": 1, "b": 2}, "score": False, "tags": ["base"]}
+    overrides = {"task_args": {"b": None}, "score": True, "tags": []}
+    assert merge_run_config_params(base, overrides) == {
+        "task_args": {"a": 1, "b": None},
+        "score": False,
+        "tags": [],
+    }
+    assert base == {"task_args": {"a": 1, "b": 2}, "score": False, "tags": ["base"]}
+    assert overrides == {"task_args": {"b": None}, "score": True, "tags": []}
+
+
+def test_model_roles_accept_deferred_configs() -> None:
+    assert get_type_hints(eval)["model_roles"] == ModelRoles | None
+    config = ModelConfig(model="mockllm/grader", config=GenerateConfig(temperature=0.2))
+    roles: ModelRoles = {"grader": config, "other": config, "panel": [config]}
+    resolved = resolve_model_roles(roles)
+    assert resolved is not None
+    grader = resolved["grader"]
+    assert isinstance(grader, Model)
+    assert grader.config.temperature == 0.2
+    assert resolved["grader"] is not resolved["other"]
+    assert isinstance(resolved["panel"], Model)
+
+
+def test_run_config_deferred_models_eval_and_log(tmp_path: Path) -> None:
+    config = RunConfig.model_validate(
+        {
+            "model": "mockllm/model",
+            "model_roles": {
+                "grader": {"model": "mockllm/grader", "config": {"temperature": 0.2}},
+                "panel": [{"model": "mockllm/a"}, {"model": "mockllm/b"}],
+            },
+        }
+    )
+    logs = eval(
+        Task(dataset=[Sample(input="Hello")]),
+        **config.to_params(resolve_models=False),
+        log_dir=str(tmp_path),
+        display="none",
+    )
+    assert logs[0].status == "success"
+    assert logs[0].eval.model_roles == config.model_roles
+
+
+def test_run_config_cli_compatibility_imports(tmp_path: Path) -> None:
+    from inspect_ai._cli.eval import (
+        RunConfigInput,
+        SolverInput,
+        TaskInput,
+        parse_run_config,
+    )
+    from inspect_ai._cli.eval import merge_run_config_params as cli_merge
+    from inspect_ai._cli.util import parse_sandbox as cli_sandbox
+    from inspect_ai._eval.run_config import SolverInput as SharedSolverInput
+    from inspect_ai._eval.run_config import TaskInput as SharedTaskInput
+    from inspect_ai.util._sandbox.environment import parse_sandbox
+
+    assert RunConfigInput is RunConfig
+    assert TaskInput is SharedTaskInput
+    assert SolverInput is SharedSolverInput
+    assert cli_merge is merge_run_config_params
+    assert cli_sandbox is parse_sandbox
+    path = tmp_path / "run.yaml"
+    path.write_text("task: example/task\ngenerate_config:\n  temperature: 0.25\n")
+    assert parse_run_config(str(path)) == read_run_config(str(path)).to_params()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -9,7 +9,7 @@ from inspect_ai import RunConfig, Task, eval, merge_run_config_params, read_run_
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import file
 from inspect_ai.dataset import Sample
-from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles
+from inspect_ai.model import GenerateConfig, Model, ModelConfig, ModelRoles, get_model
 from inspect_ai.model._util import resolve_model_roles
 
 
@@ -172,17 +172,24 @@ def test_run_config_merge_public_api() -> None:
     assert overrides == {"task_args": {"b": None}, "score": True, "tags": []}
 
 
-def test_model_roles_accept_deferred_configs() -> None:
+def test_model_roles_accept_deferred_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     assert get_type_hints(eval)["model_roles"] == ModelRoles | None
-    config = ModelConfig(model="mockllm/grader", config=GenerateConfig(temperature=0.2))
+    # a provider get_model memoizes (mockllm never is), so a deferred config
+    # that resolved to the shared instance would show up here (#4450)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    config = ModelConfig(model="openai/gpt-4o", config=GenerateConfig(temperature=0.2))
     roles: ModelRoles = {"grader": config, "other": config, "panel": [config]}
     resolved = resolve_model_roles(roles)
     assert resolved is not None
     grader = resolved["grader"]
     assert isinstance(grader, Model)
     assert grader.config.temperature == 0.2
+    assert grader.role == "grader"
     assert resolved["grader"] is not resolved["other"]
     assert isinstance(resolved["panel"], Model)
+    shared = get_model("openai/gpt-4o")
+    assert shared is not grader
+    assert shared.role is None
 
 
 def test_run_config_deferred_models_eval_and_log(tmp_path: Path) -> None:

--- a/tests/test_task_defaults.py
+++ b/tests/test_task_defaults.py
@@ -1,0 +1,909 @@
+import importlib.util
+import json
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from inspect_ai import (
+    RunConfig,
+    Task,
+    eval,
+    eval_async,
+    eval_retry,
+    eval_set,
+    task,
+)
+from inspect_ai._cli.eval import eval_command, eval_set_command
+from inspect_ai._cli.list import tasks as list_tasks_command
+from inspect_ai._cli.log import export_config_command
+from inspect_ai._eval.list import list_tasks
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.file import file, filesystem, local_path
+from inspect_ai.dataset import Sample
+from inspect_ai.log import EvalLog, list_eval_logs, read_eval_log
+from inspect_ai.log._config import eval_log_to_run_config_dict
+from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.solver import SolverSpec, generate
+
+
+@dataclass
+class TaskSource:
+    source: Path
+    config: Path
+    name: str
+
+    @property
+    def spec(self) -> str:
+        return f"{self.source}@{self.name}"
+
+    @property
+    def target(self) -> str:
+        return self.spec
+
+    def load(self, monkeypatch: pytest.MonkeyPatch) -> Callable[..., Task]:
+        spec = importlib.util.spec_from_file_location(self.name, self.source)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, self.name, module)
+        spec.loader.exec_module(module)
+        return cast(Callable[..., Task], getattr(module, self.name))
+
+
+@pytest.fixture(autouse=True)
+def isolated_task_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    import inspect_ai._util.registry as registry
+
+    monkeypatch.setattr(registry, "_registry", registry._registry.copy())
+    for name in os.environ:
+        if name.startswith("INSPECT_EVAL_"):
+            monkeypatch.delenv(name)
+
+
+def make_source(
+    tmp_path: Path,
+    config: dict[str, Any] | str | None,
+    config_reference: str | None = None,
+) -> TaskSource:
+    """Write the standard task to a module on disk, config alongside it.
+
+    Only for tests that need a real source file: relative default_config
+    resolution, file@name CLI references, discovery, or import-time behaviour.
+    Otherwise use make_task, which defines the same task in-process.
+    """
+    name = f"task_defaults_{uuid4().hex}"
+    source = tmp_path / f"{name}.py"
+    config_path = tmp_path / f"{name}.yaml"
+    if config is not None:
+        config_path.write_text(
+            config if isinstance(config, str) else yaml.safe_dump(config)
+        )
+    reference = config_reference if config_reference is not None else config_path.name
+    source.write_text(
+        "from typing import Any\n"
+        "from inspect_ai import Task, task\n"
+        "from inspect_ai.dataset import Sample\n"
+        "from inspect_ai.model import GenerateConfig, get_model\n"
+        "from inspect_ai.solver import generate\n\n"
+        f"@task(default_config={reference!r})\n"
+        f"def {name}(value: Any = 'signature', keep: str = 'signature-keep', "
+        "fallback: str = 'signature-fallback') -> Task:\n"
+        "    return Task(\n"
+        "        dataset=[Sample(id=i, input='Hello', target='Hello') for i in (1, 2)],\n"
+        "        solver=generate(),\n"
+        "        config=GenerateConfig(temperature=0.9, seed=91, max_tokens=32),\n"
+        "        message_limit=20, token_limit=200, epochs=1,\n"
+        "        model_roles={'grader': get_model('mockllm/constructor')},\n"
+        "        metadata={'value': value, 'keep': keep, 'fallback': fallback},\n"
+        "    )\n"
+    )
+    return TaskSource(source=source, config=config_path, name=name)
+
+
+@dataclass
+class TaskDefault:
+    """A task defined in-process with an attached default config."""
+
+    factory: Callable[..., Task]
+    config: Path
+    name: str
+
+    @property
+    def target(self) -> Callable[..., Task]:
+        return self.factory
+
+
+def make_task(
+    tmp_path: Path,
+    config: dict[str, Any] | str | None,
+    config_reference: str | None = None,
+) -> TaskDefault:
+    """Same task as make_source, defined here rather than written to disk.
+
+    Use this unless the test needs a source file: relative default_config
+    resolution, file@name CLI references, discovery, or import-time behaviour.
+    The config path is absolute so it does not resolve against this module.
+    """
+    name = f"task_defaults_{uuid4().hex}"
+    config_path = tmp_path / f"{name}.yaml"
+    if config is not None:
+        config_path.write_text(
+            config if isinstance(config, str) else yaml.safe_dump(config)
+        )
+    reference = config_reference if config_reference is not None else str(config_path)
+
+    @task(name=name, default_config=reference)
+    def factory(
+        value: Any = "signature",
+        keep: str = "signature-keep",
+        fallback: str = "signature-fallback",
+    ) -> Task:
+        return Task(
+            dataset=[Sample(id=i, input="Hello", target="Hello") for i in (1, 2)],
+            solver=generate(),
+            config=GenerateConfig(temperature=0.9, seed=91, max_tokens=32),
+            message_limit=20,
+            token_limit=200,
+            epochs=1,
+            model_roles={"grader": get_model("mockllm/constructor")},
+            metadata={"value": value, "keep": keep, "fallback": fallback},
+        )
+
+    return TaskDefault(factory=factory, config=config_path, name=name)
+
+
+def runtime_config(temperature: float = 0.2) -> dict[str, Any]:
+    return {
+        "generate_config": {"temperature": temperature, "max_tokens": 16},
+        "eval_config": {
+            "limit": 1,
+            "message_limit": 8,
+            "token_limit": 100,
+            "epochs": 2,
+        },
+        "model_roles": {
+            "grader": {
+                "model": "mockllm/default-grader",
+                "config": {"temperature": 0.3},
+            }
+        },
+        "solver": {
+            "solver": "prompt_template",
+            "args": {"template": "Default: {prompt}"},
+        },
+    }
+
+
+def run_task(
+    source: TaskSource | TaskDefault, tmp_path: Path, **kwargs: Any
+) -> EvalLog:
+    logs = eval(
+        source.target,
+        model="mockllm/model",
+        log_dir=str(tmp_path / "logs"),
+        display="none",
+        **kwargs,
+    )
+    assert len(logs) == 1
+    assert logs[0].status == "success"
+    return logs[0]
+
+
+def run_cli(
+    tmp_path: Path, args: list[str], env: dict[str, str | None] | None = None
+) -> EvalLog:
+    log_dir = tmp_path / f"cli-logs-{uuid4().hex}"
+    result = CliRunner().invoke(
+        eval_command,
+        [
+            *args,
+            "--model",
+            "mockllm/model",
+            "--log-dir",
+            str(log_dir),
+            "--display",
+            "none",
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    logs = list_eval_logs(str(log_dir))
+    assert len(logs) == 1
+    log = read_eval_log(logs[0])
+    assert log.status == "success"
+    return log
+
+
+def effective_run_config(log: EvalLog) -> dict[str, Any]:
+    config = eval_log_to_run_config_dict(log)
+    model_config = config["model"].pop("config", {})
+    config["generate_config"] = model_config | config.get("generate_config", {})
+    return config
+
+
+def assert_constructor_config(log: EvalLog) -> None:
+    assert log.eval.task_args == {
+        "value": "signature",
+        "keep": "signature-keep",
+        "fallback": "signature-fallback",
+    }
+    assert log.plan.config.temperature == 0.9
+    assert log.plan.config.max_tokens == 32
+    assert log.eval.config.message_limit == 20
+    assert log.eval.config.token_limit == 200
+    assert log.eval.config.epochs == 1
+    assert log.eval.config.limit is None
+    assert log.eval.model_roles is not None
+    grader = log.eval.model_roles["grader"]
+    assert not isinstance(grader, list)
+    assert grader.model == "mockllm/constructor"
+    assert log.samples and log.samples[0].output.completion
+
+
+def assert_default_config(log: EvalLog, config: Path) -> None:
+    assert log.plan.config.temperature == 0.2
+    assert log.plan.config.max_tokens == 16
+    assert log.plan.config.seed == 91
+    assert log.eval.config.limit == 1
+    assert log.eval.config.message_limit == 8
+    assert log.eval.config.token_limit == 100
+    assert log.eval.config.epochs == 2
+    assert log.eval.model == "mockllm/model"
+    assert log.eval.model_roles is not None
+    grader = log.eval.model_roles["grader"]
+    assert not isinstance(grader, list)
+    assert grader.model == "mockllm/default-grader"
+    assert grader.config.temperature == 0.3
+    assert log.samples and len(log.samples) == 2
+    assert all(sample.messages[0].text == "Default: Hello" for sample in log.samples)
+    assert (
+        getattr(log.eval, "run_config_source", None)
+        == f"task_default:{config.resolve()}"
+    )
+
+
+@pytest.mark.parametrize(
+    "content", [None, "invalid: [", {"task": {"args": {"value": "file"}}}]
+)
+def test_default_config_is_inert_at_import_and_direct_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    content: dict[str, Any] | str | None,
+) -> None:
+    source = make_source(tmp_path, content)
+    factory = source.load(monkeypatch)
+    instance = factory()
+    assert instance.metadata == {
+        "value": "signature",
+        "keep": "signature-keep",
+        "fallback": "signature-fallback",
+    }
+    assert instance.config.temperature == 0.9
+    explicit = factory(value=False)
+    assert explicit.metadata is not None
+    assert explicit.metadata["value"] is False
+
+
+@pytest.mark.parametrize("kind", ["callable", "name", "file"])
+def test_default_config_resolves_relative_to_task_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    source = make_source(tmp_path, None)
+    factory = source.load(monkeypatch)
+    source.config.write_text(yaml.safe_dump(runtime_config()))
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / source.config.name).write_text("invalid: [")
+    monkeypatch.chdir(elsewhere)
+    target = (
+        factory
+        if kind == "callable"
+        else source.name
+        if kind == "name"
+        else source.spec
+    )
+    log = eval(
+        target, model="mockllm/model", log_dir=str(tmp_path / "logs"), display="none"
+    )[0]
+    assert log.status == "success"
+    assert_default_config(log, source.config)
+    persisted = read_eval_log(log.location)
+    assert (
+        getattr(persisted.eval, "run_config_source", None)
+        == f"task_default:{source.config.resolve()}"
+    )
+
+
+async def test_eval_async_loads_task_default(tmp_path: Path) -> None:
+    attached = make_task(tmp_path, runtime_config())
+    logs = await eval_async(
+        attached.factory,
+        model="mockllm/model",
+        log_dir=str(tmp_path / "logs"),
+        ctl_server=False,
+    )
+    assert logs[0].status == "success"
+    assert_default_config(logs[0], attached.config)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [None, "invalid: [", runtime_config() | {"task": {"args": {"value": "file"}}}],
+)
+def test_preconstructed_task_skips_entire_default(
+    tmp_path: Path,
+    content: dict[str, Any] | str | None,
+) -> None:
+    instance = make_task(tmp_path, content).factory()
+    log = eval(
+        instance, model="mockllm/model", log_dir=str(tmp_path / "logs"), display="none"
+    )[0]
+    assert log.status == "success"
+    assert_constructor_config(log)
+    assert getattr(log.eval, "run_config_source", None) is None
+
+
+def test_run_config_accepts_task_args_without_reference() -> None:
+    args = {"value": None, "keep": "file"}
+    config = RunConfig.model_validate({"task": {"args": args}})
+    assert config.to_params() == {"task_args": args}
+    assert RunConfig.model_validate_json(config.model_dump_json()).to_params() == {
+        "task_args": args
+    }
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"model": "mockllm/forbidden"},
+        {"model": None},
+        {"model": {"model": "mockllm/forbidden"}},
+        {"task": "not_installed/forbidden"},
+        {"task": {"task": "not_installed/forbidden", "args": {"value": "file"}}},
+    ],
+)
+def test_task_default_rejects_model_and_task_reference(
+    tmp_path: Path, config: dict[str, Any]
+) -> None:
+    attached = make_task(tmp_path, config)
+    with pytest.raises((PrerequisiteError, ValueError)) as error:
+        run_task(attached, tmp_path)
+    assert "model" in str(error.value).lower() or "task" in str(error.value).lower()
+
+
+def test_task_default_mismatched_task_error_names_both(tmp_path: Path) -> None:
+    attached = make_task(tmp_path, {"task": "other_task"})
+    with pytest.raises(ValueError) as error:
+        run_task(attached, tmp_path)
+    assert "other_task" in str(error.value)
+    assert attached.name in str(error.value)
+
+
+@pytest.mark.parametrize("form", ["string", "object"])
+def test_task_default_may_name_its_own_task(tmp_path: Path, form: str) -> None:
+    """A matching task reference documents the file without changing selection."""
+    attached = make_task(tmp_path, None)
+    config = runtime_config()
+    if form == "string":
+        config["task"] = attached.name
+    else:
+        config["task"] = {"task": attached.name, "args": {"value": "file"}}
+    attached.config.write_text(yaml.safe_dump(config))
+    log = run_task(attached, tmp_path)
+    assert_default_config(log, attached.config)
+    if form == "object":
+        assert log.eval.task_args["value"] == "file"
+
+
+def test_task_default_file_works_standalone_as_run_config(tmp_path: Path) -> None:
+    """Naming the task lets the same file select it via --run-config.
+
+    The task is already registered in-process, as package tasks are on import,
+    so the bare registry name resolves.
+    """
+    config = runtime_config()
+    attached = make_task(tmp_path, config)
+    config["task"] = attached.name
+    attached.config.write_text(yaml.safe_dump(config))
+    with_default = run_task(attached, tmp_path)
+    log_dir = tmp_path / "standalone"
+    result = CliRunner().invoke(
+        eval_command,
+        [
+            "--run-config",
+            str(attached.config),
+            "--model",
+            "mockllm/model",
+            "--log-dir",
+            str(log_dir),
+            "--display",
+            "none",
+        ],
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    logs = list_eval_logs(str(log_dir))
+    assert len(logs) == 1
+    standalone = read_eval_log(logs[0])
+    assert standalone.status == "success"
+    # the task reference records how each run was invoked; everything the
+    # file governs must match
+    expected = effective_run_config(with_default)
+    actual = effective_run_config(standalone)
+    assert expected["task"].pop("task").endswith(attached.name)
+    assert actual["task"].pop("task").endswith(attached.name)
+    assert actual == expected
+    assert standalone.eval.run_config_source == f"cli:{attached.config}"
+
+
+@pytest.mark.parametrize(
+    "content", [None, "invalid: [", {"unknown_default_field": True}]
+)
+def test_invalid_attached_file_is_reported_at_eval(
+    tmp_path: Path, content: dict[str, Any] | str | None
+) -> None:
+    attached = make_task(tmp_path, content)
+    with pytest.raises(
+        (PrerequisiteError, ValueError, FileNotFoundError, yaml.YAMLError)
+    ):
+        run_task(attached, tmp_path)
+
+
+@pytest.mark.parametrize("value", [None, False, 0, [], {}, "caller"])
+def test_task_argument_precedence_preserves_explicit_values(
+    tmp_path: Path, value: Any
+) -> None:
+    attached = make_task(
+        tmp_path, {"task": {"args": {"value": "file", "keep": "file-keep"}}}
+    )
+    log = run_task(attached, tmp_path, task_args={"value": value})
+    expected = {"value": value, "keep": "file-keep", "fallback": "signature-fallback"}
+    assert log.eval.task_args == expected
+    assert log.eval.metadata == expected
+
+
+def test_task_argument_file_over_signature_fallback(tmp_path: Path) -> None:
+    attached = make_task(tmp_path, {"task": {"args": {"value": "file"}}})
+    log = run_task(attached, tmp_path)
+    assert log.eval.task_args == {
+        "value": "file",
+        "keep": "signature-keep",
+        "fallback": "signature-fallback",
+    }
+
+
+def test_eval_kwargs_override_file_and_constructor(tmp_path: Path) -> None:
+    attached = make_task(tmp_path, runtime_config())
+    log = run_task(
+        attached,
+        tmp_path,
+        temperature=0,
+        message_limit=5,
+        epochs=1,
+        model_roles={
+            "grader": get_model("mockllm/caller", config=GenerateConfig(temperature=0))
+        },
+        solver=SolverSpec(
+            "prompt_template",
+            args={"template": "Caller: {prompt}"},
+            args_passed={"template": "Caller: {prompt}"},
+        ),
+    )
+    assert log.plan.config.temperature == 0
+    assert log.plan.config.max_tokens == 16
+    assert log.eval.config.message_limit == 5
+    assert log.eval.config.token_limit == 100
+    assert log.eval.config.epochs == 1
+    assert log.eval.model_roles is not None
+    grader = log.eval.model_roles["grader"]
+    assert not isinstance(grader, list)
+    assert grader.model == "mockllm/caller"
+    assert grader.config.temperature == 0
+    assert log.samples and log.samples[0].messages[0].text == "Caller: Hello"
+
+
+@pytest.mark.parametrize("override", ["flag", "environment"])
+def test_cli_and_environment_override_task_default(
+    tmp_path: Path, override: str
+) -> None:
+    source = make_source(tmp_path, runtime_config())
+    args = [source.spec]
+    env: dict[str, str | None] | None = None
+    if override == "flag":
+        args.extend(["--temperature", "0", "--message-limit", "5"])
+    else:
+        env = {"INSPECT_EVAL_TEMPERATURE": "0", "INSPECT_EVAL_MESSAGE_LIMIT": "5"}
+    log = run_cli(tmp_path, args, env)
+    assert log.plan.config.temperature == 0
+    assert log.eval.config.message_limit == 5
+    assert log.plan.config.max_tokens == 16
+    assert log.eval.config.token_limit == 100
+    assert (
+        getattr(log.eval, "run_config_source", None)
+        == f"task_default:{source.config.resolve()}"
+    )
+
+
+@pytest.mark.parametrize("interface", ["api", "cli"])
+@pytest.mark.parametrize("content", [None, "invalid: [", runtime_config()])
+def test_opt_out_skips_entire_default(
+    tmp_path: Path, interface: str, content: dict[str, Any] | str | None
+) -> None:
+    source = make_source(tmp_path, content)
+    log = (
+        run_task(source, tmp_path, default_config=False)
+        if interface == "api"
+        else run_cli(tmp_path, [source.spec, "--no-default-config"])
+    )
+    assert_constructor_config(log)
+    assert getattr(log.eval, "run_config_source", None) is None
+
+
+@pytest.mark.parametrize("content", [None, "invalid: [", runtime_config()])
+@pytest.mark.parametrize("replacement", [{}, {"generate_config": {"temperature": 0.4}}])
+def test_explicit_run_config_replaces_attached_default(
+    tmp_path: Path, content: dict[str, Any] | str | None, replacement: dict[str, Any]
+) -> None:
+    source = make_source(tmp_path, content)
+    path = tmp_path / "explicit.yaml"
+    path.write_text(yaml.safe_dump(replacement))
+    log = run_cli(tmp_path, [source.spec, "--run-config", str(path)])
+    assert log.plan.config.temperature == replacement.get("generate_config", {}).get(
+        "temperature", 0.9
+    )
+    assert log.plan.config.max_tokens == 32
+    assert log.eval.config.message_limit == 20
+    assert log.eval.config.token_limit == 200
+    assert log.eval.config.epochs == 1
+    assert log.eval.config.limit is None
+    assert getattr(log.eval, "run_config_source", None) == f"cli:{path}"
+
+
+@pytest.mark.parametrize("interface", ["eval", "eval_set"])
+def test_two_tasks_have_isolated_defaults(tmp_path: Path, interface: str) -> None:
+    first = make_task(tmp_path, runtime_config())
+    second_config = runtime_config(0.7)
+    second_config["eval_config"] = {
+        "limit": 2,
+        "message_limit": 12,
+        "token_limit": 150,
+        "epochs": 1,
+    }
+    second_config["model_roles"] = {"grader": {"model": "mockllm/second"}}
+    second_config["solver"] = {
+        "solver": "system_message",
+        "args": {"template": "Second"},
+    }
+    second = make_task(tmp_path, second_config)
+    kwargs: dict[str, Any] = {
+        "model": "mockllm/model",
+        "log_dir": str(tmp_path / "logs"),
+        "display": "none",
+    }
+    if interface == "eval_set":
+        success, logs = eval_set(
+            [first.factory, second.factory], retry_attempts=0, **kwargs
+        )
+        assert success
+    else:
+        logs = eval([first.factory, second.factory], **kwargs)
+    assert len(logs) == 2
+    by_name = {log.eval.task: read_eval_log(log.location) for log in logs}
+    assert_default_config(by_name[first.name], first.config)
+    other = by_name[second.name]
+    assert other.status == "success"
+    assert other.plan.config.temperature == 0.7
+    assert other.eval.config.limit == 2
+    assert other.eval.config.message_limit == 12
+    assert other.eval.config.token_limit == 150
+    assert other.eval.config.epochs == 1
+    assert other.eval.model_roles is not None
+    grader = other.eval.model_roles["grader"]
+    assert not isinstance(grader, list)
+    assert grader.model == "mockllm/second"
+    assert other.samples and all(
+        sample.messages[0].text == "Second" for sample in other.samples
+    )
+    assert (
+        getattr(other.eval, "run_config_source", None)
+        == f"task_default:{second.config.resolve()}"
+    )
+
+
+@pytest.mark.parametrize("change", ["modify", "delete"])
+def test_export_config_replay_is_independent_of_attached_file(
+    tmp_path: Path, change: str
+) -> None:
+    attached = make_task(tmp_path, runtime_config())
+    original = run_task(attached, tmp_path)
+    exported = tmp_path / "exported.yaml"
+    result = CliRunner().invoke(
+        export_config_command, [original.location, "--output", str(exported)]
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    if change == "modify":
+        attached.config.write_text(yaml.safe_dump(runtime_config(0.8)))
+    else:
+        attached.config.unlink()
+    replay = run_cli(tmp_path, ["--run-config", str(exported)])
+    assert effective_run_config(replay) == effective_run_config(original)
+    assert getattr(replay.eval, "run_config_source", None) == f"cli:{exported}"
+    assert_default_config(original, attached.config)
+
+
+@pytest.mark.parametrize("change", ["modify", "delete"])
+def test_retry_uses_logged_configuration_not_attached_file(
+    tmp_path: Path, change: str
+) -> None:
+    attached = make_task(tmp_path, runtime_config())
+    original = run_task(attached, tmp_path)
+    if change == "modify":
+        attached.config.write_text(yaml.safe_dump(runtime_config(0.8)))
+    else:
+        attached.config.unlink()
+    retried = eval_retry(
+        original.location, log_dir=str(tmp_path / "retry"), display="none"
+    )[0]
+    assert retried.status == "success"
+    assert effective_run_config(retried) == effective_run_config(original)
+    assert_default_config(original, attached.config)
+
+
+@pytest.mark.parametrize("changed_field", ["task_args", "temperature", "token_limit"])
+def test_eval_set_reuses_logs_and_selects_changed_defaults(
+    tmp_path: Path, changed_field: str
+) -> None:
+    config = runtime_config()
+    config["task"] = {"args": {"value": "first"}}
+    attached = make_task(tmp_path, config)
+    kwargs: dict[str, Any] = {
+        "model": "mockllm/model",
+        "log_dir": str(tmp_path / "set"),
+        "display": "none",
+        "retry_attempts": 0,
+        "log_dir_allow_dirty": True,
+    }
+    success, first = eval_set(attached.factory, **kwargs)
+    assert success and len(first) == 1
+    success, reused = eval_set(attached.factory, **kwargs)
+    assert success and len(reused) == 1
+    assert local_path(reused[0].location) == local_path(first[0].location)
+    assert len(list_eval_logs(kwargs["log_dir"])) == 1
+    if changed_field == "task_args":
+        config["task"]["args"]["value"] = "second"
+    elif changed_field == "temperature":
+        config["generate_config"]["temperature"] = 0.8
+    else:
+        config["eval_config"]["token_limit"] = 150
+    attached.config.write_text(yaml.safe_dump(config))
+    success, changed = eval_set(attached.factory, **kwargs)
+    assert success and len(changed) == 1
+    assert local_path(changed[0].location) != local_path(first[0].location)
+    assert len(list_eval_logs(kwargs["log_dir"])) == 2
+    assert changed[0].eval.task_args["value"] == config["task"]["args"]["value"]
+    assert (
+        changed[0].plan.config.temperature == config["generate_config"]["temperature"]
+    )
+    assert changed[0].eval.config.token_limit == config["eval_config"]["token_limit"]
+
+
+@pytest.mark.parametrize("location", ["absolute", "file_uri", "memory"])
+def test_attached_config_filesystem_locations(tmp_path: Path, location: str) -> None:
+    path = tmp_path / "default config.yaml"
+    reference = (
+        f"memory://task-defaults-{uuid4().hex}/defaults.yaml"
+        if location == "memory"
+        else path.as_uri()
+        if location == "file_uri"
+        else str(path)
+    )
+    with file(reference, "w") as stream:
+        stream.write(yaml.safe_dump({"generate_config": {"temperature": 0.2}}))
+    try:
+        attached = make_task(tmp_path, None, config_reference=reference)
+        log = run_task(attached, tmp_path)
+        assert log.plan.config.temperature == 0.2
+        assert log.plan.config.seed == 91
+    finally:
+        if location == "memory":
+            filesystem(reference).rm(reference)
+
+
+def test_task_default_discovery_does_not_read_file(tmp_path: Path) -> None:
+    source = make_source(tmp_path, "invalid: [")
+    # list_tasks globs relative to root_dir (the cwd for the CLI)
+    discovered = list_tasks([source.source.name], absolute=True, root_dir=tmp_path)
+    assert len(discovered) == 1
+    assert discovered[0].default_config == source.config.name
+    # the CLI's root_dir default binds the import-time cwd, so chdir does not
+    # reach it; address the file relative to that directory instead
+    relative = os.path.relpath(source.source, Path.cwd())
+    result = CliRunner().invoke(list_tasks_command, [relative, "--json"])
+    assert result.exit_code == 0, result.output
+    assert (
+        json.loads(result.output)[0]["attribs"]["default_config"] == source.config.name
+    )
+
+
+def test_task_default_notice_is_displayed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import inspect_ai._display.core.active as active_mod
+
+    # the display is created once per process, so an earlier eval in this
+    # module would otherwise leave a non-plain display in place
+    monkeypatch.setattr(active_mod, "_active_display", None)
+    source = make_source(tmp_path, {"generate_config": {"temperature": 0.2}})
+    result = CliRunner().invoke(
+        eval_command,
+        [
+            source.spec,
+            "--model",
+            "mockllm/model",
+            "--log-dir",
+            str(tmp_path / "logs"),
+            "--display",
+            "plain",
+        ],
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    assert f"default config: {source.config.name}" in result.output
+    assert "--no-default-config" in result.output
+
+
+@pytest.mark.parametrize(
+    "file_selection, override, expected",
+    [
+        ({"sample_id": [1]}, {"limit": 2}, {"limit": 2, "sample_id": None}),
+        (
+            {"sample_id": [1]},
+            {"sample_shuffle": 7},
+            {"sample_shuffle": 7, "sample_id": None},
+        ),
+        (
+            {"limit": 1, "sample_shuffle": 7},
+            {"sample_id": [2]},
+            {"limit": None, "sample_shuffle": None, "sample_id": [2]},
+        ),
+    ],
+)
+def test_explicit_sample_selection_replaces_file_selection(
+    tmp_path: Path,
+    file_selection: dict[str, Any],
+    override: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    """limit/sample_shuffle and sample_id are one setting, not three.
+
+    Merging them field by field would let a file sample_id survive an explicit
+    limit and silently win in slice_dataset.
+    """
+    attached = make_task(tmp_path, {"eval_config": file_selection})
+    log = run_task(attached, tmp_path, **override)
+    for key, value in expected.items():
+        assert getattr(log.eval.config, key) == value, key
+    assert log.samples is not None
+    if "sample_id" in override:
+        assert [s.id for s in log.samples] == override["sample_id"]
+    else:
+        assert len(log.samples) == 2
+
+
+def test_eval_set_reuses_log_when_file_sets_shuffle_and_caller_limits(
+    tmp_path: Path,
+) -> None:
+    attached = make_task(tmp_path, {"eval_config": {"sample_shuffle": 42}})
+    kwargs: dict[str, Any] = {
+        "model": "mockllm/model",
+        "log_dir": str(tmp_path / "set"),
+        "display": "none",
+        "retry_attempts": 0,
+        "limit": 1,
+    }
+    success, first = eval_set(attached.factory, **kwargs)
+    assert success and first[0].eval.config.sample_shuffle == 42
+    success, again = eval_set(attached.factory, **kwargs)
+    assert success
+    assert local_path(again[0].location) == local_path(first[0].location)
+    assert len(list_eval_logs(kwargs["log_dir"])) == 1
+
+
+def test_eval_set_capture_counts_samples_with_file_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    attached = make_task(tmp_path, {"eval_config": {"limit": 1, "epochs": 2}})
+    capture = tmp_path / "capture.json"
+    monkeypatch.setenv("INSPECT_EVAL_SET_CAPTURE", str(capture))
+    with pytest.raises(SystemExit):
+        eval_set(
+            attached.factory,
+            model="mockllm/model",
+            log_dir=str(tmp_path / "set"),
+            display="none",
+            retry_attempts=0,
+        )
+    manifest = json.loads(capture.read_text())
+    assert [entry["samples"] for entry in manifest["tasks"]] == [1]
+    assert [entry["epochs"] for entry in manifest["tasks"]] == [2]
+
+
+def test_unscoped_resolution_drops_run_wide_defaults(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unscoped resolution must not record run-wide settings as applied.
+
+    eval_resolve_tasks alone (the Inspect Flow path) has no run to agree
+    run-wide settings for.
+    """
+    from inspect_ai._eval.eval import eval_resolve_tasks
+
+    attached = make_task(
+        tmp_path, {"eval_config": {"max_tasks": 7, "log_samples": False, "limit": 1}}
+    )
+    resolved, _ = eval_resolve_tasks(
+        attached.factory,
+        {},
+        [get_model("mockllm/model")],
+        None,
+        GenerateConfig(),
+        None,
+        None,
+        None,
+    )
+    assert "max_tasks" not in resolved[0].run_config
+    assert "log_samples" not in resolved[0].run_config
+    assert resolved[0].run_config["limit"] == 1
+    assert "max_tasks" in caplog.text and attached.config.name in caplog.text
+    log = eval(resolved, log_dir=str(tmp_path / "logs"), display="none")[0]
+    assert log.eval.config.max_tasks is None
+    assert log.eval.config.log_samples is not False
+    assert log.eval.config.limit == 1
+    assert log.samples is not None and len(log.samples) == 1
+
+
+@pytest.mark.parametrize("disabled", [False, True])
+def test_task_default_eval_set_cli(tmp_path: Path, disabled: bool) -> None:
+    source = make_source(tmp_path, None if disabled else runtime_config())
+    args = [
+        source.spec,
+        "--model",
+        "mockllm/model",
+        "--log-dir",
+        str(tmp_path / "logs"),
+        "--display",
+        "none",
+        "--retry-attempts",
+        "0",
+    ]
+    if disabled:
+        args.append("--no-default-config")
+    result = CliRunner().invoke(eval_set_command, args)
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    logs = list_eval_logs(str(tmp_path / "logs"))
+    assert len(logs) == 1
+    log = read_eval_log(logs[0])
+    if disabled:
+        assert_constructor_config(log)
+    else:
+        assert_default_config(log, source.config)
+
+
+def test_old_eval_spec_without_run_config_source() -> None:
+    from inspect_ai.log import EvalConfig, EvalDataset, EvalSpec
+
+    old = {
+        "created": "2026-01-01T00:00:00Z",
+        "task": "old_task",
+        "model": "mockllm/model",
+        "dataset": EvalDataset().model_dump(),
+        "config": EvalConfig().model_dump(),
+    }
+    spec = EvalSpec.model_validate(old)
+    assert spec.run_config_source is None
+    assert "run_config_source" not in spec.model_dump(exclude_none=True)

--- a/tests/test_task_defaults.py
+++ b/tests/test_task_defaults.py
@@ -867,6 +867,107 @@ def test_unscoped_resolution_drops_run_wide_defaults(
     assert log.samples is not None and len(log.samples) == 1
 
 
+def test_discovery_runs_after_dotenv_is_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default-config discovery imports task modules, so .env must load first.
+
+    On main, string task specs are first imported inside eval_resolve_tasks,
+    after eval_init has loaded .env; discovery must not move that earlier.
+    """
+    monkeypatch.delenv("TASK_DEFAULTS_DOTENV_PROBE", raising=False)
+    source = make_source(tmp_path, {"generate_config": {"temperature": 0.2}})
+    source.source.write_text(
+        "import os\n"
+        "os.environ['TASK_DEFAULTS_DOTENV_PROBE']\n" + source.source.read_text()
+    )
+    (tmp_path / ".env").write_text("TASK_DEFAULTS_DOTENV_PROBE=present\n")
+    monkeypatch.chdir(tmp_path)
+    log = eval(
+        source.spec,
+        model="mockllm/model",
+        log_dir=str(tmp_path / "logs"),
+        display="none",
+    )[0]
+    assert log.status == "success"
+    assert log.plan.config.temperature == 0.2
+
+
+def test_file_shuffle_is_not_applied_under_explicit_sample_id(tmp_path: Path) -> None:
+    """The loader shuffles at resolution time; it must honour the same rule."""
+    from inspect_ai._eval.eval import eval_resolve_tasks
+
+    attached = make_task(tmp_path, {"eval_config": {"sample_shuffle": 42}})
+    common = ([get_model("mockllm/model")], None, GenerateConfig(), None, None)
+    shuffled, _ = eval_resolve_tasks(attached.factory, {}, *common, None)
+    assert shuffled[0].task.dataset.shuffled
+    attached = make_task(tmp_path, {"eval_config": {"sample_shuffle": 42}})
+    unshuffled, _ = eval_resolve_tasks(
+        attached.factory, {}, *common, None, sample_id=[2]
+    )
+    assert not unshuffled[0].task.dataset.shuffled
+
+
+def test_retry_does_not_print_default_config_notice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retry replays logged settings; it never reads the file, so no hint."""
+    import inspect_ai._display.core.active as active_mod
+    from inspect_ai._cli.eval import eval_retry_command
+
+    source = make_source(tmp_path, {"generate_config": {"temperature": 0.2}})
+    original = run_task(source, tmp_path)
+    monkeypatch.setattr(active_mod, "_active_display", None)
+    result = CliRunner().invoke(
+        eval_retry_command,
+        [
+            original.location,
+            "--log-dir",
+            str(tmp_path / "retry"),
+            "--display",
+            "plain",
+        ],
+    )
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
+    assert "default config:" not in result.output
+    retried = read_eval_log(list_eval_logs(str(tmp_path / "retry"))[0])
+    assert retried.plan.config.temperature == 0.2
+    assert retried.eval.run_config_source == original.eval.run_config_source
+
+
+def test_enqueued_task_with_run_wide_default_warns_and_runs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A task enqueued mid-run could not join run-wide agreement; drop and warn."""
+    from inspect_ai._eval.task.enqueue import enqueue_task
+    from inspect_ai.solver import Generate, TaskState, solver
+
+    enqueued = make_source(tmp_path, {"eval_config": {"log_images": False, "limit": 1}})
+
+    @solver
+    def enqueuer():
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            enqueue_task(enqueued.spec)
+            return state
+
+        return solve
+
+    @task(name=f"seed_{uuid4().hex}")
+    def seed() -> Task:
+        return Task(dataset=[Sample(input="hi", target="hi")], solver=enqueuer())
+
+    logs = eval(
+        seed, model="mockllm/model", log_dir=str(tmp_path / "logs"), display="none"
+    )
+    by_name = {log.eval.task: log for log in logs}
+    assert all(log.status == "success" for log in logs), [
+        (log.eval.task, log.error and log.error.message) for log in logs
+    ]
+    assert by_name[enqueued.name].eval.config.limit == 1
+    assert by_name[enqueued.name].eval.config.log_images is not False
+    assert "log_images" in caplog.text and enqueued.config.name in caplog.text
+
+
 @pytest.mark.parametrize("disabled", [False, True])
 def test_task_default_eval_set_cli(tmp_path: Path, disabled: bool) -> None:
     source = make_source(tmp_path, None if disabled else runtime_config())


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

**Stacked on #5292** (#5290 has merged and is no longer carried here). The first four commits are #5292; review from `d182fb539` onward. Paired ts-mono PR: meridianlabs-ai/ts-mono#624 (two-phase landing; `submodule-on-main` stays red until it merges).

Implements #4784. Discussion prototype: UKGovernmentBEIS/inspect_evals#2006.

### What is the current behavior? (You can also link to an open issue here)

Author-recommended run settings (paper-faithful generation config, grader model, epochs, limits) have nowhere to live. They end up hardcoded in task constructors, where they're invisible as defaults and can't be exported, or in sidecar files a user must know about and pass by hand, so most runs never apply them.

### What is the new behavior?

```python
@task(default_config="recommended.yaml")
def my_task(category: str | None = None) -> Task: ...
```

The file uses the existing run-config format and is applied whenever `inspect eval`, `eval()`, `eval_async()` or `eval_set()` resolves the task from a callable, registry name, or `file.py@name`. Direct calls and preconstructed `Task` objects are untouched, so composing tasks in Python keeps ordinary semantics.

- **Precedence per setting:** signature default < constructor value < file < explicit argument. Supplied task args keep `None`, `False`, `0`, `[]`, `{}`.
- **Opt-out / replace:** `--no-default-config` / `default_config=False` skips reading the file; an explicit `--run-config` replaces it entirely.
- **Restricted schema:** the file may set `model_roles` but not the evaluated `model`. It may name only the task it is attached to (by registry name), which makes the file self-documenting and usable standalone via `--run-config`; any other task reference errors naming both.
- **Run-wide vs per-task:** run-wide `EvalConfig` fields (scheduling, logging, initialisation) are agreed across all tasks before any model or sandbox starts; conflicting values require an explicit override rather than letting task order decide. Per-task fields stay on `ResolvedTask` so `eval_set` pairs tasks with existing logs using the selection they actually ran with, and the capture manifest counts samples the same way.
- **Provenance:** logs gain nullable `EvalSpec.run_config_source` (`task_default:<path>` or `cli:<path>`); the run display names the applied file. `export-config` emits effective settings, and retries replay the recorded settings rather than re-reading a file that may have changed.
- **Discovery:** `TaskInfo.default_config` and `inspect list tasks --json` expose the declared path without reading it.

Docs: new "Default Run Config" section in `tasks.qmd`, plus `options.qmd` and `eval-logs.qmd`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Tasks without `default_config` behave exactly as before. `default_config` is appended to the `eval`/`eval_async`/`eval_set` signatures so positional callers are unaffected. `TaskInput.task` in the run-config schema becomes optional (a `task:` section may carry only `args`).

### Other information:

**Testing.** `tests/test_task_defaults.py`: 69 cases covering direct-call inertness, precedence (including falsy explicit values), opt-out and replacement, multi-task isolation, model-role precedence, source-relative and remote (`file://`, `memory://`) paths, missing/malformed files, run-wide conflicts, retry identity, `eval_set` reuse and changed-default detection, capture manifest counts, unscoped resolution (Inspect Flow path), export-config round trip, CLI notice, and discovery. Broad regression (eval, eval_set, pruning/selection, retry, run-config, CLI, model roles, launch handoff): 735 passed, 43 skipped. ts-mono `pnpm typecheck` and `pnpm test` pass.

**Review fixes folded in** (see Agent review below): file `sample_id` surviving an explicit `limit` (selection is now one setting); `eval_set` re-running when the file set `sample_shuffle` and the caller passed `limit`; capture manifest ignoring per-task selection; unscoped `eval_resolve_tasks` recording run-wide values it never applied (now dropped with a warning).

**Deliberate follow-ups, not in this PR:**
- `enqueue_task("file.py@task")` mid-run cannot participate in run-wide agreement; a default with run-wide fields currently errors the enqueuing sample. Options: ignore with a warning, or reclassify the per-task-readable fields (`log_images`, `log_samples`, `sandbox_cleanup`, `score_display`).
- Accept `file.py@name` in the file's `task:` when it resolves to the attached factory, so `export-config` output can be attached directly.
- Retry logs inherit `task_default:` provenance and the display notice although the retry did not read the file; consider a `retry:` prefix or suppressing the notice.
- Pruned eval_set placeholders still instantiate file roles and solver; skip when `is_placeholder`.
- Pre-existing, seen while testing: `eval_config.approval` in any run-config file raises `AttributeError` (affects `--run-config` on main too); `eval_set` never reuses a log when a non-mean `epochs_reducer` is set on the task.

### Agent review
- Pre-open: fresh-context subagent review (Claude, 1 pass) of the feature range. 4 confirmed defects, all fixed with tests before opening: file `sample_id` surviving an explicit `limit`; `eval_set` re-running when the file set `sample_shuffle` and the caller passed `limit`; capture manifest ignoring per-task selection; unscoped `eval_resolve_tasks` recording run-wide values it never applied. 4 plausible findings deferred as follow-ups (listed above). 1 positional-signature hazard fixed (`default_config` appended, not inserted).
- Post-open: automated external review (Claude, meridianlabs-ai/inspect_ai#455), fresh context, 1 pass, verdict "changes needed": 1 blocking, 5 non-blocking. Addressed in `105a3ed03` with a test each: the blocking `.env` ordering (discovery now calls `init_dotenv()` first); the loader shuffling from the file under an explicit `sample_id` (`sample_id` threaded into `resolve_tasks`); the retry notice (suppressed for replayed tasks, provenance kept and documented); `enqueue_task` with run-wide defaults (warn and drop, as the unscoped path does). Not addressed: task modules executing twice per `eval()` (discovery then construction; a design change to cache discovery or collect factories from constructed tasks, worth its own PR) and the notice wording/channel (cosmetic).

**Rebased 2026-09-11** onto the updated #5292 (on current `main`). Resolved against #5342 (`samples_selected` now also takes `task_names`; the per-task selection merge is kept alongside it) and #5303 (`resolve_task_epochs`). Changelog entries verified under `## Unreleased`.

*Posted by [Claude Code](https://claude.com/claude-code) on Matt's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


