### PR TITLE
fix(scorer): tag no-selection choice() scores with a Score.reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scoring: `choice()` now records `reason="no_response"` for an empty completion and `reason="invalid_response_format"` when the completion selects no answer, so both are distinguishable from a wrong letter; score values are unchanged. (#5323)
 - Multiple choice: A dataset target of `0` now raises an error instead of being interpreted as option Z on tasks with 26 or more choices.
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.
 - Scoring: `multiple_choice()` now recognizes answer letters wrapped in LaTeX or markdown (`$B$`, `**B**`, `(B)`), which previously scored INCORRECT.

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -101,6 +101,24 @@ def choice() -> Scorer:
             i for i, choice in enumerate(choices) if choice.correct is True
         ]
 
+        # the model selected nothing although an answer was expected (an empty
+        # target means "none of the choices", which no selection satisfies):
+        # an instruction-following failure charged to the model under test
+        # (INCORRECT, as pattern() and math() score a missing answer), but one
+        # that must stay distinguishable from a wrong letter, so record which
+        # kind using the shared ScoreReason vocabulary
+        if not generated_selected_choices and target_positions:
+            return Score(
+                value=INCORRECT,
+                answer="",
+                explanation=explanation,
+                reason=(
+                    "no_response"
+                    if not state.output.completion.strip()
+                    else "invalid_response_format"
+                ),
+            )
+
         target_matches_choices = generated_selected_choices == sorted(target_positions)
 
         return Score(

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -145,6 +145,73 @@ async def test_score_no_choices_does_not_raise(target: str):
     assert result.explanation == "No"
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("output", ["", "   \n"])
+async def test_score_empty_completion_records_no_response(output: str):
+    # nothing came back at all: still INCORRECT (no number moves), but tagged
+    # so it can be told apart from a wrong letter downstream (#5323)
+    scorer = choice()
+    state = simple_task_state(model_output=output, choices=["choice 1", "choice 2"])
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.answer == ""
+    assert result.reason == "no_response"
+
+
+@pytest.mark.anyio
+async def test_score_unparseable_completion_records_invalid_response_format():
+    # prose with no ANSWER line: the multiple_choice solver marks no choice,
+    # which is a format violation by the model under test, not a wrong answer
+    scorer = choice()
+    state = simple_task_state(
+        model_output="I think it is the second one.",
+        choices=["choice 1", "choice 2"],
+    )
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.answer == ""
+    assert result.explanation == "I think it is the second one."
+    assert result.reason == "invalid_response_format"
+
+
+@pytest.mark.anyio
+async def test_score_unparseable_completion_keeps_shuffled_explanation():
+    scorer = choice()
+    state = simple_task_state(
+        model_output="no idea",
+        choices=["choice 1", "choice 2"],
+    )
+    state.choices.shuffle(Random(42))
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.reason == "invalid_response_format"
+    assert "Choices were shuffled" in (result.explanation or "")
+
+
+@pytest.mark.anyio
+async def test_score_wrong_letter_has_no_reason():
+    # a parseable but wrong selection is a plain verdict with no reason tag
+    scorer = choice()
+    state = simple_task_state(
+        model_output="ANSWER: B",
+        choices=["choice 1", "choice 2"],
+    )
+    state.choices.mark_choice(0, False)
+    state.choices.mark_choice(1, True)
+
+    result = await scorer(state, Target("A"))
+
+    assert result.text == INCORRECT
+    assert result.answer == "B"
+    assert result.reason is None
+
+
 def test_answer_index_rejects_separators():
     # answer_index() should never silently return garbage indices for
     # separator characters -- it should raise so callers know to filter.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #5323. `choice()` returned `INCORRECT` with no `reason` whether the model picked the wrong letter, wrote prose without an `ANSWER:` line, or returned nothing, so the three were indistinguishable in `inspect view` and dataframes. `ScoreReason` defines `no_response` and `invalid_response_format` for the last two, and `pattern()` and `math()` already record them.

### What is the new behavior?

When an answer was expected and the model selected no choice, `choice()` keeps `INCORRECT` and sets `reason="no_response"` for an empty or whitespace-only completion, `reason="invalid_response_format"` otherwise. No score value changes, so accuracy is unaffected. An empty target still scores `CORRECT` with no selection, as the existing `test_correct_multiple_answers_*` tests require. A selected choice, right or wrong, carries no reason, as today.

The issue also floated `NOANSWER` for the empty case. This PR does not do that, to keep every number unchanged and to match how `math()` and `pattern()` treat a missing answer; it is a one-line change if preferred.

Tests: empty and whitespace completions record `no_response`; prose records `invalid_response_format`, with and without shuffled choices (the shuffled explanation is preserved); a wrong letter has `reason=None`. Three of the new tests fail on `main`. CHANGELOG entry added under Unreleased.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Score values are unchanged; only `Score.reason` is populated where it was `None`.

### Other information:

`ruff format`, `ruff check` and `mypy` clean; `tests/scorer/test_choice.py` 25 passed. The four-case mockllm reproduction from the issue now prints `no_response`, `no_response`, `invalid_response_format`, `None` with the values unchanged.
