### PR TITLE
Fix Anthropic ignoring explicit api_key when ANTHROPIC_AUTH_TOKEN is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: Explicit API keys now take precedence over ambient ANTHROPIC_AUTH_TOKEN environment variables.
 - Compaction: summary compaction now produces a more detailed, structured summary that preserves code snippets, user messages, and any security-relevant constraints stated earlier in the conversation.
 - Control Channel: `inspect ctl sample cancel` now works on a sample that is still initializing (e.g. waiting on sandbox provisioning) — the cancel applies the moment the sample starts, and `inspect ctl sample list` marks the pending cancel.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -451,23 +451,23 @@ class AnthropicAPI(ModelAPI):
             )
         else:
             base_url = model_base_url(self.base_url, "ANTHROPIC_BASE_URL")
-            # Support OAuth Bearer auth via ANTHROPIC_AUTH_TOKEN. When set,
-            # create the client with auth_token= (sends Authorization: Bearer)
-            # instead of api_key= (sends X-Api-Key). The Anthropic API rejects
-            # requests that have both headers if the X-Api-Key is invalid, so
+            # Resolve credentials: an explicit api_key (constructor argument or
+            # credential hook) takes precedence over ambient environment variables.
+            # When no explicit api_key is set, support OAuth Bearer auth via
+            # ANTHROPIC_AUTH_TOKEN (sends Authorization: Bearer). The Anthropic API
+            # rejects requests that have both headers if X-Api-Key is invalid, so
             # we must use one or the other — not both.
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
-            if auth_token:
-                return AsyncAnthropic(
-                    base_url=base_url,
-                    auth_token=auth_token,
-                    default_headers={
-                        "anthropic-beta": "oauth-2025-04-20",
-                    },
-                    **model_args,
-                )
-            # resolve api_key
             if not self.api_key:
+                auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+                if auth_token:
+                    return AsyncAnthropic(
+                        base_url=base_url,
+                        auth_token=auth_token,
+                        default_headers={
+                            "anthropic-beta": "oauth-2025-04-20",
+                        },
+                        **model_args,
+                    )
                 self.api_key = os.environ.get(ANTHROPIC_API_KEY, None)
             if self.api_key is None:
                 raise environment_prerequisite_error("Anthropic", ANTHROPIC_API_KEY)

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -96,6 +96,36 @@ def test_anthropic_oauth_beta_preserved_with_effort() -> None:
             os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
 
 
+def test_anthropic_credential_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit api_key must take precedence over ambient ANTHROPIC_AUTH_TOKEN."""
+    # 1. Explicit api_key wins even if ANTHROPIC_AUTH_TOKEN and ANTHROPIC_API_KEY are set
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "ambient-token")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    api = AnthropicAPI(model_name="claude-sonnet-4-6", api_key="explicit-key")
+    assert getattr(api.client, "api_key", None) == "explicit-key"
+    assert getattr(api.client, "auth_token", None) is None
+
+    # 2. When no explicit api_key is supplied, ANTHROPIC_AUTH_TOKEN takes precedence over ANTHROPIC_API_KEY
+    api_token = AnthropicAPI(model_name="claude-sonnet-4-6")
+    assert getattr(api_token.client, "auth_token", None) == "ambient-token"
+    assert getattr(api_token.client, "api_key", None) is None
+
+    # 3. When neither explicit api_key nor ANTHROPIC_AUTH_TOKEN is present, ANTHROPIC_API_KEY is used
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    api_env_key = AnthropicAPI(model_name="claude-sonnet-4-6")
+    assert getattr(api_env_key.client, "api_key", None) == "ambient-key"
+    assert getattr(api_env_key.client, "auth_token", None) is None
+
+    # 4. Credential rotation / override via self.api_key takes precedence over ambient ANTHROPIC_AUTH_TOKEN
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "ambient-token")
+    api_hook = AnthropicAPI(model_name="claude-sonnet-4-6")
+    assert getattr(api_hook.client, "auth_token", None) == "ambient-token"
+    api_hook.api_key = "rotated-key"
+    api_hook.initialize()
+    assert getattr(api_hook.client, "api_key", None) == "rotated-key"
+    assert getattr(api_hook.client, "auth_token", None) is None
+
+
 def test_anthropic_extra_headers_not_mutated_across_calls() -> None:
     """Ensure per-call extra_headers are stable across repeated use."""
     api = AnthropicAPI(model_name="claude-sonnet-4-6", api_key="test-key")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5304.

When `ANTHROPIC_AUTH_TOKEN` is present in the environment (e.g. from Claude Code, OAuth, or ambient shell configurations), `AnthropicAPI._create_client()` unconditionally reads `ANTHROPIC_AUTH_TOKEN` and configures the client with `auth_token=...`, silently ignoring any explicitly passed `api_key` (via constructor argument, `--model-base-url/api-key`, task configs, or credential hooks).

This inverts the documented credential precedence of the `anthropic` SDK ("Explicit constructor arguments ... When any of these is passed, environment variables are not consulted for credentials") and prevents users with ambient OAuth tokens from executing evaluations against a specific Anthropic API key or rotating keys via hooks.

### What is the new behavior?

`AnthropicAPI._create_client()` now prioritizes an explicitly resolved `self.api_key` (from constructor arguments or credential hooks) before checking `ANTHROPIC_AUTH_TOKEN`.

- When an explicit `api_key` is supplied, `AsyncAnthropic` is initialized with `api_key=self.api_key` regardless of environment variables.
- When no explicit `api_key` is supplied, `ANTHROPIC_AUTH_TOKEN` is checked first for OAuth Bearer authentication.
- When neither an explicit key nor `ANTHROPIC_AUTH_TOKEN` is set, `ANTHROPIC_API_KEY` from the environment is used.
- When none are present, `PrerequisiteError` is raised as before.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Ambient OAuth workflows without an explicit `api_key` continue to work unchanged. Explicit API keys now take precedence as callers expect.

### Other information:

Submitted as a tested draft pending triage/acceptance of #5304.

Validation:
- Added `test_anthropic_credential_precedence` in `tests/model/providers/test_anthropic.py` covering:
  1. Explicit `api_key` precedence over `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY`.
  2. Fallback to `ANTHROPIC_AUTH_TOKEN` when no explicit `api_key` is provided.
  3. Fallback to `ANTHROPIC_API_KEY` when neither explicit key nor auth token is present.
  4. Credential rotation / override via `self.api_key` taking precedence over ambient auth tokens.
- `uv run pytest tests/model/providers/test_anthropic.py -k test_anthropic_credential_precedence`: passed.
- `uv run pytest tests/model/providers/test_anthropic.py -m "not slow"`: 184 passed, 72 skipped (live API / trio tests), 0 failed.
- `uv run make check`: passed (ruff, ruff format, inspect tool support, mypy across 1,458 source files, suppressions ledger check).

### Slow tests
No live Anthropic API calls were made (`--runapi` skipped). No Docker/sandbox or async plumbing changes were made.

### Agent review
- Author: Antigravity
- Reviewer: Antigravity (fresh context code inspection pass)
- Findings: 1 — initial draft inadvertently omitted `model_base_url` assignment, caught and fixed before committing. 0 dismissed findings.