### PR TITLE
Fix stray angle brackets and viewer leakage from double-wrapped content-internal tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI: Fixed double-wrapped content-internal tags in assistant messages leaving stray angle brackets in conversation history.
 - Compaction: summary compaction now produces a more detailed, structured summary that preserves code snippets, user messages, and any security-relevant constraints stated earlier in the conversation.
 - Control Channel: `inspect ctl sample cancel` now works on a sample that is still initializing (e.g. waiting on sandbox provisioning) — the cancel applies the moment the sample starts, and `inspect ctl sample list` marks the pending cancel.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -470,7 +470,7 @@ def openai_assistant_content(
             elif c.type == "text":
                 content = f"{content}\n{c.text}"
                 if c.internal is not None:
-                    content = f"{content}\n<{content_internal_tag(c.internal)}>\n"
+                    content = f"{content}\n{content_internal_tag(c.internal)}\n"
 
     return content, extra_body
 

--- a/tests/model/test_openai_chat_messages.py
+++ b/tests/model/test_openai_chat_messages.py
@@ -1,6 +1,13 @@
+import re
+
 import pytest
 
 from inspect_ai._util.content import ContentAudio, ContentReasoning, ContentText
+from inspect_ai.model._chat_message import ChatMessageAssistant
+from inspect_ai.model._internal import (
+    CONTENT_INTERNAL_TAG,
+    parse_content_with_internal,
+)
 from inspect_ai.model._openai import (
     messages_from_openai,
     messages_to_openai,
@@ -260,3 +267,31 @@ async def test_user_input_audio_is_normalized_to_data_uri():
 
     serialized = await openai_chat_completion_part(audio)
     assert serialized["input_audio"] == {"data": audio_data, "format": "mp3"}
+
+
+async def test_assistant_message_content_internal_round_trip() -> None:
+    """Ensure ContentText.internal is serialized with single tag and round-trips without stray brackets."""
+    m = ChatMessageAssistant(
+        content=[
+            ContentText(text="hello world", internal={"key": "val"}),
+        ]
+    )
+    openai_msgs = await messages_to_openai([m])
+    content = openai_msgs[0]["content"]
+    assert isinstance(content, str)
+    # Must NOT have double brackets <<content-internal>...</content-internal>>
+    assert "<<" not in content
+    assert ">>" not in content
+    assert "<content-internal>" in content
+    assert "</content-internal>" in content
+
+    # Parse back with parse_content_with_internal: text must be pristine without stray '<>'
+    cleaned, internal = parse_content_with_internal(content, CONTENT_INTERNAL_TAG)
+    assert cleaned == "hello world"
+    assert internal == {"key": "val"}
+
+    # Must also match the web viewer's regex anchor (trailing > in double-bracket would break this)
+    viewer_pattern = re.compile(
+        r"<content-internal>([A-Za-z0-9+/]+={0,2})</content-internal>\s*$"
+    )
+    assert viewer_pattern.search(content) is not None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5314.

In `src/inspect_ai/model/_openai.py:473`, `openai_assistant_content` wraps the return value of `content_internal_tag(c.internal)` in an extra pair of angle brackets:
```python
content = f"{content}\\n<{content_internal_tag(c.internal)}>\\n"
```
Because `content_internal_tag()` already returns `<content-internal>...</content-internal>`, the serialized wire content becomes `<<content-internal>...</content-internal>>`.

This causes two distinct user-visible issues:
1. When parsed back via `parse_content_with_internal()`, regex stripping leaves the outer brackets stranded as `<>` in the text (`'first\\n<>'`). Over multi-turn conversations through OpenAI or bridge endpoints, this repeatedly pollutes the prompt history seen by the model.
2. In the log viewer UI (`inspect view`), the stripping regex `/<content-internal>([A-Za-z0-9+/]+={0,2})<\\/content-internal>\\s*$/` fails to match due to the trailing `>`, so raw base64 data is displayed directly to the user in the transcript instead of being stripped.

### What is the new behavior?

Line 473 now emits `f"{content}\\n{content_internal_tag(c.internal)}\\n"`, matching the other call sites in `src/inspect_ai/model/_providers/anthropic.py` and `src/inspect_ai/agent/_bridge/responses_impl.py`.

- Outbound assistant text carries a single, well-formed `<content-internal>...</content-internal>` tag.
- `parse_content_with_internal()` completely strips the tag on round trip with zero residual `<>` in the conversation history.
- The viewer's end-of-string regex matches cleanly, preventing base64 tag leakage into the transcript view.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This eliminates stray `<>` characters in assistant message text and restores expected tag stripping.

### Other information:

Submitted as a tested draft pending triage/acceptance of #5314.

Validation:
- Added `test_assistant_message_content_internal_round_trip` in `tests/model/test_openai_chat_messages.py` verifying:
  1. Serialized OpenAI messages do not contain double brackets (`<<` / `>>`).
  2. Round-trip through `parse_content_with_internal()` leaves the original text pristine without stray `<>`.
  3. Wire text satisfies the web viewer's anchor pattern `/<content-internal>([A-Za-z0-9+/]+={0,2})<\\/content-internal>\\s*$/`.
- `uv run pytest tests/model/test_openai_chat_messages.py -v`: all 13 asyncio tests passed (13 trio variants skipped as expected).
- `uv run pytest tests/model/test_openai_chat_messages.py -k test_assistant_message_content_internal_round_trip --runtrio -v`: passed on trio backend.
- `uv run make check`: passed (ruff, ruff format, inspect tool support, mypy across 1,458 source files, suppressions ledger check).

### Slow tests
No live API or Docker tests were required. The change is isolated to OpenAI message serialization.

### Agent review
- Author: Antigravity
- Reviewer: Antigravity (fresh context code inspection pass)
- Findings: 0 open issues. Traced all call sites of `content_internal_tag` across the codebase and verified that `anthropic.py` and `responses_impl.py` already emit without extra brackets.