### PR TITLE
fix(file): keep the drive or host from a file:// authority in local_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: `file://` locations whose authority carries a Windows drive (`file://D:/logs/...`, the form the local filesystem reports) now resolve to `D:\logs\...` instead of `\logs\...`, so `read_eval_log()` and `read_eval_log_headers()` work when the log directory is on a different drive from the working directory; a UNC host is kept as well. (#5322)
 - Multiple choice: A dataset target of `0` now raises an error instead of being interpreted as option Z on tasks with 26 or more choices.
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.
 - Scoring: `multiple_choice()` now recognizes answer letters wrapped in LaTeX or markdown (`$B$`, `**B**`, `(B)`), which previously scored INCORRECT.

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -442,16 +442,28 @@ def to_uri(path_or_uri: str) -> str:
     return "file://" + quote_from_bytes(bytes(path_obj), safe="/:@")
 
 
+_WINDOWS_DRIVE_AUTHORITY = re.compile(r"[A-Za-z]:")
+
+
 def local_path(filename: str) -> str:
     """Convert a file:// URL to a local path, or return as-is.
 
     Percent-encoded characters are decoded (the inverse of `to_uri`, which
     encodes them), so paths with spaces or literal percent sequences round
-    trip. Known limitation (unchanged): a UNC-style `file://server/share`
-    URL drops its host component — only the path part is returned.
+    trip. The authority component is honoured: `file://D:/logs` (the form
+    the local filesystem reports on Windows) keeps its drive, and a
+    UNC-style `file://server/share` URL keeps its host.
     """
     if filename.startswith("file://"):
-        return url2pathname(urlparse(filename).path)
+        parsed = urlparse(filename)
+        # urlparse puts a Windows drive ("D:") or a UNC host in netloc and
+        # leaves only "/logs/..." in path; converting the path alone gives
+        # "\logs\...", which resolves against the current drive (#5322)
+        if _WINDOWS_DRIVE_AUTHORITY.fullmatch(parsed.netloc):
+            return url2pathname(parsed.netloc + parsed.path)
+        if parsed.netloc and parsed.netloc != "localhost":
+            return url2pathname("//" + parsed.netloc + parsed.path)
+        return url2pathname(parsed.path)
     return filename
 
 

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -315,6 +315,41 @@ def test_local_path_windows_drive() -> None:
     assert local_path("file:///C:/logs/eval%20run.eval") == "C:\\logs\\eval run.eval"
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows drive-path form")
+def test_local_path_windows_drive_in_authority() -> None:
+    """`file://D:/...` is how the local filesystem names files on Windows.
+
+    urlparse puts the drive in netloc, so converting the path alone gave
+    `\\logs\\x.eval`, which resolves against the current drive (#5322).
+    """
+    assert local_path("file://D:/logs/eval%20run.eval") == "D:\\logs\\eval run.eval"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows UNC form")
+def test_local_path_windows_unc_host() -> None:
+    assert local_path("file://server/share/x.eval") == "\\\\server\\share\\x.eval"
+
+
+def test_local_path_localhost_authority() -> None:
+    assert local_path("file://localhost/tmp/x.eval") == local_path("file:///tmp/x.eval")
+
+
+def test_local_path_resolves_filesystem_ls_names(tmp_path: Path) -> None:
+    """A name reported by filesystem().ls() must name the file on any drive.
+
+    `read_eval_log()` feeds `list_eval_logs()` names through `local_path`;
+    a result relative to the current drive is a FileNotFoundError whenever
+    the log dir and the working directory differ (#5322).
+    """
+    target = tmp_path / "eval run.eval"
+    target.write_text("x")
+    names = [info.name for info in filesystem(str(tmp_path)).ls(str(tmp_path))]
+    assert len(names) == 1
+    resolved = Path(local_path(names[0]))
+    assert resolved.is_absolute()
+    assert resolved.resolve() == target.resolve()
+
+
 async def test_cleanup_s3_sessions_no_instances() -> None:
     """cleanup_s3_sessions is a no-op when there are no cached instances."""
     with patch("s3fs.S3FileSystem") as mock_s3fs:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5322. `local_path()` converted a `file://` URL with `url2pathname(urlparse(url).path)`. For `file://D:/logs/x.eval`, the form the local filesystem reports on Windows and what `list_eval_logs()` returns, `urlparse` puts the drive in `netloc` and leaves `/logs/x.eval` in `path`, so the result was `\logs\x.eval`, a path relative to the current drive. `read_eval_log()` and `read_eval_log_headers()` then raised `FileNotFoundError` whenever the log directory was on a different drive from the working directory. The issue guessed the conversion lived elsewhere; it is this function, since #5064 only decoded the path component.

### What is the new behavior?

`local_path()` honours the authority: a drive-letter authority (`D:`) is prefixed to the path, giving `D:\logs\x.eval`; any other authority is restored as a UNC host (`file://server/share/x` becomes `\\server\share\x`), which the docstring had listed as a known limitation; `localhost` and an empty authority take the unchanged path-only branch, so POSIX `file:///...` URIs behave exactly as before.

Tests: two Windows-only cases (drive in authority, UNC host), a platform-independent `localhost` equivalence, and one that lists a temp directory through `filesystem().ls()` and asserts the name resolves to an absolute path that exists, which is the `read_eval_log()` path. The drive, UNC and listing tests fail on `main` on Windows. CHANGELOG entry added under Unreleased.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Only `file://` URLs with a non-empty, non-`localhost` authority change, and those resolved to the wrong file before.

### Other information:

`ruff format`, `ruff check` and `mypy` clean on the touched files. On Windows `tests/util/test_file.py` goes from 14 failed / 40 passed to 11 failed / 43 passed; the remaining 11 assume POSIX paths and fail identically on `main`. The reproduction from the issue now prints OK for both calls from a working directory on another drive. Not run on Linux here; the POSIX branch is untouched.
