### PR TITLE
ci-perf skill: stop re-boarding closed and deferred findings, describe the live workflow inputs, narrow the human-only flag

### DIFF
--- a/.agents/skills/ci-perf/SKILL.md
+++ b/.agents/skills/ci-perf/SKILL.md
@@ -116,9 +116,10 @@ Write `$CI_PERF_OUTPUT_DIR/findings.json` as a JSON list, at most five items:
 ]
 ```
 
-Set `human_implementation` to true only when the only proposed change requires
-a human (for example workflow edits or node/pnpm work). The publisher records
-that need and omits the automation label. Otherwise set it to false.
+Set `human_implementation` to true only when the proposed change edits files
+under `.github/workflows/` or requires node or pnpm (builds, type generation,
+ts-mono). Python-only changes, including this skill's own scripts and tests,
+are false. The publisher records that need and omits the automation label.
 
 When reusing an issue, copy its current title exactly into `title`; the publisher
 checks it before adding evidence or a trigger. Do not put automation mentions

--- a/.agents/skills/ci-perf/scripts/publish_ci_findings.py
+++ b/.agents/skills/ci-perf/scripts/publish_ci_findings.py
@@ -158,6 +158,7 @@ def publish(
 
     The workflow serializes runs. Markers make retries skip completed writes.
     Closed findings are left closed, and deferred findings are left untouched.
+    Returns the URLs of the open, non-deferred finding issues only.
     """
     match = re.fullmatch(
         r"https://github.com/meridianlabs-ai/actions/actions/runs/(\d+)", run_url
@@ -176,6 +177,7 @@ def publish(
     known = issues()
     tracking = tracking_issue(known)
     urls = []
+    active_urls = []
     findings_complete = False
     try:
         for finding in findings:
@@ -211,6 +213,7 @@ def publish(
                 label["name"] == "deferred" for label in issue.get("labels", [])
             ):
                 continue
+            active_urls.append(issue["html_url"])
             existing = comments(number)
             if evidence_marker not in (issue.get("body") or "") and not any(
                 evidence_marker in comment["body"] for comment in existing
@@ -264,7 +267,7 @@ def publish(
             if not findings_complete:
                 links += "\n\nFinding publication failed; see the workflow run for the error."
             api(f"issues/{number}/comments", {"body": summary_body + links})
-    return urls
+    return active_urls
 
 
 def main() -> None:

--- a/.agents/skills/ci-perf/scripts/test_ci_perf.py
+++ b/.agents/skills/ci-perf/scripts/test_ci_perf.py
@@ -250,6 +250,56 @@ def test_closed_and_deferred_findings_are_not_retriggered(
     )
 
 
+def test_only_open_non_deferred_issues_are_returned(
+    snapshot: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    issues_by_number = {
+        1: {"state": "open", "labels": []},
+        2: {"state": "closed", "labels": []},
+        3: {"state": "open", "labels": [{"name": "deferred"}]},
+    }
+    writes: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(publisher, "issues", lambda: [])
+    monkeypatch.setattr(publisher, "tracking_issue", lambda known=None: {"number": 8})
+    monkeypatch.setattr(publisher, "comments", lambda number: [])
+    monkeypatch.setattr(
+        publisher,
+        "gh",
+        lambda *args: {
+            "number": int(args[1].rsplit("/", 1)[1]),
+            "html_url": f"https://github.com/meridianlabs-ai/inspect_ai/issues/{args[1].rsplit('/', 1)[1]}",
+            "title": "Slow job",
+            **issues_by_number[int(args[1].rsplit("/", 1)[1])],
+        },
+    )
+    monkeypatch.setattr(
+        publisher, "api", lambda path, fields: writes.append((path, fields))
+    )
+    urls = publish(
+        [
+            {
+                "key": f"slow-job-{number}",
+                "title": "Slow job",
+                "body": "Evidence",
+                "existing_issue": number,
+            }
+            for number in issues_by_number
+        ],
+        summarize(snapshot),
+        "Report",
+        "https://github.com/meridianlabs-ai/actions/actions/runs/123",
+    )
+    assert urls == ["https://github.com/meridianlabs-ai/inspect_ai/issues/1"]
+    tracking_comment = next(
+        fields["body"] for path, fields in writes if path == "issues/8/comments"
+    )
+    for number in issues_by_number:
+        assert (
+            f"https://github.com/meridianlabs-ai/inspect_ai/issues/{number}"
+            in tracking_comment
+        )
+
+
 @pytest.mark.parametrize("title", ["Slow job", "Unrelated issue"])
 def test_existing_issue_identity_and_empty_body(
     title: str, snapshot: dict[str, Any], monkeypatch: pytest.MonkeyPatch

--- a/design/ci-perf/README.md
+++ b/design/ci-perf/README.md
@@ -43,11 +43,13 @@ queue time. Workflow wall uses updated_at, not push-to-all-checks-green. Pytest
 outcomes are per job, and unavailable logs are missing observations.
 
 See [the CI skill](../../.claude/skills/ci-perf/SKILL.md) for collection,
-analysis, and issue publication. For a branch proof, dispatch the actions
-workflow with `dry_run=true`, `inspect_ai_ref=main`, and `ci_perf_ref` set to the
-fork's tooling branch. `ci_perf_ref` executes that branch's code; workflow
-dispatch requires collaborator write access. The dry-run creates only workflow
-outputs and artifacts.
+analysis, and issue publication. The actions workflow has two dispatch inputs:
+`inspect_ai_ref`, an upstream branch, tag, or commit (default `main`), and
+`dry_run` (default `true`). The skill's tooling and the analyzed source both
+come from that one upstream checkout. For a tooling branch proof, set
+`inspect_ai_ref` to an upstream branch or `refs/pull/NNN/head` with `dry_run=true`;
+workflow dispatch requires collaborator write access. A dry run creates only
+workflow outputs and artifacts.
 
 Analysis and publication run in one job. Their separation is between tokens:
 analysis uses the read-only workflow token, and publication uses the fork write


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Three loose ends in the ci-perf skill after #5318 and the actions workflow landed. The publisher writes every finding issue it touched to published.json, including closed issues and issues labeled deferred; the actions workflow adds each of those to the Atlas board and assigns it, so a closed or deferred finding gets re-boarded and re-assigned every time it recurs. design/ci-perf/README.md describes a workflow input the workflow does not have. SKILL.md's rule for the human_implementation flag let the first live run mark a Python-only finding as needing a human.

### What is the new behavior?

published.json lists only open finding issues without the deferred label; the trend comment on the tracking issue still links every observed issue. The README describes the workflow's two dispatch inputs, inspect_ai_ref and dry_run, and the single upstream checkout. SKILL.md sets human_implementation only for changes under .github/workflows/ or changes that need node or pnpm.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Skill tooling and docs only; no product code.

### Other information:

Tests: 39 passed in test_ci_perf.py run as the actions workflow runs it (`-c /dev/null`), including the new test covering open, closed, and deferred issues. ruff check, ruff format, and pre-commit (typos) pass on the changed files. No CHANGELOG entry: CI tooling, not product functionality.

### Slow tests

Not applicable. CI tooling and docs only; no provider, sandbox, tool, agent, or async code changes.

### Agent review

- Author: Claude in a fresh worker session under the coder bot.
- Reviewer: Claude Fable 5.1, fresh context, 1 pass on the diff with the tests run.
- Findings: 1 nit, fixed (README said "the branch"; the checkout is pinned to upstream, so it now says "an upstream branch"). No blocking or should-fix findings. The reviewer confirmed the returned list matches the open-and-not-deferred condition on every path, that the new test fails on the old code, and that the README matches the live workflow inputs.
