### PR TITLE
Keep auxiliary agent requests out of canonical conversation state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
-- Agent Bridge: `state_filter` lets integrations select which bridged requests update canonical agent state.
+- Agent Bridge: `state_filter` on `agent_bridge()` and `sandbox_agent_bridge()` selects which requests may update canonical state and compaction history without dropping auxiliary responses or model events.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Checkpoints: Invalidating a sample now re-runs it from scratch on retry (its checkpoints are discarded) instead of resuming from its last checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
+- Agent Bridge: Continuing a main conversation now restores its state after a one-shot side request temporarily takes tracking.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Checkpoints: Invalidating a sample now re-runs it from scratch on retry (its checkpoints are discarded) instead of resuming from its last checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
-- Agent Bridge: Continuing a main conversation now restores its state after a one-shot side request temporarily takes tracking.
+- Agent Bridge: `state_filter` lets integrations select which bridged requests update canonical agent state.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Checkpoints: Invalidating a sample now re-runs it from scratch on retry (its checkpoints are discarded) instead of resuming from its last checkpoint.

--- a/docs/agent-bridge.qmd
+++ b/docs/agent-bridge.qmd
@@ -243,6 +243,12 @@ Rejection works by telling the model rather than by editing the response: the re
 
 When combining approval policies with `bridged_tools`, give bridged tools names that are unique across bridged servers and distinct from the agent's own tools: an approval identifies a call only by function name and arguments, so a name shared with an agent-local tool also authorizes one execution of the same-named bridged tool, and a name shared across bridged servers is ambiguous and will be denied.
 
+## Canonical State
+
+Both `agent_bridge()` and `sandbox_agent_bridge()` accept a `state_filter` predicate over the translated request messages. Return `False` for auxiliary requests, such as title generation, that must not update `bridge.state`. Returning `True` makes a request eligible for the usual conversation-tracking heuristics; it does not force the bridge to adopt that request.
+
+The predicate runs once before generation and compaction. Excluded requests still generate responses, emit model events, and tick the checkpointer, but bypass canonical compaction and cannot enter its retained history. Predicate exceptions propagate before generation. Omitting `state_filter` preserves the default tracking behavior.
+
 ## Transcript
 
 Custom agents run through a bridge still get most of the benefit of the Inspect transcript and log viewer. All model calls are captured and produce the same transcript output as when using conventional agents.

--- a/docs/reference/inspect_ai.agent.qmd
+++ b/docs/reference/inspect_ai.agent.qmd
@@ -30,6 +30,7 @@ description: Agent scaffolds and protocol.
 ### AgentBridge
 ### sandbox_agent_bridge
 ### SandboxAgentBridge
+### StateFilter
 ### BridgedToolsSpec
 
 ## Filters

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -6,7 +6,7 @@ from ._as_tool import as_tool
 from ._bridge.bridge import agent_bridge, bridge
 from ._bridge.sandbox.bridge import sandbox_agent_bridge
 from ._bridge.sandbox.types import SandboxAgentBridge
-from ._bridge.types import AgentBridge
+from ._bridge.types import AgentBridge, StateFilter
 from ._channel import (
     AgentChannel,
     AgentInterrupted,
@@ -37,6 +37,7 @@ __all__ = [
     "sandbox_agent_bridge",
     "AgentBridge",
     "SandboxAgentBridge",
+    "StateFilter",
     "BridgedToolsSpec",
     "content_only",
     "last_message",

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -176,16 +176,9 @@ async def inspect_anthropic_api_request_impl(
     config = resolve_generate_config(model, config)
 
     # if there is a bridge filter give it a shot first
-    output, c_message = await bridge_generate(
-        bridge, model, messages, tools, tool_choice, config
-    )
-    if c_message is not None:
-        messages.append(c_message)
+    output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
 
     debug_log("INSPECT OUTPUT", output.message)
-
-    # update state if we have more messages than the last generation
-    await bridge._track_state(messages, output)
 
     # return message (use beta message type if request came from beta endpoint)
     message_class = BetaMessage if beta else Message

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -175,7 +175,7 @@ async def inspect_anthropic_api_request_impl(
     # give inspect-level config priority over agent default config
     config = resolve_generate_config(model, config)
 
-    # if there is a bridge filter give it a shot first
+    # generate via bridge
     output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
 
     debug_log("INSPECT OUTPUT", output.message)

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -19,7 +19,7 @@ from pydantic_core import to_json
 
 from inspect_ai._util._async import is_callable_coroutine
 from inspect_ai.agent._agent import Agent, AgentState, agent
-from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.types import AgentBridge, StateFilter
 from inspect_ai.log._samples import sample_active
 from inspect_ai.model._compaction.types import CompactionStrategy
 from inspect_ai.model._model import GenerateFilter, ModelEventSink, get_model
@@ -101,6 +101,7 @@ async def agent_bridge(
     state: AgentState | None = None,
     *,
     filter: GenerateFilter | None = None,
+    state_filter: StateFilter | None = None,
     retry_refusals: int | None = None,
     compaction: CompactionStrategy | None = None,
     web_search: WebSearchProviders | bool | None = None,
@@ -125,6 +126,8 @@ async def agent_bridge(
        state: Initial state for agent bridge. Used as a basis for yielding
           an updated state based on traffic over the bridge.
        filter: Filter for bridge model generation.
+       state_filter: Predicate selecting requests that update canonical state.
+          Excluded requests still generate responses and emit model events.
        retry_refusals: Should refusals be retried? (pass number of times to retry)
        compaction: Compact the conversation when it it is close to overflowing
           the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
@@ -187,6 +190,7 @@ async def agent_bridge(
         approval=approval,
         allow_remote_mcp=allow_remote_mcp,
         allow_remote_media=True,
+        state_filter=state_filter,
     )
 
     # set the patch config for this context and child coroutines

--- a/src/inspect_ai/agent/_bridge/completions.py
+++ b/src/inspect_ai/agent/_bridge/completions.py
@@ -91,15 +91,7 @@ async def inspect_completions_api_request(
     config = resolve_generate_config(model, config)
 
     # if there is a bridge filter give it a shot first
-    output, c_message = await bridge_generate(
-        bridge, model, messages, tools, tool_choice, config
-    )
-    if c_message is not None:
-        messages.append(c_message)
-
-    # update state if we have more messages than the last generation
-    await bridge._track_state(messages, output)
-
+    output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
     # inspect completion to openai completion
     return ChatCompletion(
         id=uuid(),

--- a/src/inspect_ai/agent/_bridge/completions.py
+++ b/src/inspect_ai/agent/_bridge/completions.py
@@ -90,7 +90,7 @@ async def inspect_completions_api_request(
     # give inspect-level config priority over agent default config
     config = resolve_generate_config(model, config)
 
-    # if there is a bridge filter give it a shot first
+    # generate via bridge
     output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
     # inspect completion to openai completion
     return ChatCompletion(

--- a/src/inspect_ai/agent/_bridge/google_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/google_api_impl.py
@@ -129,16 +129,9 @@ async def inspect_google_api_request_impl(
     config = resolve_generate_config(model, config)
 
     # generate via bridge
-    output, c_message = await bridge_generate(
-        bridge, model, messages, tools, tool_choice, config
-    )
-    if c_message is not None:
-        messages.append(c_message)
+    output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
 
     debug_log("INSPECT OUTPUT", output.message)
-
-    # update state if we have more messages than the last generation
-    await bridge._track_state(messages, output)
 
     # translate response to Gemini format
     response = gemini_response_from_output(output, model.api.model_name)

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -312,16 +312,9 @@ async def inspect_responses_api_request_impl(
     config = resolve_generate_config(model, config)
 
     # if there is a bridge filter give it a shot first
-    output, c_message = await bridge_generate(
-        bridge, model, messages, tools, tool_choice, config
-    )
-    if c_message is not None:
-        messages.append(c_message)
+    output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
 
     debug_log("INSPECT OUTPUT", output.message)
-
-    # update state if we have more messages than the last generation
-    await bridge._track_state(messages, output)
 
     # return response
     response = Response(

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -311,7 +311,7 @@ async def inspect_responses_api_request_impl(
     # give inspect-level config priority over agent default config
     config = resolve_generate_config(model, config)
 
-    # if there is a bridge filter give it a shot first
+    # generate via bridge
     output = await bridge_generate(bridge, model, messages, tools, tool_choice, config)
 
     debug_log("INSPECT OUTPUT", output.message)

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -28,6 +28,7 @@ from inspect_ai.util._sandbox.exec_remote import (
 )
 
 from ..._agent import AgentState
+from ..types import StateFilter
 from ..util import resolve_bridge_code_execution, resolve_bridge_web_search
 from .service import MODEL_SERVICE, run_model_service
 from .types import SandboxAgentBridge
@@ -60,6 +61,7 @@ async def sandbox_agent_bridge(
     forward_generation_config: bool = False,
     approval: list["ApprovalPolicy"] | None = None,
     checkpointer: Checkpointer | None = None,
+    state_filter: StateFilter | None = None,
 ) -> AsyncIterator[SandboxAgentBridge]:
     """Sandbox agent bridge.
 
@@ -132,6 +134,10 @@ async def sandbox_agent_bridge(
             state (messages, output, compaction prefix) for checkpoint backup
             and restore, so a checkpointed run survives resume. Defaults to
             `None` (no checkpointing).
+        state_filter: Optional predicate that selects client requests whose
+            generations update the yielded state's messages and output.
+            Rejected requests still receive normal model responses and model
+            events, and still tick the checkpointer.
     """
     # instance id for this bridge
     instance = f"proxy_{uuid()}"
@@ -174,6 +180,7 @@ async def sandbox_agent_bridge(
                 forward_generation_config=forward_generation_config,
                 approval=approval,
                 checkpointer=checkpointer,
+                state_filter=state_filter,
                 allow_remote_mcp=allow_remote_mcp,
             )
 

--- a/src/inspect_ai/agent/_bridge/sandbox/types.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/types.py
@@ -8,7 +8,7 @@ from pydantic_core import to_jsonable_python
 from inspect_ai._util.exception import TerminateSampleError
 from inspect_ai._util.logger import warn_once
 from inspect_ai.agent._agent import AgentState
-from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.types import AgentBridge, StateFilter
 from inspect_ai.model._compaction.types import CompactionStrategy
 from inspect_ai.model._model import GenerateFilter, Model, ModelEventSink
 from inspect_ai.tool import Tool
@@ -48,6 +48,7 @@ class SandboxAgentBridge(AgentBridge):
         checkpointer: Checkpointer | None = None,
         allow_remote_mcp: bool = False,
         allow_remote_media: bool = False,
+        state_filter: StateFilter | None = None,
     ) -> None:
         super().__init__(
             state,
@@ -62,6 +63,7 @@ class SandboxAgentBridge(AgentBridge):
             checkpointer=checkpointer,
             allow_remote_mcp=allow_remote_mcp,
             allow_remote_media=allow_remote_media,
+            state_filter=state_filter,
         )
         self.port = port
         self.mcp_server_configs = mcp_server_configs or []

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,6 +1,14 @@
 from enum import IntEnum
 from functools import lru_cache
-from typing import TYPE_CHECKING, Callable, NamedTuple, NoReturn, Sequence, Set
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    NamedTuple,
+    NoReturn,
+    Sequence,
+    Set,
+    TypeAlias,
+)
 
 from shortuuid import uuid
 
@@ -33,7 +41,14 @@ if TYPE_CHECKING:
     from inspect_ai.approval._policy import ApprovalPolicy
 
 
-StateFilter = Callable[[Sequence[ChatMessage]], bool]
+StateFilter: TypeAlias = Callable[[Sequence[ChatMessage]], bool]
+"""Predicate over the translated request messages for one generation request.
+
+Evaluated once per request, after operator-provenance restoration and before
+generation or compaction. Returning `False` excludes the request from
+`AgentBridge.state` and from canonical compaction history; the request still
+generates, still emits events and usage, and still ticks the checkpointer.
+"""
 
 
 class AgentBridge:

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -299,16 +299,16 @@ class AgentBridge:
           has more messages than the previous generation (or, when both
           threads descend, than the tracked thread — so a parked side call
           can't lower the bar for a stray descending one-shot).
-        - A new thread that isn't adopted is remembered as a candidate; if the
-          next call extends it, it's a live agent loop and is promoted. This is
-          what recovers tracking after history compaction (scaffold-side
-          compaction replaces the conversation with a summary, so the
-          post-compaction loop neither extends the tracked thread nor descends
-          from the initial input). Promotion is unconditional, so a multi-call
-          sub-agent loop transiently takes over tracking this way — the main
-          loop reclaims it on resumption, by extension when it makes several
-          further calls (candidate promotion) or by the longer-descending-call
-          displacement above when it makes only one.
+        - A new thread that isn't adopted is remembered as a candidate; a
+          thread displaced by a new adoption remains one too. If the next call
+          extends the candidate, it is a live agent loop and is promoted. This
+          recovers tracking after history compaction (scaffold-side compaction
+          replaces the conversation with a summary, so the post-compaction loop
+          neither extends the tracked thread nor descends from the initial
+          input) and after a one-shot side call temporarily displaces a main
+          loop. Promotion is unconditional, so a multi-call sub-agent loop
+          transiently takes over; the displaced main loop can reclaim tracking
+          on its next extension.
         """
         messages = input + [output.message]
         fps = [_message_fingerprint(m) for m in messages]
@@ -322,7 +322,13 @@ class AgentBridge:
         elif self._candidate_fps is not None and _extends(self._candidate_fps, fps):
             # the candidate got continued so it is a live agent loop (e.g. the
             # post-compaction conversation): promote it over the tracked thread
-            self._adopt_thread(messages, output, fps, calls=2)
+            self._adopt_thread(
+                messages,
+                output,
+                fps,
+                calls=2,
+                displaced=self._tracked_fps,
+            )
         else:
             descends = self._descends_from_initial(messages, fps)
             if (
@@ -339,7 +345,13 @@ class AgentBridge:
                 # that nothing extends). a short stray descending one-shot
                 # still can't displace an established weaker-anchored thread
                 # (flapping guard).
-                self._adopt_thread(messages, output, fps, calls=1)
+                self._adopt_thread(
+                    messages,
+                    output,
+                    fps,
+                    calls=1,
+                    displaced=self._tracked_fps,
+                )
             elif descends == self._tracked_descends and len(messages) > (
                 len(self._tracked_fps) if descends else self._last_message_count
             ):
@@ -350,7 +362,13 @@ class AgentBridge:
                 # rewrites message text every call (breaking fingerprint
                 # continuity and descent) recovers from compaction only
                 # through it.
-                self._adopt_thread(messages, output, fps, calls=1)
+                self._adopt_thread(
+                    messages,
+                    output,
+                    fps,
+                    calls=1,
+                    displaced=self._tracked_fps,
+                )
             else:
                 self._candidate_fps = fps
 
@@ -365,19 +383,23 @@ class AgentBridge:
         output: ModelOutput,
         fps: list["_MessageFingerprint"],
         calls: int,
+        *,
+        displaced: list["_MessageFingerprint"] | None = None,
     ) -> None:
         """Make `messages` the tracked main thread (see `_track_state`).
 
         `calls` is the number of bridge calls attributed to the thread; a
         stronger-descending thread may displace a weaker-anchored one-shot
-        (`calls == 1`) thread regardless of length.
+        (`calls == 1`) thread regardless of length. `displaced` retains the
+        prior tracked thread as a continuation candidate when switching
+        threads.
         """
         self.state.messages = messages
         self.state.output = output
         self._tracked_fps = fps
         self._tracked_calls = calls
         self._tracked_descends = self._descends_from_initial(messages, fps)
-        self._candidate_fps = None
+        self._candidate_fps = displaced
 
     def _descends_from_initial(
         self, messages: list[ChatMessage], fps: list["_MessageFingerprint"]

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -123,7 +123,12 @@ class AgentBridge:
         self._tracked_descends: _Descent | None = None
         self._candidate_fps: list[_MessageFingerprint] | None = None
         self._pending_operator = 0
-        self._operator_keys: set[str] = set()
+        self._operator_keys = self._cp.track(
+            "bridge_operator_keys",
+            lambda: self._operator_keys,
+            set(),
+            value_type=set[str],
+        )
 
     state: AgentState
     """State updated from messages traveling over the bridge."""
@@ -137,9 +142,12 @@ class AgentBridge:
     state_filter: StateFilter | None
     """Optional predicate that selects requests whose generations update state.
 
+    The predicate sees the translated request, including restored operator
+    provenance, before generation or compaction.
     Requests rejected by the predicate still generate responses, emit model
-    events, and tick the checkpointer, but leave tracked conversation state
-    unchanged. Exceptions from the predicate propagate to the request handler.
+    events, and tick the checkpointer, but bypass canonical compaction and leave
+    tracked conversation state unchanged. Predicate exceptions propagate before
+    generation begins.
     """
 
     model: str | None
@@ -280,9 +288,8 @@ class AgentBridge:
         We need to distinguish the "main" thread of generation from side /
         sub-agent model calls (e.g. claude code does bash path detection with a
         side call; opencode names the session with a title-generation call).
-        An optional state filter determines which requests contribute to the
-        canonical agent state. Rejected requests still complete normally but
-        leave the tracked conversation unchanged.
+        The shared generation path applies the optional state filter before
+        calling this method.
 
         Message counts alone can't do this: a side call that is longer than the
         main conversation (opencode's title call fires before the main loop's
@@ -324,10 +331,6 @@ class AgentBridge:
           descends from the initial input). Promotion is unconditional, so a
           multi-call sub-agent loop transiently takes over.
         """
-        if self.state_filter is not None and not self.state_filter(input):
-            await self._cp.tick()
-            return
-
         messages = input + [output.message]
         fps = [_message_fingerprint(m) for m in messages]
 

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 from functools import lru_cache
-from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
+from typing import TYPE_CHECKING, Callable, NamedTuple, NoReturn, Sequence, Set
 
 from shortuuid import uuid
 
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from inspect_ai.approval._policy import ApprovalPolicy
 
 
+StateFilter = Callable[[Sequence[ChatMessage]], bool]
+
+
 class AgentBridge:
     """Agent bridge."""
 
@@ -50,6 +53,7 @@ class AgentBridge:
         checkpointer: Checkpointer | None = None,
         allow_remote_mcp: bool = True,
         allow_remote_media: bool = False,
+        state_filter: StateFilter | None = None,
     ) -> None:
         # Capabilities a client-declared request may reach for. Media defaults
         # closed so new bridge subclasses cannot accidentally grant host I/O.
@@ -101,6 +105,7 @@ class AgentBridge:
         self.model_event_sink = model_event_sink
         self.forward_generation_config = forward_generation_config
         self.approval = approval
+        self.state_filter = state_filter
         self._compaction = compaction
         self._compact: Compact | None = None
         self._last_message_count = 0
@@ -127,6 +132,14 @@ class AgentBridge:
     """Filter for bridge model generation.
 
     A filter may substitute for the default model generation by returning a ModelOutput or return None to allow default processing to continue.
+    """
+
+    state_filter: StateFilter | None
+    """Optional predicate that selects requests whose generations update state.
+
+    Requests rejected by the predicate still generate responses, emit model
+    events, and tick the checkpointer, but leave tracked conversation state
+    unchanged. Exceptions from the predicate propagate to the request handler.
     """
 
     model: str | None
@@ -267,6 +280,10 @@ class AgentBridge:
         We need to distinguish the "main" thread of generation from side /
         sub-agent model calls (e.g. claude code does bash path detection with a
         side call; opencode names the session with a title-generation call).
+        An optional state filter determines which requests contribute to the
+        canonical agent state. Rejected requests still complete normally but
+        leave the tracked conversation unchanged.
+
         Message counts alone can't do this: a side call that is longer than the
         main conversation (opencode's title call fires before the main loop's
         first call and carries an extra preamble message) would permanently
@@ -299,17 +316,18 @@ class AgentBridge:
           has more messages than the previous generation (or, when both
           threads descend, than the tracked thread — so a parked side call
           can't lower the bar for a stray descending one-shot).
-        - A new thread that isn't adopted is remembered as a candidate; a
-          thread displaced by a new adoption remains one too. If the next call
-          extends the candidate, it is a live agent loop and is promoted. This
-          recovers tracking after history compaction (scaffold-side compaction
-          replaces the conversation with a summary, so the post-compaction loop
-          neither extends the tracked thread nor descends from the initial
-          input) and after a one-shot side call temporarily displaces a main
-          loop. Promotion is unconditional, so a multi-call sub-agent loop
-          transiently takes over; the displaced main loop can reclaim tracking
-          on its next extension.
+        - A new thread that isn't adopted is remembered as a candidate. If the
+          next call extends the candidate, it is a live agent loop and is
+          promoted. This recovers tracking after history compaction
+          (scaffold-side compaction replaces the conversation with a summary,
+          so the post-compaction loop neither extends the tracked thread nor
+          descends from the initial input). Promotion is unconditional, so a
+          multi-call sub-agent loop transiently takes over.
         """
+        if self.state_filter is not None and not self.state_filter(input):
+            await self._cp.tick()
+            return
+
         messages = input + [output.message]
         fps = [_message_fingerprint(m) for m in messages]
 
@@ -322,13 +340,7 @@ class AgentBridge:
         elif self._candidate_fps is not None and _extends(self._candidate_fps, fps):
             # the candidate got continued so it is a live agent loop (e.g. the
             # post-compaction conversation): promote it over the tracked thread
-            self._adopt_thread(
-                messages,
-                output,
-                fps,
-                calls=2,
-                displaced=self._tracked_fps,
-            )
+            self._adopt_thread(messages, output, fps, calls=2)
         else:
             descends = self._descends_from_initial(messages, fps)
             if (
@@ -345,13 +357,7 @@ class AgentBridge:
                 # that nothing extends). a short stray descending one-shot
                 # still can't displace an established weaker-anchored thread
                 # (flapping guard).
-                self._adopt_thread(
-                    messages,
-                    output,
-                    fps,
-                    calls=1,
-                    displaced=self._tracked_fps,
-                )
+                self._adopt_thread(messages, output, fps, calls=1)
             elif descends == self._tracked_descends and len(messages) > (
                 len(self._tracked_fps) if descends else self._last_message_count
             ):
@@ -362,13 +368,7 @@ class AgentBridge:
                 # rewrites message text every call (breaking fingerprint
                 # continuity and descent) recovers from compaction only
                 # through it.
-                self._adopt_thread(
-                    messages,
-                    output,
-                    fps,
-                    calls=1,
-                    displaced=self._tracked_fps,
-                )
+                self._adopt_thread(messages, output, fps, calls=1)
             else:
                 self._candidate_fps = fps
 
@@ -383,23 +383,14 @@ class AgentBridge:
         output: ModelOutput,
         fps: list["_MessageFingerprint"],
         calls: int,
-        *,
-        displaced: list["_MessageFingerprint"] | None = None,
     ) -> None:
-        """Make `messages` the tracked main thread (see `_track_state`).
-
-        `calls` is the number of bridge calls attributed to the thread; a
-        stronger-descending thread may displace a weaker-anchored one-shot
-        (`calls == 1`) thread regardless of length. `displaced` retains the
-        prior tracked thread as a continuation candidate when switching
-        threads.
-        """
+        """Make `messages` the tracked main thread (see `_track_state`)."""
         self.state.messages = messages
         self.state.output = output
         self._tracked_fps = fps
         self._tracked_calls = calls
         self._tracked_descends = self._descends_from_initial(messages, fps)
-        self._candidate_fps = displaced
+        self._candidate_fps = None
 
     def _descends_from_initial(
         self, messages: list[ChatMessage], fps: list["_MessageFingerprint"]

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -484,8 +484,8 @@ async def bridge_generate(
     tools: Sequence[ToolInfo | Tool],
     tool_choice: ToolChoice | None,
     config: GenerateConfig,
-) -> tuple[ModelOutput, ChatMessageUser | None]:
-    """Generate model output through the agent bridge.
+) -> ModelOutput:
+    """Generate model output and track eligible requests through the agent bridge.
 
     If a filter is configured, it will be called on each attempt (including retries).
     The filter can either return a ModelOutput directly or modify the generation inputs.
@@ -504,8 +504,12 @@ async def bridge_generate(
     # ModelEvent input and state.messages (and thus the eval log).
     _restore_operator_message_source(bridge, input)
 
+    # Select once from the scaffold's request, before compaction can append a
+    # synthetic summary or incorporate this input into the canonical history.
+    state_eligible = bridge.state_filter is None or bridge.state_filter(input)
+
     # get compaction function and run compaction once before retry loop
-    compact = bridge.compaction(tools, model)
+    compact = bridge.compaction(tools, model) if state_eligible else None
     if compact is not None:
         input_messages, c_message = await compact.compact_input(input)
     else:
@@ -588,7 +592,13 @@ async def bridge_generate(
             bridge.register_tool_execution_grants(
                 reviewed.output.message.tool_calls or []
             )
-            return reviewed.output, c_message
+            if state_eligible:
+                if c_message is not None:
+                    input.append(c_message)
+                await bridge._track_state(input, reviewed.output)
+            else:
+                await bridge._cp.tick()
+            return reviewed.output
 
         rejections += 1
         if rejections >= MAX_CONSECUTIVE_REJECTIONS:

--- a/tests/agent/test_acp/test_operator_provenance.py
+++ b/tests/agent/test_acp/test_operator_provenance.py
@@ -242,16 +242,16 @@ def test_restore_carry_forward_does_not_touch_other_users() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Integration: bridge_generate + _track_state (the log path)
+# Integration: bridge generation and canonical state (the log path)
 # ---------------------------------------------------------------------------
 
 
 @skip_if_trio
 @pytest.mark.anyio
 async def test_bridge_generate_restores_into_state_messages() -> None:
-    """note_operator_message → bridge_generate stamps in place → _track_state.
+    """Bridge generation restores provenance before recording canonical state.
 
-    Proves source lands in BOTH the input list (which the ModelEvent records) and
+    Proves source persists in BOTH the input list (which the ModelEvent records) and
     bridge.state.messages (which becomes the sample conversation in the log).
     """
     tr = Transcript()
@@ -273,10 +273,7 @@ async def test_bridge_generate_restores_into_state_messages() -> None:
             ChatMessageAssistant(content="working"),
             operator,
         ]
-        output, _ = await bridge_generate(
-            bridge, model, messages, [], None, GenerateConfig()
-        )
-        await bridge._track_state(messages, output)  # mirrors completions.py:97
+        await bridge_generate(bridge, model, messages, [], None, GenerateConfig())
 
         assert operator.source == "operator"
         assert task.source is None
@@ -319,8 +316,7 @@ async def test_bridge_generate_carry_forward_into_state_on_later_turn() -> None:
             ChatMessageAssistant(content="a"),
             ChatMessageUser(content="redirect"),
         ]
-        out1, _ = await bridge_generate(bridge, model, t1, [], None, GenerateConfig())
-        await bridge._track_state(t1, out1)
+        await bridge_generate(bridge, model, t1, [], None, GenerateConfig())
 
         # turn 2: larger, operator mid-history, source-less, NO pending
         operator_t2 = ChatMessageUser(content="redirect")
@@ -330,8 +326,7 @@ async def test_bridge_generate_carry_forward_into_state_on_later_turn() -> None:
             operator_t2,
             ChatMessageAssistant(content="b"),
         ]
-        out2, _ = await bridge_generate(bridge, model, t2, [], None, GenerateConfig())
-        await bridge._track_state(t2, out2)
+        await bridge_generate(bridge, model, t2, [], None, GenerateConfig())
 
         assert operator_t2.source == "operator"  # carry-forward
         # state.messages updated to the larger turn 2 and carries the operator

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -39,6 +39,38 @@ from inspect_ai.tool._tool_params import ToolParam, ToolParams
 from inspect_ai.util._json import json_schema
 
 
+async def test_in_process_state_filter_preserves_task_answer() -> None:
+    state = AgentState(messages=[])
+    model = get_model(
+        "mockllm/model",
+        memoize=False,
+        custom_outputs=[
+            ModelOutput.from_content("mockllm/model", "Task answer"),
+            ModelOutput.from_content("mockllm/model", "Auxiliary title"),
+        ],
+    )
+    async with agent_bridge(
+        state, state_filter=lambda messages: messages[-1].text == "Main task"
+    ) as bridge:
+        bridge.model_aliases["inspect"] = model
+        async with AsyncOpenAI(api_key="inspect") as client:
+            main = await client.chat.completions.create(
+                model="inspect", messages=[{"role": "user", "content": "Main task"}]
+            )
+            auxiliary = await client.chat.completions.create(
+                model="inspect",
+                messages=[
+                    {"role": "user", "content": "Main task"},
+                    {"role": "assistant", "content": "Task answer"},
+                    {"role": "user", "content": "Generate a title"},
+                ],
+            )
+    assert main.choices[0].message.content == "Task answer"
+    assert auxiliary.choices[0].message.content == "Auxiliary title"
+    assert [message.text for message in state.messages] == ["Main task", "Task answer"]
+    assert state.output.completion == "Task answer"
+
+
 @agent
 def completions_agent(tools: bool) -> Agent:
     async def execute(state: AgentState) -> AgentState:

--- a/tests/agent/test_bridge_approval.py
+++ b/tests/agent/test_bridge_approval.py
@@ -157,7 +157,7 @@ async def run_bridge(
     if approval is not None:
         bridge.approval = approval
 
-    output, _ = await bridge_generate(
+    output = await bridge_generate(
         bridge, model, list(messages), [], None, GenerateConfig()
     )
     return BridgeRun(output, inputs)
@@ -914,10 +914,9 @@ async def test_track_state_is_unaffected_by_the_round_trip() -> None:
         input=messages,
     )
 
-    # the caller's list is what the dialect impl hands to _track_state
+    # Synthetic rejection messages must not enter the scaffold's conversation.
     assert [(m.role, m.text) for m in messages] == [("user", TASK)]
 
-    await bridge._track_state(messages, run.output)
     assert [m.text for m in bridge.state.messages] == [TASK, run.output.message.text]
 
 

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -1,14 +1,13 @@
 """Tests for AgentBridge._track_state main-thread tracking.
 
-The bridge observes every generation a scaffold makes (main agent loop,
-side calls like opencode's session title generation, sub-agent loops,
-post-compaction continuations) and must surface the *main* conversation
-as the agent state. See meridianlabs-ai/inspect_ai#140 for the failure
-mode where a longer side call permanently displaced the real conversation.
+The bridge tracks selected model generations as agent state while side requests
+can remain outside the canonical conversation.
 """
 
+from collections.abc import Sequence
 from typing import Any
 
+import pytest
 from test_helpers.checkpoint import RecordingCheckpointer
 
 from inspect_ai._util.hash import mm3_hash
@@ -20,6 +19,7 @@ from inspect_ai.agent._bridge.util import (
     default_code_execution_providers,
     internal_web_search_providers,
 )
+from inspect_ai.event._model import ModelEvent
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -53,14 +53,6 @@ def title_generation_input() -> list[ChatMessage]:
     return [
         ChatMessageSystem(content="You are a title generator ..."),
         ChatMessageUser(content="Generate a title for this conversation:\n"),
-        ChatMessageUser(content=TASK),
-    ]
-
-
-def exact_title_generation_input() -> list[ChatMessage]:
-    """A one-shot title request that copies the task prompt verbatim."""
-    return [
-        ChatMessageSystem(content="You are a title generator ..."),
         ChatMessageUser(content=TASK),
     ]
 
@@ -585,148 +577,6 @@ async def test_title_call_then_multi_turn_main_loop() -> None:
 
     assert bridge.state.output.completion == "Castle"
     assert len(bridge.state.messages) == len(turn3) + 1
-
-
-async def test_contained_main_recovers_after_exact_one_shot_displacement() -> None:
-    """Continuing a displaced main call promotes its preserved candidate."""
-    bridge = task_bridge()
-    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
-    main1: list[ChatMessage] = [
-        TASK_SYSTEM,
-        ChatMessageUser(content=decorated_task),
-    ]
-
-    main1_output = await track(bridge, main1, "I will look into that.")
-
-    # This exact prompt copy temporarily wins over the decorated main call.
-    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9 setting")
-
-    main2 = main1 + [
-        main1_output.message,
-        ChatMessageTool(content="search results"),
-    ]
-    await track(bridge, main2, "Castle")
-
-    expected_messages = [
-        TASK_SYSTEM.text,
-        decorated_task,
-        "I will look into that.",
-        "search results",
-        "Castle",
-    ]
-    assert bridge.state.output.completion == "Castle"
-    assert [message.text for message in bridge.state.messages] == expected_messages
-
-    # A trailing one-shot must not steal the recovered, multi-call main loop.
-    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9")
-    assert bridge.state.output.completion == "Castle"
-    assert [message.text for message in bridge.state.messages] == expected_messages
-
-
-async def test_contained_main_recovers_when_exact_one_shot_arrives_first() -> None:
-    """The reverse call order retains ordinary candidate-promotion recovery."""
-    bridge = task_bridge()
-    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
-    main1: list[ChatMessage] = [
-        TASK_SYSTEM,
-        ChatMessageUser(content=decorated_task),
-    ]
-
-    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9 setting")
-    main1_output = await track(bridge, main1, "I will look into that.")
-
-    main2 = main1 + [
-        main1_output.message,
-        ChatMessageTool(content="search results"),
-    ]
-    await track(bridge, main2, "Castle")
-
-    assert bridge.state.output.completion == "Castle"
-    assert [message.text for message in bridge.state.messages] == [
-        TASK_SYSTEM.text,
-        decorated_task,
-        "I will look into that.",
-        "search results",
-        "Castle",
-    ]
-
-
-async def test_contained_main_recovers_after_promoted_sub_agent_loop() -> None:
-    """A promoted sub-agent keeps the displaced main loop as a candidate."""
-    bridge = task_bridge()
-    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
-    main1: list[ChatMessage] = [
-        TASK_SYSTEM,
-        ChatMessageUser(content=decorated_task),
-    ]
-    main1_output = await track(bridge, main1, "I will look into that.")
-
-    sub1: list[ChatMessage] = [
-        ChatMessageSystem(content="You are a subtask agent ..."),
-        ChatMessageUser(content="Research Doctor Who series 9 filming locations."),
-    ]
-    sub1_output = await track(bridge, sub1, "researching")
-    sub2 = sub1 + [
-        sub1_output.message,
-        ChatMessageTool(content="search results"),
-    ]
-    await track(bridge, sub2, "Cardiff Castle")
-
-    main2 = main1 + [
-        main1_output.message,
-        ChatMessageTool(content="subtask: Cardiff Castle"),
-    ]
-    await track(bridge, main2, "Castle")
-
-    assert bridge.state.output.completion == "Castle"
-    assert [message.text for message in bridge.state.messages] == [
-        TASK_SYSTEM.text,
-        decorated_task,
-        "I will look into that.",
-        "subtask: Cardiff Castle",
-        "Castle",
-    ]
-
-
-async def test_main_recovers_after_legacy_length_displacement() -> None:
-    """A legacy-length side-call displacement preserves the main candidate.
-
-    With no descent anchor, the one-shot's six messages displace the primary's
-    three by previous-call length. Its five-message continuation is shorter
-    than that side call, so candidate promotion is its only recovery path.
-    """
-    bridge = AgentBridge(AgentState(messages=[]))
-    main1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
-    main1_output = await track(bridge, main1, "I will look into that.")
-
-    # With no initial input every thread descends as None, so this six-message
-    # one-shot takes the legacy previous-call length path.
-    await track(
-        bridge,
-        [
-            ChatMessageSystem(content="You are a title generator ..."),
-            ChatMessageUser(content="Create a title."),
-            ChatMessageUser(content="Return only the title."),
-            ChatMessageUser(content="Do not use punctuation."),
-            ChatMessageUser(content="Keep it concise."),
-        ],
-        "Doctor Who Series 9 setting",
-    )
-
-    main2 = main1 + [
-        main1_output.message,
-        ChatMessageTool(content="search results"),
-    ]
-    await track(bridge, main2, "Castle")
-
-    assert bridge.state.output.completion == "Castle"
-    assert [message.text for message in bridge.state.messages] == [
-        TASK_SYSTEM.text,
-        TASK,
-        "I will look into that.",
-        "search results",
-        "Castle",
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1568,6 +1418,20 @@ def scenario_model(completions: list[str]) -> Model:
     )
 
 
+class RecordingModelEvents:
+    """Capture lifecycle events emitted by bridge request handlers."""
+
+    def __init__(self) -> None:
+        self.pending: list[ModelEvent] = []
+        self.completed: list[ModelEvent] = []
+
+    def on_pending(self, event: ModelEvent) -> None:
+        self.pending.append(event)
+
+    def on_complete(self, event: ModelEvent) -> None:
+        self.completed.append(event)
+
+
 async def test_completions_handler_tracks_main_thread_end_to_end() -> None:
     """The opencode scenario through the real OpenAI completions handler.
 
@@ -1682,3 +1546,334 @@ async def test_anthropic_handler_tracks_main_thread_end_to_end() -> None:
         "please continue",
         "Castle",
     ]
+
+
+@pytest.mark.parametrize("main_first", [True, False])
+async def test_state_filter_preserves_main_state_and_excluded_request_accounting(
+    main_first: bool,
+) -> None:
+    """Excluded real-handler requests emit normally without changing state."""
+    completions = (
+        [
+            "Castle",
+            "Doctor Who Series 9 setting",
+            "/tmp",
+            "Castle after search",
+        ]
+        if main_first
+        else [
+            "Doctor Who Series 9 setting",
+            "Castle",
+            "/tmp",
+            "Castle after search",
+        ]
+    )
+    events = RecordingModelEvents()
+    checkpointer = RecordingCheckpointer()
+
+    def state_filter(messages: Sequence[ChatMessage]) -> bool:
+        return any(
+            isinstance(message, ChatMessageSystem) and message.text == TASK_SYSTEM.text
+            for message in messages
+        )
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(completions)},
+        model_event_sink=events,
+        checkpointer=checkpointer,
+        state_filter=state_filter,
+    )
+    responses: list[Any] = []
+
+    async def request(messages: list[dict[str, str]]) -> Any:
+        response = await inspect_completions_api_request(
+            {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+        )
+        responses.append(response)
+        return response
+
+    main = [
+        {"role": "system", "content": TASK_SYSTEM.text},
+        {"role": "user", "content": TASK},
+    ]
+    title = [
+        {"role": "system", "content": "You are a title generator ..."},
+        {"role": "user", "content": "Generate a title for this conversation:"},
+        {"role": "user", "content": TASK},
+        {"role": "user", "content": "Respond with the title only."},
+    ]
+    unrelated = [
+        {"role": "system", "content": "You are a path detector ..."},
+        {"role": "user", "content": "Extract the path from: ls /tmp"},
+    ]
+    if main_first:
+        main_response = await request(main)
+        title_response = await request(title)
+    else:
+        title_response = await request(title)
+        main_response = await request(main)
+
+    assert main_response.choices[0].message.content == "Castle"
+    assert title_response.choices[0].message.content == "Doctor Who Series 9 setting"
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+    tracked_fps = bridge._tracked_fps
+    tracked_calls = bridge._tracked_calls
+    tracked_descends = bridge._tracked_descends
+    last_message_count = bridge._last_message_count
+    candidate_fps = bridge._candidate_fps
+
+    await request(unrelated)
+
+    assert bridge.state.output.completion == "Castle"
+    assert bridge._tracked_fps == tracked_fps
+    assert bridge._tracked_calls == tracked_calls
+    assert bridge._tracked_descends == tracked_descends
+    assert bridge._last_message_count == last_message_count
+    assert bridge._candidate_fps == candidate_fps
+
+    await request(
+        main
+        + [
+            {"role": "assistant", "content": "Castle"},
+            {"role": "user", "content": "Continue with the result."},
+        ]
+    )
+
+    assert bridge.state.output.completion == "Castle after search"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+        "Continue with the result.",
+        "Castle after search",
+    ]
+    assert all(message.id is not None for message in bridge.state.messages[:-1])
+    assert len(events.pending) == len(events.completed) == 4
+    assert [event.output.completion for event in events.completed] == completions
+    assert all(event.output.usage is not None for event in events.completed)
+    assert [
+        event.output.usage.total_tokens if event.output.usage is not None else None
+        for event in events.completed
+    ] == [1, 1, 1, 1]
+    response_ids = [response.id for response in responses]
+    assert all(response_ids)
+    assert len(set(response_ids)) == 4
+    event_ids = [event.uuid for event in events.completed]
+    assert all(event_ids)
+    assert len(set(event_ids)) == 4
+    assert [
+        response.usage.total_tokens if response.usage is not None else None
+        for response in responses
+    ] == [1, 1, 1, 1]
+    assert checkpointer.ticks == 4
+
+
+async def test_state_filter_exception_propagates_from_completion_handler() -> None:
+    """A filter failure is not converted into untracked request state."""
+
+    def state_filter(_messages: Sequence[ChatMessage]) -> bool:
+        raise RuntimeError("state filter failed")
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Castle"])},
+        state_filter=state_filter,
+    )
+
+    with pytest.raises(RuntimeError, match="state filter failed"):
+        await inspect_completions_api_request(
+            {
+                "model": BRIDGE_MODEL,
+                "messages": [
+                    {"role": "system", "content": TASK_SYSTEM.text},
+                    {"role": "user", "content": TASK},
+                ],
+            },
+            None,
+            bridge,
+        )
+
+
+async def test_state_filter_defaults_to_tracking_all_handler_requests() -> None:
+    """Without a state filter, the handler retains its existing behavior."""
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Castle"])},
+    )
+
+    await inspect_completions_api_request(
+        {
+            "model": BRIDGE_MODEL,
+            "messages": [
+                {"role": "system", "content": TASK_SYSTEM.text},
+                {"role": "user", "content": TASK},
+            ],
+        },
+        None,
+        bridge,
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+
+
+async def test_state_filter_rejects_exact_main_extension_without_state_mutation() -> (
+    None
+):
+    """An excluded extension leaves an established main thread unchanged."""
+    events = RecordingModelEvents()
+    checkpointer = RecordingCheckpointer()
+
+    def state_filter(messages: Sequence[ChatMessage]) -> bool:
+        return not any(
+            isinstance(message, ChatMessageAssistant) for message in messages
+        )
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={
+            BRIDGE_MODEL: scenario_model(["Castle", "Ignored continuation"])
+        },
+        model_event_sink=events,
+        checkpointer=checkpointer,
+        state_filter=state_filter,
+    )
+
+    async def request(messages: list[dict[str, str]]) -> Any:
+        return await inspect_completions_api_request(
+            {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+        )
+
+    main = [
+        {"role": "system", "content": TASK_SYSTEM.text},
+        {"role": "user", "content": TASK},
+    ]
+    first_response = await request(main)
+    tracked_fps = bridge._tracked_fps
+    tracked_calls = bridge._tracked_calls
+    tracked_descends = bridge._tracked_descends
+    last_message_count = bridge._last_message_count
+    candidate_fps = bridge._candidate_fps
+
+    continuation_response = await request(
+        main
+        + [
+            {"role": "assistant", "content": "Castle"},
+            {"role": "user", "content": "Continue with the result."},
+        ]
+    )
+
+    assert first_response.choices[0].message.content == "Castle"
+    assert continuation_response.choices[0].message.content == "Ignored continuation"
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+    assert bridge._tracked_fps == tracked_fps
+    assert bridge._tracked_calls == tracked_calls
+    assert bridge._tracked_descends == tracked_descends
+    assert bridge._last_message_count == last_message_count
+    assert bridge._candidate_fps == candidate_fps
+    assert len(events.pending) == len(events.completed) == 2
+    assert [event.output.completion for event in events.completed] == [
+        "Castle",
+        "Ignored continuation",
+    ]
+    assert all(event.output.usage is not None for event in events.completed)
+    assert [
+        event.output.usage.total_tokens if event.output.usage is not None else None
+        for event in events.completed
+    ] == [1, 1]
+    assert first_response.id
+    assert continuation_response.id
+    assert first_response.id != continuation_response.id
+    assert [
+        response.usage.total_tokens if response.usage is not None else None
+        for response in [first_response, continuation_response]
+    ] == [1, 1]
+    assert checkpointer.ticks == 2
+
+
+async def test_state_filter_error_on_main_extension_preserves_state() -> None:
+    """A rejected extension propagates its filter error before state mutation."""
+    events = RecordingModelEvents()
+    checkpointer = RecordingCheckpointer()
+
+    def state_filter(messages: Sequence[ChatMessage]) -> bool:
+        if any(isinstance(message, ChatMessageAssistant) for message in messages):
+            raise RuntimeError("state filter rejected main continuation")
+        return True
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={
+            BRIDGE_MODEL: scenario_model(["Castle", "Ignored continuation"])
+        },
+        model_event_sink=events,
+        checkpointer=checkpointer,
+        state_filter=state_filter,
+    )
+
+    main = [
+        {"role": "system", "content": TASK_SYSTEM.text},
+        {"role": "user", "content": TASK},
+    ]
+    first_response = await inspect_completions_api_request(
+        {"model": BRIDGE_MODEL, "messages": main}, None, bridge
+    )
+    tracked_fps = bridge._tracked_fps
+    tracked_calls = bridge._tracked_calls
+    tracked_descends = bridge._tracked_descends
+    last_message_count = bridge._last_message_count
+    candidate_fps = bridge._candidate_fps
+
+    with pytest.raises(RuntimeError, match="state filter rejected main continuation"):
+        await inspect_completions_api_request(
+            {
+                "model": BRIDGE_MODEL,
+                "messages": main
+                + [
+                    {"role": "assistant", "content": "Castle"},
+                    {"role": "user", "content": "Continue with the result."},
+                ],
+            },
+            None,
+            bridge,
+        )
+
+    assert first_response.id
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+    assert bridge._tracked_fps == tracked_fps
+    assert bridge._tracked_calls == tracked_calls
+    assert bridge._tracked_descends == tracked_descends
+    assert bridge._last_message_count == last_message_count
+    assert bridge._candidate_fps == candidate_fps
+    assert len(events.pending) == len(events.completed) == 2
+    assert [event.output.completion for event in events.completed] == [
+        "Castle",
+        "Ignored continuation",
+    ]
+    assert all(event.output.usage is not None for event in events.completed)
+    assert [
+        event.output.usage.total_tokens if event.output.usage is not None else None
+        for event in events.completed
+    ] == [1, 1]
+    # The exception occurs before `_track_state` reaches its ordinary tick.
+    assert checkpointer.ticks == 1

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -27,6 +27,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
+from inspect_ai.model._compaction import CompactionSummary
 from inspect_ai.model._model import Model, get_model
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
 
@@ -1674,6 +1675,87 @@ async def test_state_filter_preserves_main_state_and_excluded_request_accounting
     assert checkpointer.ticks == 4
 
 
+@pytest.mark.parametrize("include", [True, False])
+async def test_state_filter_preserves_operator_provenance(include: bool) -> None:
+    """Selection sees restored provenance; excluded events retain it too."""
+    events = RecordingModelEvents()
+
+    def state_filter(messages: Sequence[ChatMessage]) -> bool:
+        return include and any(message.source == "operator" for message in messages)
+
+    task = ChatMessageUser(content=TASK)
+    bridge = AgentBridge(
+        AgentState(messages=[task]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Castle"])},
+        model_event_sink=events,
+        state_filter=state_filter,
+    )
+    bridge.note_operator_message(ChatMessageUser(content="Please continue."))
+    await inspect_completions_api_request(
+        {
+            "model": BRIDGE_MODEL,
+            "messages": [
+                {"role": "user", "content": TASK},
+                {"role": "assistant", "content": "Checking."},
+                {"role": "user", "content": "Please continue."},
+            ],
+        },
+        None,
+        bridge,
+    )
+
+    if include:
+        assert bridge.state.output.completion == "Castle"
+        assert bridge.state.messages[-2].source == "operator"
+    else:
+        assert bridge.state.messages == [task]
+        assert bridge.state.output.completion == ""
+    assert [
+        message.source
+        for message in events.completed[0].input
+        if isinstance(message, ChatMessageUser)
+    ] == [None, "operator"]
+
+
+async def test_excluded_operator_provenance_survives_checkpoint_resume() -> None:
+    """An excluded turn's provenance is retained when the CLI replays it."""
+    checkpointer = RecordingCheckpointer()
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Side response"])},
+        checkpointer=checkpointer,
+        state_filter=lambda _messages: False,
+    )
+    bridge.note_operator_message(ChatMessageUser(content="Please continue."))
+    messages = [
+        {"role": "user", "content": TASK},
+        {"role": "assistant", "content": "Checking."},
+        {"role": "user", "content": "Please continue."},
+    ]
+    await inspect_completions_api_request(
+        {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+    )
+
+    resumed = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Castle"])},
+        checkpointer=RecordingCheckpointer(
+            restored={
+                key: callback() for key, callback in checkpointer.callbacks.items()
+            }
+        ),
+        state_filter=lambda request: any(
+            message.source == "operator" for message in request
+        ),
+    )
+    await inspect_completions_api_request(
+        {"model": BRIDGE_MODEL, "messages": messages}, None, resumed
+    )
+
+    assert resumed.state.output.completion == "Castle"
+    assert resumed.state.messages[-2].source == "operator"
+
+
 async def test_state_filter_exception_propagates_from_completion_handler() -> None:
     """A filter failure is not converted into untracked request state."""
 
@@ -1865,15 +1947,91 @@ async def test_state_filter_error_on_main_extension_preserves_state() -> None:
     assert bridge._tracked_descends == tracked_descends
     assert bridge._last_message_count == last_message_count
     assert bridge._candidate_fps == candidate_fps
-    assert len(events.pending) == len(events.completed) == 2
+    assert len(events.pending) == len(events.completed) == 1
     assert [event.output.completion for event in events.completed] == [
         "Castle",
-        "Ignored continuation",
     ]
     assert all(event.output.usage is not None for event in events.completed)
     assert [
         event.output.usage.total_tokens if event.output.usage is not None else None
         for event in events.completed
-    ] == [1, 1]
-    # The exception occurs before `_track_state` reaches its ordinary tick.
+    ] == [1]
+    # A predicate failure stops the request before generation and checkpointing.
     assert checkpointer.ticks == 1
+
+
+async def test_state_filter_excludes_requests_from_compaction_history() -> None:
+    events = RecordingModelEvents()
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={
+            BRIDGE_MODEL: scenario_model(["Castle", "Title", "Final answer"])
+        },
+        model_event_sink=events,
+        compaction=CompactionSummary(threshold=1_000_000, memory=False),
+        state_filter=lambda messages: messages[-1].text != "Generate a title",
+    )
+    main = [{"role": "user", "content": TASK}]
+    continuation = main + [
+        {"role": "assistant", "content": "Castle"},
+        {"role": "user", "content": "Continue"},
+    ]
+    for messages in [
+        main,
+        [{"role": "user", "content": "Generate a title"}],
+        continuation,
+    ]:
+        await inspect_completions_api_request(
+            {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+        )
+
+    assert [message.text for message in events.completed[1].input] == [
+        "Generate a title"
+    ]
+    assert [message.text for message in events.completed[2].input] == [
+        TASK,
+        "Castle",
+        "Continue",
+    ]
+    assert bridge.state.output.completion == "Final answer"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK,
+        "Castle",
+        "Continue",
+        "Final answer",
+    ]
+
+
+async def test_state_filter_selects_request_before_summary_is_appended() -> None:
+    continuation = "Continue with this evidence: " + "castle " * 1000
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: scenario_model(["Castle", "Final answer"])},
+        compaction=CompactionSummary(
+            threshold=500,
+            memory=False,
+            model=scenario_model(["The castle has been found."]),
+        ),
+        state_filter=lambda messages: messages[-1].text in (TASK, continuation),
+    )
+    main = [{"role": "user", "content": TASK}]
+    for messages in [
+        main,
+        main
+        + [
+            {"role": "assistant", "content": "Castle"},
+            {"role": "user", "content": continuation},
+        ],
+    ]:
+        await inspect_completions_api_request(
+            {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+        )
+
+    assert bridge.state.output.completion == "Final answer"
+    summaries = [
+        message
+        for message in bridge.state.messages
+        if (message.metadata or {}).get("summary")
+    ]
+    assert len(summaries) == 1
+    assert "The castle has been found." in summaries[0].text

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -57,6 +57,14 @@ def title_generation_input() -> list[ChatMessage]:
     ]
 
 
+def exact_title_generation_input() -> list[ChatMessage]:
+    """A one-shot title request that copies the task prompt verbatim."""
+    return [
+        ChatMessageSystem(content="You are a title generator ..."),
+        ChatMessageUser(content=TASK),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Reproduction of meridianlabs-ai/inspect_ai#140
 # ---------------------------------------------------------------------------
@@ -577,6 +585,148 @@ async def test_title_call_then_multi_turn_main_loop() -> None:
 
     assert bridge.state.output.completion == "Castle"
     assert len(bridge.state.messages) == len(turn3) + 1
+
+
+async def test_contained_main_recovers_after_exact_one_shot_displacement() -> None:
+    """Continuing a displaced main call promotes its preserved candidate."""
+    bridge = task_bridge()
+    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
+    main1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content=decorated_task),
+    ]
+
+    main1_output = await track(bridge, main1, "I will look into that.")
+
+    # This exact prompt copy temporarily wins over the decorated main call.
+    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9 setting")
+
+    main2 = main1 + [
+        main1_output.message,
+        ChatMessageTool(content="search results"),
+    ]
+    await track(bridge, main2, "Castle")
+
+    expected_messages = [
+        TASK_SYSTEM.text,
+        decorated_task,
+        "I will look into that.",
+        "search results",
+        "Castle",
+    ]
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == expected_messages
+
+    # A trailing one-shot must not steal the recovered, multi-call main loop.
+    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9")
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == expected_messages
+
+
+async def test_contained_main_recovers_when_exact_one_shot_arrives_first() -> None:
+    """The reverse call order retains ordinary candidate-promotion recovery."""
+    bridge = task_bridge()
+    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
+    main1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content=decorated_task),
+    ]
+
+    await track(bridge, exact_title_generation_input(), "Doctor Who Series 9 setting")
+    main1_output = await track(bridge, main1, "I will look into that.")
+
+    main2 = main1 + [
+        main1_output.message,
+        ChatMessageTool(content="search results"),
+    ]
+    await track(bridge, main2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        decorated_task,
+        "I will look into that.",
+        "search results",
+        "Castle",
+    ]
+
+
+async def test_contained_main_recovers_after_promoted_sub_agent_loop() -> None:
+    """A promoted sub-agent keeps the displaced main loop as a candidate."""
+    bridge = task_bridge()
+    decorated_task = f"## Task\n\n{TASK}\n\nRespond concisely."
+    main1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content=decorated_task),
+    ]
+    main1_output = await track(bridge, main1, "I will look into that.")
+
+    sub1: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a subtask agent ..."),
+        ChatMessageUser(content="Research Doctor Who series 9 filming locations."),
+    ]
+    sub1_output = await track(bridge, sub1, "researching")
+    sub2 = sub1 + [
+        sub1_output.message,
+        ChatMessageTool(content="search results"),
+    ]
+    await track(bridge, sub2, "Cardiff Castle")
+
+    main2 = main1 + [
+        main1_output.message,
+        ChatMessageTool(content="subtask: Cardiff Castle"),
+    ]
+    await track(bridge, main2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        decorated_task,
+        "I will look into that.",
+        "subtask: Cardiff Castle",
+        "Castle",
+    ]
+
+
+async def test_main_recovers_after_legacy_length_displacement() -> None:
+    """A legacy-length side-call displacement preserves the main candidate.
+
+    With no descent anchor, the one-shot's six messages displace the primary's
+    three by previous-call length. Its five-message continuation is shorter
+    than that side call, so candidate promotion is its only recovery path.
+    """
+    bridge = AgentBridge(AgentState(messages=[]))
+    main1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    main1_output = await track(bridge, main1, "I will look into that.")
+
+    # With no initial input every thread descends as None, so this six-message
+    # one-shot takes the legacy previous-call length path.
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Create a title."),
+            ChatMessageUser(content="Return only the title."),
+            ChatMessageUser(content="Do not use punctuation."),
+            ChatMessageUser(content="Keep it concise."),
+        ],
+        "Doctor Who Series 9 setting",
+    )
+
+    main2 = main1 + [
+        main1_output.message,
+        ChatMessageTool(content="search results"),
+    ]
+    await track(bridge, main2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert [message.text for message in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "I will look into that.",
+        "search results",
+        "Castle",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -5,7 +5,7 @@ can remain outside the canonical conversation.
 """
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 from test_helpers.checkpoint import RecordingCheckpointer
@@ -14,7 +14,7 @@ from inspect_ai._util.hash import mm3_hash
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
 from inspect_ai.agent._bridge.completions import inspect_completions_api_request
-from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.types import AgentBridge, _Descent, _MessageFingerprint
 from inspect_ai.agent._bridge.util import (
     default_code_execution_providers,
     internal_web_search_providers,
@@ -1549,6 +1549,80 @@ async def test_anthropic_handler_tracks_main_thread_end_to_end() -> None:
     ]
 
 
+# ---------------------------------------------------------------------------
+# State filters
+# ---------------------------------------------------------------------------
+
+
+class BridgeTrackingSnapshot(NamedTuple):
+    """Snapshot of `AgentBridge`'s private thread-tracking attributes."""
+
+    tracked_fps: list[_MessageFingerprint] | None
+    tracked_calls: int
+    tracked_descends: _Descent | None
+    last_message_count: int
+    candidate_fps: list[_MessageFingerprint] | None
+
+
+def snapshot_tracking(bridge: AgentBridge) -> BridgeTrackingSnapshot:
+    """Capture `bridge`'s private thread-tracking attributes."""
+    return BridgeTrackingSnapshot(
+        tracked_fps=bridge._tracked_fps,
+        tracked_calls=bridge._tracked_calls,
+        tracked_descends=bridge._tracked_descends,
+        last_message_count=bridge._last_message_count,
+        candidate_fps=bridge._candidate_fps,
+    )
+
+
+def assert_tracking_unchanged(
+    bridge: AgentBridge, before: BridgeTrackingSnapshot
+) -> None:
+    """Assert an excluded request left `bridge`'s thread-tracking state untouched."""
+    assert bridge._tracked_fps == before.tracked_fps
+    assert bridge._tracked_calls == before.tracked_calls
+    assert bridge._tracked_descends == before.tracked_descends
+    assert bridge._last_message_count == before.last_message_count
+    assert bridge._candidate_fps == before.candidate_fps
+
+
+def assert_request_accounting(
+    events: RecordingModelEvents,
+    checkpointer: RecordingCheckpointer,
+    *,
+    completions: list[str],
+    ticks: int,
+    responses: Sequence[Any] | None = None,
+    check_event_ids: bool = False,
+) -> None:
+    """Assert one pending/completed event pair with usage per completion.
+
+    When `responses` is given, also assert each response carries a unique,
+    non-empty id and usage matching `completions`. When `check_event_ids`
+    is set, assert the same uniqueness for the underlying event uuids.
+    """
+    assert len(events.pending) == len(events.completed) == len(completions)
+    assert [event.output.completion for event in events.completed] == completions
+    assert all(event.output.usage is not None for event in events.completed)
+    assert [
+        event.output.usage.total_tokens if event.output.usage is not None else None
+        for event in events.completed
+    ] == [1] * len(completions)
+    if check_event_ids:
+        event_ids = [event.uuid for event in events.completed]
+        assert all(event_ids)
+        assert len(set(event_ids)) == len(completions)
+    if responses is not None:
+        response_ids = [response.id for response in responses]
+        assert all(response_ids)
+        assert len(set(response_ids)) == len(responses)
+        assert [
+            response.usage.total_tokens if response.usage is not None else None
+            for response in responses
+        ] == [1] * len(responses)
+    assert checkpointer.ticks == ticks
+
+
 @pytest.mark.parametrize("main_first", [True, False])
 async def test_state_filter_preserves_main_state_and_excluded_request_accounting(
     main_first: bool,
@@ -1623,20 +1697,12 @@ async def test_state_filter_preserves_main_state_and_excluded_request_accounting
         TASK,
         "Castle",
     ]
-    tracked_fps = bridge._tracked_fps
-    tracked_calls = bridge._tracked_calls
-    tracked_descends = bridge._tracked_descends
-    last_message_count = bridge._last_message_count
-    candidate_fps = bridge._candidate_fps
+    tracking = snapshot_tracking(bridge)
 
     await request(unrelated)
 
     assert bridge.state.output.completion == "Castle"
-    assert bridge._tracked_fps == tracked_fps
-    assert bridge._tracked_calls == tracked_calls
-    assert bridge._tracked_descends == tracked_descends
-    assert bridge._last_message_count == last_message_count
-    assert bridge._candidate_fps == candidate_fps
+    assert_tracking_unchanged(bridge, tracking)
 
     await request(
         main
@@ -1655,24 +1721,14 @@ async def test_state_filter_preserves_main_state_and_excluded_request_accounting
         "Castle after search",
     ]
     assert all(message.id is not None for message in bridge.state.messages[:-1])
-    assert len(events.pending) == len(events.completed) == 4
-    assert [event.output.completion for event in events.completed] == completions
-    assert all(event.output.usage is not None for event in events.completed)
-    assert [
-        event.output.usage.total_tokens if event.output.usage is not None else None
-        for event in events.completed
-    ] == [1, 1, 1, 1]
-    response_ids = [response.id for response in responses]
-    assert all(response_ids)
-    assert len(set(response_ids)) == 4
-    event_ids = [event.uuid for event in events.completed]
-    assert all(event_ids)
-    assert len(set(event_ids)) == 4
-    assert [
-        response.usage.total_tokens if response.usage is not None else None
-        for response in responses
-    ] == [1, 1, 1, 1]
-    assert checkpointer.ticks == 4
+    assert_request_accounting(
+        events,
+        checkpointer,
+        completions=completions,
+        ticks=4,
+        responses=responses,
+        check_event_ids=True,
+    )
 
 
 @pytest.mark.parametrize("include", [True, False])
@@ -1739,11 +1795,7 @@ async def test_excluded_operator_provenance_survives_checkpoint_resume() -> None
     resumed = AgentBridge(
         AgentState(messages=[ChatMessageUser(content=TASK)]),
         model_aliases={BRIDGE_MODEL: scenario_model(["Castle"])},
-        checkpointer=RecordingCheckpointer(
-            restored={
-                key: callback() for key, callback in checkpointer.callbacks.items()
-            }
-        ),
+        checkpointer=RecordingCheckpointer(restored=checkpointer.snapshot()),
         state_filter=lambda request: any(
             message.source == "operator" for message in request
         ),
@@ -1841,11 +1893,7 @@ async def test_state_filter_rejects_exact_main_extension_without_state_mutation(
         {"role": "user", "content": TASK},
     ]
     first_response = await request(main)
-    tracked_fps = bridge._tracked_fps
-    tracked_calls = bridge._tracked_calls
-    tracked_descends = bridge._tracked_descends
-    last_message_count = bridge._last_message_count
-    candidate_fps = bridge._candidate_fps
+    tracking = snapshot_tracking(bridge)
 
     continuation_response = await request(
         main
@@ -1863,29 +1911,14 @@ async def test_state_filter_rejects_exact_main_extension_without_state_mutation(
         TASK,
         "Castle",
     ]
-    assert bridge._tracked_fps == tracked_fps
-    assert bridge._tracked_calls == tracked_calls
-    assert bridge._tracked_descends == tracked_descends
-    assert bridge._last_message_count == last_message_count
-    assert bridge._candidate_fps == candidate_fps
-    assert len(events.pending) == len(events.completed) == 2
-    assert [event.output.completion for event in events.completed] == [
-        "Castle",
-        "Ignored continuation",
-    ]
-    assert all(event.output.usage is not None for event in events.completed)
-    assert [
-        event.output.usage.total_tokens if event.output.usage is not None else None
-        for event in events.completed
-    ] == [1, 1]
-    assert first_response.id
-    assert continuation_response.id
-    assert first_response.id != continuation_response.id
-    assert [
-        response.usage.total_tokens if response.usage is not None else None
-        for response in [first_response, continuation_response]
-    ] == [1, 1]
-    assert checkpointer.ticks == 2
+    assert_tracking_unchanged(bridge, tracking)
+    assert_request_accounting(
+        events,
+        checkpointer,
+        completions=["Castle", "Ignored continuation"],
+        ticks=2,
+        responses=[first_response, continuation_response],
+    )
 
 
 async def test_state_filter_error_on_main_extension_preserves_state() -> None:
@@ -1915,11 +1948,7 @@ async def test_state_filter_error_on_main_extension_preserves_state() -> None:
     first_response = await inspect_completions_api_request(
         {"model": BRIDGE_MODEL, "messages": main}, None, bridge
     )
-    tracked_fps = bridge._tracked_fps
-    tracked_calls = bridge._tracked_calls
-    tracked_descends = bridge._tracked_descends
-    last_message_count = bridge._last_message_count
-    candidate_fps = bridge._candidate_fps
+    tracking = snapshot_tracking(bridge)
 
     with pytest.raises(RuntimeError, match="state filter rejected main continuation"):
         await inspect_completions_api_request(
@@ -1942,22 +1971,14 @@ async def test_state_filter_error_on_main_extension_preserves_state() -> None:
         TASK,
         "Castle",
     ]
-    assert bridge._tracked_fps == tracked_fps
-    assert bridge._tracked_calls == tracked_calls
-    assert bridge._tracked_descends == tracked_descends
-    assert bridge._last_message_count == last_message_count
-    assert bridge._candidate_fps == candidate_fps
-    assert len(events.pending) == len(events.completed) == 1
-    assert [event.output.completion for event in events.completed] == [
-        "Castle",
-    ]
-    assert all(event.output.usage is not None for event in events.completed)
-    assert [
-        event.output.usage.total_tokens if event.output.usage is not None else None
-        for event in events.completed
-    ] == [1]
+    assert_tracking_unchanged(bridge, tracking)
     # A predicate failure stops the request before generation and checkpointing.
-    assert checkpointer.ticks == 1
+    assert_request_accounting(
+        events,
+        checkpointer,
+        completions=["Castle"],
+        ticks=1,
+    )
 
 
 async def test_state_filter_excludes_requests_from_compaction_history() -> None:

--- a/tests/agent/test_sandbox_agent_bridge_media.py
+++ b/tests/agent/test_sandbox_agent_bridge_media.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -7,10 +8,10 @@ import pytest
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import Task, eval
-from inspect_ai.agent import sandbox_agent_bridge
+from inspect_ai.agent import StateFilter, sandbox_agent_bridge
 from inspect_ai.dataset import Sample
-from inspect_ai.model import GenerateConfig, get_model
-from inspect_ai.solver import Solver, solver
+from inspect_ai.model import ChatMessage, GenerateConfig, ModelOutput, get_model
+from inspect_ai.solver import Generate, Solver, TaskState, solver
 from inspect_ai.util import sandbox
 
 
@@ -107,3 +108,79 @@ def test_sandbox_bridge_cannot_read_host_media(tmp_path: Path) -> None:
         assert secret_bytes.decode() not in serialized_requests
     finally:
         asyncio.run(target_model.api.aclose())
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_sandbox_agent_bridge_forwards_state_filter(tmp_path: Path) -> None:
+    """Filtered requests respond normally without replacing canonical state."""
+
+    def accepts_main(messages: Sequence[ChatMessage]) -> bool:
+        return messages[-1].text != "auxiliary"
+
+    state_filter: StateFilter = accepts_main
+
+    @solver
+    def bridge_solver() -> Solver:
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            async with sandbox_agent_bridge(state_filter=state_filter) as bridge:
+                requests = [
+                    [{"role": "user", "content": "test"}],
+                    [
+                        {"role": "user", "content": "test"},
+                        {"role": "assistant", "content": "retained reply"},
+                        {"role": "user", "content": "auxiliary"},
+                    ],
+                ]
+                script = (
+                    "import json, urllib.error, urllib.request\n"
+                    "responses = []\n"
+                    f"for messages in {requests!r}:\n"
+                    "    request = urllib.request.Request(\n"
+                    f"        'http://127.0.0.1:{bridge.port}/v1/chat/completions',\n"
+                    "        data=json.dumps({'model': 'inspect', 'messages': messages}).encode(),\n"
+                    "        headers={'Content-Type': 'application/json'},\n"
+                    "    )\n"
+                    "    try:\n"
+                    "        with urllib.request.urlopen(request, timeout=30) as response:\n"
+                    "            responses.append(json.load(response))\n"
+                    "    except urllib.error.HTTPError as ex:\n"
+                    "        raise RuntimeError(ex.read().decode()) from ex\n"
+                    "print(json.dumps(responses))\n"
+                )
+                result = await sandbox().exec(["python3", "-c", script], timeout=60)
+                assert result.success, result.stderr
+                state.metadata["responses"] = json.loads(result.stdout)
+                state.messages = bridge.state.messages
+                state.output = bridge.state.output
+            return state
+
+        return solve
+
+    logs = eval(
+        Task(
+            dataset=[Sample(id="sample", input="test")],
+            solver=bridge_solver(),
+            sandbox="docker",
+        ),
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content(model="mockllm/model", content=reply)
+                for reply in ("retained reply", "auxiliary reply")
+            ],
+            memoize=False,
+        ),
+        display="none",
+        log_dir=str(tmp_path / "logs"),
+    )
+
+    assert logs[0].status == "success", logs[0].error
+    assert logs[0].samples is not None
+    sample = logs[0].samples[0]
+    assert [
+        response["choices"][0]["message"]["content"]
+        for response in sample.metadata["responses"]
+    ] == ["retained reply", "auxiliary reply"]
+    assert [message.text for message in sample.messages] == ["test", "retained reply"]
+    assert sample.output.completion == "retained reply"

--- a/tests/test_helpers/checkpoint.py
+++ b/tests/test_helpers/checkpoint.py
@@ -18,15 +18,16 @@ class RecordingCheckpointer:
     """Minimal in-memory `Checkpointer` for tests.
 
     Records the callbacks registered via `track()` so a test can fire a
-    snapshot on demand (`cp.callbacks[key]()`), and optionally seeds
-    `restored` state to simulate a resume. All lifecycle methods are inert,
-    so it exercises agent/handler wiring without the real checkpointer's
-    restic/transcript machinery.
+    snapshot on demand (`cp.callbacks[key]()`), counts ticks, and optionally
+    seeds `restored` state to simulate a resume. All other lifecycle methods
+    are inert, so it exercises agent/handler wiring without the real
+    checkpointer's restic/transcript machinery.
     """
 
     def __init__(self, restored: dict[str, object] | None = None) -> None:
         self._restored = restored or {}
         self.callbacks: dict[str, Callable[[], object]] = {}
+        self.ticks = 0
 
     @property
     def attempt(self) -> Literal["initial", "resume", "resume_for_scoring"]:
@@ -39,7 +40,7 @@ class RecordingCheckpointer:
         return None
 
     async def tick(self) -> None:
-        return None
+        self.ticks += 1
 
     async def checkpoint(self) -> None:
         return None

--- a/tests/test_helpers/checkpoint.py
+++ b/tests/test_helpers/checkpoint.py
@@ -4,6 +4,9 @@ import contextlib
 from collections.abc import AsyncIterator, Callable
 from typing import Literal, TypeVar
 
+from pydantic import BaseModel, TypeAdapter
+from pydantic_core import to_jsonable_python
+
 from inspect_ai.util import ResumeReport
 
 T = TypeVar("T")
@@ -22,6 +25,10 @@ class RecordingCheckpointer:
     seeds `restored` state to simulate a resume. All other lifecycle methods
     are inert, so it exercises agent/handler wiring without the real
     checkpointer's restic/transcript machinery.
+
+    By default, `restored` values are live objects handed back as-is (a
+    fast in-memory path). To exercise the same lossy JSON round-trip a real
+    resume goes through, seed `restored` from `snapshot()` instead.
     """
 
     def __init__(self, restored: dict[str, object] | None = None) -> None:
@@ -48,6 +55,20 @@ class RecordingCheckpointer:
     def span_session(self) -> contextlib.AbstractAsyncContextManager[None]:
         return _noop_span()
 
+    def snapshot(self) -> dict[str, object]:
+        """Serialize every tracked value as the production checkpointer does at fire time.
+
+        Mirrors `CheckpointerImpl`'s write path
+        (`pydantic_core.to_jsonable_python`), so seeding a resumed
+        `RecordingCheckpointer`'s `restored` from this crosses the same
+        lossy JSON containers a real checkpoint file does (e.g. `set[str]`
+        becomes a `list[str]`).
+        """
+        return {
+            key: to_jsonable_python(callback())
+            for key, callback in self.callbacks.items()
+        }
+
     def track(
         self,
         key: str,
@@ -59,9 +80,14 @@ class RecordingCheckpointer:
         self.callbacks[key] = callback
         if key not in self._restored:
             return initial_value
-        restored = self._restored[key]
-        assert isinstance(restored, type(initial_value)), (
-            f"restored {key!r} is {type(restored).__name__}, "
+        raw = self._restored[key]
+        if value_type is not None:
+            return TypeAdapter(value_type).validate_python(raw)
+        if isinstance(initial_value, BaseModel):
+            model: T = type(initial_value).model_validate(raw)
+            return model
+        assert isinstance(raw, type(initial_value)), (
+            f"restored {key!r} is {type(raw).__name__}, "
             f"expected {type(initial_value).__name__}"
         )
-        return restored
+        return raw


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

An agent can send task and auxiliary requests through the same bridge. Core's conversation heuristics cannot always identify which requests the caller intends to retain in `AgentState`, even when the native client provides an explicit conversation identity.

### What is the new behavior?

`AgentBridge`, `agent_bridge()`, and `sandbox_agent_bridge()` accept an optional `state_filter`. It runs once on translated messages, after operator provenance restoration but before generation and compaction. Excluded requests still return responses, receive IDs, emit model events and usage, and tick the checkpointer, without entering canonical state or compaction history. Recognized operator provenance survives checkpoint resume, including after excluded requests. Predicate exceptions propagate before generation.

`StateFilter` is publicly importable. Omitting it preserves the existing arbitration policy. No native-client heuristics, extra conversation buffers, or output rewriting are added.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The new argument is optional and defaults to `None`.

### Other information:

This is distinct from #4890's model-identity selection and #4766's accumulation of multiple conversations. It supplies eligibility rather than changing arbitration.

### Verification

The author exercised `agent_bridge()` through the OpenAI Chat Completions and Responses SDKs, Anthropic SDK, and Google GenAI SDK, with deterministic model responses and compaction enabled. Every dialect returned the task answer, auxiliary title, and continuation; canonical state retained only the task conversation, all three model events and usage were recorded, and the auxiliary request did not enter the continuation's compaction input. These checks exercise the SDK-to-bridge path, not live provider services.

- Targeted bridge, approval, generation-config, and operator-provenance suites: 252 passed, 145 skipped (opposite async backend, slow, or provider-dependent cases).
- Three new operator-provenance cases failed before the fix: selection, excluded-event provenance, and checkpoint resume. All pass after restoration was moved before selection and recognized provenance was checkpointed.
- `make check`: Ruff passed; mypy checked 1,458 source files; suppression ledger matched.

### Slow tests

The public sandbox context manager was exercised in real Docker using the locally built sandbox-tools executable:

`uv run --no-sync pytest tests/agent/test_sandbox_agent_bridge_media.py::test_sandbox_agent_bridge_forwards_state_filter --runslow -q`

Result: 1 passed. Accepted and excluded requests returned normally without auxiliary content replacing canonical state. An earlier negative control disabling the predicate made this case fail; the temporary mutation was removed.

### Agent review

Authored with AI assistance in Oh My Pi. Independent reviews covered completeness, the public API, correctness, and simplification. The latest correctness pass identified operator-provenance ordering and resume loss; both were reproduced and repaired. The API and simplification passes found no remaining actionable findings.
