### PR TITLE
Distinguish empty and unparseable multiple-choice answers from wrong ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
+- Scoring: `choice()` now tags empty completions as `NOANSWER` with `reason="no_response"` and records `reason="invalid_response_format"` when no choice can be parsed, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Approval: Policy files given as percent-encoded `file://` URIs (e.g. paths with spaces, as `Path.as_uri()` produces) are now accepted by `eval()`, `Task()`, and `--approval`.
 - Checkpoints: Invalidating a sample now re-runs it from scratch on retry (its checkpoints are discarded) instead of resuming from its last checkpoint.

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -5,7 +5,7 @@ from inspect_ai.solver._multiple_choice import (
 )
 from inspect_ai.solver._task_state import Choices, TaskState
 
-from ._metric import CORRECT, INCORRECT, Score
+from ._metric import CORRECT, INCORRECT, NOANSWER, Score
 from ._metrics import accuracy, stderr
 from ._scorer import Scorer, scorer
 from ._target import Target
@@ -103,8 +103,35 @@ def choice() -> Scorer:
 
         target_matches_choices = generated_selected_choices == sorted(target_positions)
 
+        if target_matches_choices:
+            return Score(
+                value=CORRECT,
+                answer=", ".join(answers),
+                explanation=explanation,
+            )
+
+        # The model left no usable answer. An empty completion means there
+        # is nothing to grade; any other completion without a selected
+        # choice means the model did not follow the requested ANSWER
+        # format. The sample stays in the denominator either way, but the
+        # reason lets analysis separate the two causes (see ScoreReason).
+        completion = state.output.completion or ""
+        if not completion.strip():
+            return Score(
+                value=NOANSWER,
+                answer="",
+                explanation=explanation,
+                reason="no_response",
+            )
+        if not generated_selected_choices:
+            return Score(
+                value=INCORRECT,
+                answer="",
+                explanation=explanation,
+                reason="invalid_response_format",
+            )
         return Score(
-            value=CORRECT if target_matches_choices else INCORRECT,
+            value=INCORRECT,
             answer=", ".join(answers),
             explanation=explanation,
         )

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -115,15 +115,17 @@ def choice() -> Scorer:
         # choice means the model did not follow the requested ANSWER
         # format. The sample stays in the denominator either way, but the
         # reason lets analysis separate the two causes (see ScoreReason).
-        completion = state.output.completion or ""
-        if not completion.strip():
-            return Score(
-                value=NOANSWER,
-                answer="",
-                explanation=explanation,
-                reason="no_response",
-            )
+        # These branches only run when no choice was selected: a marked
+        # choice keeps its answer even if the completion text is empty.
         if not generated_selected_choices:
+            completion = state.output.completion or ""
+            if not completion.strip():
+                return Score(
+                    value=NOANSWER,
+                    answer="",
+                    explanation=explanation,
+                    reason="no_response",
+                )
             return Score(
                 value=INCORRECT,
                 answer="",

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -309,6 +309,24 @@ async def test_score_selected_choices_carry_no_reason():
     assert result.reason is None
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("completion", ["", "   "])
+async def test_score_marked_choice_with_empty_completion_keeps_answer(
+    completion: str,
+):
+    scorer = choice()
+    state = simple_task_state(model_output=completion, choices=["choice 1", "choice 2"])
+    state.choices.mark_choice(0, False)
+    state.choices.mark_choice(1, True)
+
+    result = await scorer(state, Target("A"))
+
+    assert result is not None
+    assert result.text == INCORRECT
+    assert result.reason is None
+    assert result.answer == "B"
+
+
 def test_target_sequences():
     t_str = Target("A")
     assert len(t_str) == 1

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -4,7 +4,7 @@ import pytest
 from test_helpers.utils import simple_task_state
 
 from inspect_ai._util.answer import answer_index
-from inspect_ai.scorer import CORRECT, INCORRECT, Target, choice
+from inspect_ai.scorer import CORRECT, INCORRECT, NOANSWER, Target, choice
 
 
 @pytest.mark.anyio
@@ -249,6 +249,64 @@ async def test_correct_multiple_answers_all_incorrect():
     assert result.text == CORRECT
     assert result.answer == ""
     assert result.explanation == "ANSWERS: "
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("completion", ["", "   "])
+async def test_score_empty_completion_is_noanswer(completion: str):
+    # the solver leaves choices unmarked when there is nothing to parse,
+    # which the scorer reads the same as all-False
+    scorer = choice()
+    state = simple_task_state(model_output=completion, choices=["choice 1", "choice 2"])
+
+    result = await scorer(state, Target("A"))
+
+    assert result is not None
+    assert result.text == NOANSWER
+    assert result.reason == "no_response"
+    assert result.answer == ""
+
+
+@pytest.mark.anyio
+async def test_score_unparsable_completion_marks_format_reason():
+    scorer = choice()
+    state = simple_task_state(
+        model_output="I think it is the second one, honestly.",
+        choices=["choice 1", "choice 2"],
+    )
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.reason == "invalid_response_format"
+    assert result.answer == ""
+
+
+@pytest.mark.anyio
+async def test_score_selected_choices_carry_no_reason():
+    scorer = choice()
+    state = simple_task_state(
+        model_output="ANSWER: B", choices=["choice 1", "choice 2"]
+    )
+    state.choices.mark_choice(0, False)
+    state.choices.mark_choice(1, True)
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.reason is None
+    assert result.answer == "B"
+
+    state = simple_task_state(
+        model_output="ANSWER: A", choices=["choice 1", "choice 2"]
+    )
+    state.choices.mark_choice(0, True)
+    state.choices.mark_choice(1, False)
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == CORRECT
+    assert result.reason is None
 
 
 def test_target_sequences():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #5323.

### What is the current behavior?

`choice()` returns `INCORRECT` with no `reason` for three different outcomes: an empty completion, a completion with no parseable `ANSWER` line, and a parsed but wrong letter. Readers of the log cannot separate "the model did not answer" from "the model answered wrong".

### What is the new behavior?

- Empty or whitespace-only completion: value `NOANSWER` with `reason="no_response"`.
- Non-empty completion with no selected choice: value stays `INCORRECT` with `reason="invalid_response_format"`.
- A selected choice: `CORRECT`/`INCORRECT` as before, with no reason.

The reasons reuse the existing `ScoreReason` vocabulary, matching what `pattern()` and `math()` already record. Headline accuracy is unchanged: the default `value_to_float` maps `NOANSWER` to 0.0, the same as `INCORRECT`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Only in a narrow sense: consumers that match on the exact score value letter will see `N` instead of `I` for empty completions. Default metrics are unaffected.

### Other information:

Note on tooling: this PR was authored with AI assistance (Muse Spark) and the author reviewed every line before submission.

Tests: added `test_score_empty_completion_is_noanswer`, `test_score_unparsable_completion_marks_format_reason`, and `test_score_selected_choices_carry_no_reason` to `tests/scorer/test_choice.py`. Ran `pytest tests/scorer/test_choice.py` (24 passed, 22 trio-skipped), `pytest tests/solver/test_multiple_choice.py` (43 passed, 41 trio-skipped), `ruff format --check` and `ruff check` on the touched files (pass), `mypy` on the touched source file (clean), and the suppressions check (ledger unchanged). Reproduction script from the issue: before the fix all abnormal cases had `reason=None`; after the fix the four cases report `N/no_response`, `I/invalid_response_format`, `I/None`, `C/None` as proposed.

### Slow tests

Not run. This change touches only the `choice()` scorer and its tests. No model provider, sandbox, tool, agent, or async plumbing is affected, so no gated class applies.

### Agent review
- Reviewer: self-review passes in the authoring context (logic cold-read plus adversarial check); no separate fresh-context frontier-model pass was run.
- Findings: 2 considered, 0 code changes needed. (1) Empty-target CORRECT case (`Target("")` with no selection) still returns CORRECT with no reason, since the reason branches only run on mismatch; covered by existing tests. (2) Solver-level tests that assert `!= CORRECT` for unparsed output (`test_i_dont_know_should_not_mark_choices`) still hold, since the value for that path stays INCORRECT.