### PR TITLE
Stop logging every OpenAI and Anthropic request at --log-level info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Inspect View: Cancelling or failing an S3 log download no longer eventually stops the view server from serving any S3 logs.
 - Inspect View: Downloading a log whose name contains non-Latin-1 characters no longer fails.
 - Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
+- Logging: `--log-level info` no longer prints a line for every OpenAI and Anthropic HTTP request.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/_util/logger.py
+++ b/src/inspect_ai/_util/logger.py
@@ -221,6 +221,7 @@ def init_logger(
             # this is a bit aggressive and we already do this at
             # our own HTTP level
             getLogger("httpx").setLevel(WARNING)
+            getLogger("httpx2").setLevel(WARNING)
 
         # set the log level for our package and inspect_ai
         def configure_logger(pkg: str) -> None:


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

Running with `--log-level info` prints an HTTP request line for every OpenAI and Anthropic call. `init_logger` sets a WARNING floor on the `httpx` logger to suppress exactly this, but those SDKs now use httpx2, which logs under its own `httpx2` logger name.

### What is the new behavior?

`httpx2` gets the same WARNING floor, so those per-request lines are suppressed as before.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

#### Agent review
- Author: Claude Opus 5 (Claude Code). No separate review pass was run — the change is a single line mirroring the adjacent `httpx` call.