### PR TITLE
Anthropic: skip server-side fallback blocks for lookback cache_control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: lookback prompt caching no longer places `cache_control` on a server-side `fallback` block (the record of a refused turn served by a fallback model), which the API rejects with `fallback.cache_control: Extra inputs are not permitted` and which failed every request following such a turn.
 - Multiple choice: A dataset target of `0` now raises an error instead of being interpreted as option Z on tasks with 26 or more choices.
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.
 - Scoring: `multiple_choice()` now recognizes answer letters wrapped in LaTeX or markdown (`$B$`, `**B**`, `(B)`), which previously scored INCORRECT.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -2184,7 +2184,10 @@ def is_code_execution_tool(
     return param.get("name") == "code_execution" and not is_tool_param(param)
 
 
-_NON_CACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+# Block types the API rejects `cache_control` on ("Extra inputs are not
+# permitted"): thinking blocks, and the server-side `fallback` block that
+# records a refused turn being served by a fallback model.
+_NON_CACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking", "fallback"})
 
 
 def add_lookback_cache_control(
@@ -2193,9 +2196,9 @@ def add_lookback_cache_control(
     """Tag the second-to-last cacheable content block across `message_params`.
 
     Walks blocks in reverse (last message first), skipping
-    thinking/redacted_thinking (the API rejects `cache_control` on those with
-    `Extra inputs are not permitted`), and tags the second cacheable block
-    found. Tagging the *second*-to-last rather than the last gives lookback
+    thinking/redacted_thinking and server-side `fallback` blocks (the API
+    rejects `cache_control` on those with `Extra inputs are not permitted`),
+    and tags the second cacheable block found. Tagging the *second*-to-last rather than the last gives lookback
     caching a fallback when the final block changes (RAG, scorers, approvers,
     branching) — auto-cache already covers the very last block.
 

--- a/tests/model/providers/test_anthropic_cache_control.py
+++ b/tests/model/providers/test_anthropic_cache_control.py
@@ -3,8 +3,9 @@
 These exercise `add_lookback_cache_control` directly with hand-built
 `MessageParam` dicts — no API calls. The function must place
 `cache_control: {type: "ephemeral"}` on the second-to-last *cacheable*
-content block, skipping `thinking` / `redacted_thinking` blocks (which the
-API rejects with `'thinking.cache_control: Extra inputs are not permitted'`).
+content block, skipping `thinking` / `redacted_thinking` blocks and
+server-side `fallback` blocks (which the API rejects with
+`'<type>.cache_control: Extra inputs are not permitted'`).
 """
 
 from __future__ import annotations
@@ -42,6 +43,16 @@ def thinking(s: str = "hmm") -> dict[str, Any]:
 
 def redacted() -> dict[str, Any]:
     return {"type": "redacted_thinking", "data": "xxx"}
+
+
+def fallback() -> dict[str, Any]:
+    # the server-side fallback beta records a refused turn served by another
+    # model as a content block; it carries no text and cannot be cached
+    return {
+        "type": "fallback",
+        "from": {"model": "claude-opus-5"},
+        "to": {"model": "claude-opus-4-8"},
+    }
 
 
 def tool_use(tid: str = "t1") -> dict[str, Any]:
@@ -162,8 +173,32 @@ def test_thinking_then_tool_use_tags_prev_tool_result() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (e) edge cases
+# server-side fallback blocks: must be skipped like thinking blocks
 # ---------------------------------------------------------------------------
+
+
+def test_fallback_at_minus_two_skipped() -> None:
+    # a mid-output decline served by the fallback model leaves the assistant
+    # message as [text, fallback, text]; the fallback sits exactly where the
+    # lookback tag lands and the API rejects cache_control on it
+    msgs: list[dict[str, Any]] = [
+        {"role": "assistant", "content": [text("a"), fallback(), text("b")]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 0)]
+    assert "cache_control" not in msgs[0]["content"][1]
+
+
+def test_fallback_at_prev_minus_one_skipped() -> None:
+    # the fallback block closes the assistant message and the tool result
+    # that follows is the only later cacheable block
+    msgs: list[dict[str, Any]] = [
+        {"role": "assistant", "content": [text("x"), tool_use(), fallback()]},
+        {"role": "user", "content": [tool_result()]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 1)]
+    assert "cache_control" not in msgs[0]["content"][2]
 
 
 def test_single_cacheable_block_no_tag() -> None:


### PR DESCRIPTION
## Problem

With `fallback_models` set on an Anthropic model, a turn the requested model refuses is served by the fallback model under the `server-side-fallback-2026-06-01` beta, and the response records the hand-off as a content block of type `fallback` (`{"type": "fallback", "from": {...}, "to": {...}}`). The block is replayed in later requests as part of the assistant message.

`add_lookback_cache_control` tags the second-to-last cacheable block of the conversation. It skips `thinking` / `redacted_thinking` because the API rejects `cache_control` on them, but not `fallback`, which the API rejects the same way. When the fallback block sits at that position the next request fails:

```
BadRequestError: Error code: 400 - messages.35.content.1.fallback.cache_control: Extra inputs are not permitted
```

In practice every generate after a refused-and-fallen-back turn failed. We hit this on a long-running eval where opus-5 as the simulator refused turns that opus-4-8 then served; all such samples errored on the following turn.

## Fix

Add `"fallback"` to `_NON_CACHEABLE_BLOCK_TYPES`, so the lookback walk skips it like thinking blocks, and update the docstring and comment.

## Tests

Two new cases in `tests/model/providers/test_anthropic_cache_control.py`, mirroring the existing thinking-block cases: a fallback block at the second-to-last position within one assistant message (a mid-output decline leaves `[text, fallback, text]`), and a fallback block closing an assistant message followed by a single tool result. Both fail on `main` and pass with the change; the full file passes (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)