### PR TITLE
Fix Krippendorff reference docstring indentation

### DIFF
--- a/src/inspect_ai/scorer/_metrics/krippendorff.py
+++ b/src/inspect_ai/scorer/_metrics/krippendorff.py
@@ -42,22 +42,22 @@ def krippendorff_alpha(
 
     Args:
        level: Measurement scale.
-         `"nominal"` (default) treats ratings as unordered categories
-         (any difference is a full disagreement). Use for
-         correct/incorrect labels and unordered category IDs.
-         `"ordinal"` treats ratings as ordered categories whose gaps
-         are not assumed equal; δ² is weighted by the marginal
-         frequency of intermediate ranks (Krippendorff 2007). Use for
-         Likert-style ratings.
-         `"interval"` treats ratings as numbers on an equal-interval
-         scale; δ² is the squared numeric difference. Use for
-         continuous scores.
+          `"nominal"` (default) treats ratings as unordered categories
+          (any difference is a full disagreement). Use for
+          correct/incorrect labels and unordered category IDs.
+          `"ordinal"` treats ratings as ordered categories whose gaps
+          are not assumed equal; δ² is weighted by the marginal
+          frequency of intermediate ranks (Krippendorff 2007). Use for
+          Likert-style ratings.
+          `"interval"` treats ratings as numbers on an equal-interval
+          scale; δ² is the squared numeric difference. Use for
+          continuous scores.
        to_float: Optional `ValueToFloat` used to coerce non-numeric
-         ratings to floats for `"ordinal"` and `"interval"` (e.g.,
-         `value_to_float()` to map CORRECT/INCORRECT/PARTIAL/NOANSWER
-         to 1/0/0.5/0). Numeric ratings need no coercion. Raises if
-         `"ordinal"` or `"interval"` is selected with non-numeric
-         ratings and no `to_float`. Ignored for `"nominal"`.
+          ratings to floats for `"ordinal"` and `"interval"` (e.g.,
+          `value_to_float()` to map CORRECT/INCORRECT/PARTIAL/NOANSWER
+          to 1/0/0.5/0). Numeric ratings need no coercion. Raises if
+          `"ordinal"` or `"interval"` is selected with non-numeric
+          ratings and no `to_float`. Ignored for `"nominal"`.
 
     Returns:
        Krippendorff's α as a float, or `nan` when there are no usable


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Generating reference docs emits 15 “Confusing indentation for continuation line” warnings from `krippendorff_alpha()`. Its parameter descriptions use five spaces relative to the docstring margin, while the Google docstring parser expects six.

### What is the new behavior?

Indent those continuation lines by one additional space. Griffe parses both complete parameter descriptions without warnings. The change is whitespace-only within the docstring.

### Does this PR introduce a breaking change?

No.

### Other information:

Authored with Codex.

Validation:
- Reproduced all 15 warnings before the fix; verified zero warnings and complete parameter descriptions afterward using Griffe's Google docstring parser.
- All applicable pre-commit hooks, `make suppressions-check`, and `git diff --check` passed.
- `make check`: lint and formatting passed; mypy reports two existing `arg-type` errors in `_chat_message.py:59` and `_log.py:666`. Confirmed the same errors on unchanged `main`.
- `make test` (with `PYTEST_ADDOPTS='-x --tb=short --color=no'`): 11,583 passed, 5,030 skipped, 33 warnings.
- All CI checks passed, including both Python test jobs and both mypy jobs.

### Agent review

No independent review pass was run for this docstring whitespace fix. Verified that `git diff -w` is empty.

### Slow tests

No gated slow, API, flaky, or trio tests were enabled for this documentation-only change.
