### PR TITLE
Fix timeline_filter() leaving excluded span types inside branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Eval Log: Reading zstd-compressed `.eval` files no longer fails with `AttributeError: ... '_needs_input'` on Python builds that include CPython's gh-156002 zipfile change.
 - Inspect View: Cancelling or failing an S3 log download no longer eventually stops the view server from serving any S3 logs.
 - Inspect View: Downloading a log whose name contains non-Latin-1 characters no longer fails.
+- Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -1369,10 +1369,10 @@ def timeline_filter(
 ) -> Timeline:
     """Return a new timeline with only spans matching the predicate.
 
-    Recursively walks the span tree, keeping ``TimelineSpan`` items
-    where ``predicate(span)`` returns ``True``. Non-matching spans and
-    their entire subtrees are pruned. ``TimelineEvent`` items are always
-    kept (they belong to the parent span).
+    Recursively walks span content and branches, keeping ``TimelineSpan``
+    items where ``predicate(span)`` returns ``True``. Non-matching spans and
+    their entire subtrees are pruned. ``TimelineEvent`` items are always kept
+    because they belong to the parent span.
 
     Use this to pre-filter a timeline before passing it to
     ``timeline_messages()``.
@@ -1396,7 +1396,7 @@ def _filter_span_by_predicate(
     span: TimelineSpan,
     predicate: Callable[[TimelineSpan], bool],
 ) -> TimelineSpan:
-    """Recursively filter a span's content, pruning non-matching child spans."""
+    """Recursively filter a span's content and branches."""
     filtered_content: list[TimelineEvent | TimelineSpan] = []
     for item in span.content:
         if isinstance(item, TimelineSpan):
@@ -1404,4 +1404,12 @@ def _filter_span_by_predicate(
                 filtered_content.append(_filter_span_by_predicate(item, predicate))
         else:
             filtered_content.append(item)
-    return span.model_copy(update={"content": filtered_content})
+
+    filtered_branches: list[TimelineSpan] = []
+    for branch in span.branches:
+        if predicate(branch):
+            filtered_branches.append(_filter_span_by_predicate(branch, predicate))
+
+    return span.model_copy(
+        update={"content": filtered_content, "branches": filtered_branches}
+    )

--- a/tests/timeline/test_timeline_branches.py
+++ b/tests/timeline/test_timeline_branches.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from inspect_ai.event import Event, timeline_build
+from inspect_ai.event import Event, Timeline, timeline_build, timeline_filter
 from inspect_ai.event._branch import BranchEvent
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
@@ -204,3 +204,104 @@ def test_branched_from_stores_message_id() -> None:
 
     assert len(agent.branches) == 1
     assert agent.branches[0].branched_from == "msg-B"
+
+
+def test_timeline_filter_prunes_scorer_branches_without_mutating_full_timeline() -> (
+    None
+):
+    """Scorer spans and descendants are removed from content and branch trees."""
+    full_timeline = Timeline(
+        name="full",
+        description="Complete task and scorer transcript",
+        root=TimelineSpan(
+            id="root",
+            name="root",
+            span_type="root",
+            content=[
+                TimelineSpan(
+                    id="target",
+                    name="target",
+                    span_type="agent",
+                    content=[
+                        TimelineSpan(
+                            id="content-scorer",
+                            name="content reviewer",
+                            span_type="scorers",
+                            content=[
+                                TimelineSpan(
+                                    id="content-reviewer",
+                                    name="reviewer",
+                                    span_type="agent",
+                                )
+                            ],
+                        ),
+                        TimelineSpan(
+                            id="agent-named-scorer",
+                            name="scorer",
+                            span_type="agent",
+                        ),
+                    ],
+                    branches=[
+                        TimelineSpan(
+                            id="scorer-branch",
+                            name="discarded scorer branch",
+                            span_type="scorers",
+                            content=[
+                                TimelineSpan(
+                                    id="branch-reviewer",
+                                    name="branch reviewer",
+                                    span_type="agent",
+                                )
+                            ],
+                        ),
+                        TimelineSpan(
+                            id="task-branch",
+                            name="task branch",
+                            span_type="branch",
+                            content=[
+                                TimelineSpan(
+                                    id="deep-parent",
+                                    name="deep task agent",
+                                    span_type="agent",
+                                    branches=[
+                                        TimelineSpan(
+                                            id="late-scorer",
+                                            name="late reviewer",
+                                            span_type="scorers",
+                                            content=[
+                                                TimelineSpan(
+                                                    id="late-reviewer",
+                                                    name="late reviewer child",
+                                                    span_type="agent",
+                                                )
+                                            ],
+                                        )
+                                    ],
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        ),
+    )
+    full_timeline_before_filtering = full_timeline.model_copy(deep=True)
+
+    judge_timeline = timeline_filter(
+        full_timeline, lambda span: span.span_type != "scorers"
+    )
+
+    for span_id in (
+        "content-scorer",
+        "content-reviewer",
+        "scorer-branch",
+        "branch-reviewer",
+        "late-scorer",
+        "late-reviewer",
+    ):
+        assert _find_span(judge_timeline.root, span_id) is None
+
+    for span_id in ("target", "agent-named-scorer", "task-branch", "deep-parent"):
+        assert _find_span(judge_timeline.root, span_id) is not None
+
+    assert full_timeline == full_timeline_before_filtering


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #5331

### What is the current behavior? (You can also link to an open issue here)

`timeline_filter()` recursively filters spans in `TimelineSpan.content`, but leaves excluded spans in `TimelineSpan.branches` unchanged. A caller that filters out a span type can therefore still receive that type inside a branch.

### What is the new behavior?

`timeline_filter()` now applies the predicate recursively to both content and branch spans. Excluded branch spans and their descendants are pruned, while the original timeline remains unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

A changelog entry under `## Unreleased` describes the corrected behavior. This fix has been running in trajectory-labs-pbc/inspect_ai since release/2026-09-07.

### Slow tests

This change is confined to `src/inspect_ai/event/_timeline.py`, a synchronous, in-memory Pydantic-model transform with no model-provider, sandbox, tool, agent, or async-plumbing surface — none of the categories that require a gated (`--runslow`/`--runapi`/`--runflaky`/`--runtrio`) run apply, so no gated class was run.

What did run, locally:
- `pytest tests/timeline/test_timeline_branches.py -q` → **4 passed** (includes the new branch-pruning test).
- `make check` (ruff + mypy across the full tree) → clean.
- `make suppressions-check` → ledger unchanged; this change adds no suppressions.

### Agent review
- Reviewer: openai/gpt-6-astra, fresh context, 1 pass.
- Findings: 1 — the changelog entry was under the released `0.3.262` heading; it is now under `## Unreleased`.
