### PR TITLE
docs: change references from update plan to todo write

### DIFF
--- a/docs/_tools-standard.md
+++ b/docs/_tools-standard.md
@@ -11,7 +11,7 @@ Inspect has built-in tools for computing and agentic planning. Computing tools i
 Agentic tools include:
 
 -   [Skill](tools-standard.qmd#sec-skill) which provides agent skill specifications to the model with specialized knowledge and expertise for specific tasks (requires a [sandbox](sandboxing.qmd)).
--   [Update Plan](tools-standard.qmd#sec-update-plan) which helps the model tracks steps and progress across longer horizon tasks.
+-   [Todo Write](tools-standard.qmd#sec-todo-write) which helps the model tracks steps and progress across longer horizon tasks.
 -   [Memory](tools-standard.qmd#sec-memory) which enables storing and retrieving information through a memory file directory.
 -   [Think](tools-standard.qmd#sec-think), which provides models the ability to include an additional thinking step as part of getting to its final answer.
 -   [Intervention](tools-standard.qmd#sec-intervention), which enable the model to ask questions or send notifications to the user.


### PR DESCRIPTION
## This PR contains:
- [X] Docs

### What is the current behavior? (You can also link to an open issue here)

No open issue for this change; it is trivial.

The current tools documentation lists the "Update Plan" tool and references a non-existent anchor. #3773 introduced the "Todo Write" tool as part of the deepagent addition and updated the page content itself, but the index for this page was not updated. This renders on both the `/tools` and `/tools-standard` pages:

<img width="1023" height="235" alt="before" src="https://github.com/user-attachments/assets/303da455-d726-4a8f-a878-6aed91ac959b" />

### What is the new behavior?

The link text is updated to read "Todo Write" and the anchor reference is updated to match:

<img width="988" height="220" alt="after" src="https://github.com/user-attachments/assets/3588c12e-56a4-4c22-ac3c-4427180190b2" />

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

This PR does not introduce a breaking changes. This is a one-line documentation update.

### Other information:

I generated a local preview of the documentation with:

```bash
uv run quarto preview docs
```

and verified that it now renders and functions properly.