### PR TITLE
docs: Clarify how epoch count overrides affect task reducers

### DIFF
--- a/docs/metrics.qmd
+++ b/docs/metrics.qmd
@@ -330,6 +330,12 @@ If a task is run over more than one `epoch`, multiple scores will be generated f
 
 By default, the reduced view is built with `mean`. You may specify other strategies by passing an `Epochs`, which includes both a count and one or more reducers to combine sample scores with. For example:
 
+::: callout-note
+An integer epoch override changes the count and preserves the reducer defined by the task. This applies to `eval(..., epochs=n)`, `eval_set(..., epochs=n)`, and `--epochs n`. To replace the task reducer, pass `Epochs(n, reducer)` or combine `--epochs n` with `--epochs-reducer reducer`. Combine `--epochs n` with `--no-epochs-reducer` to disable epoch reduction.
+
+A task with a fixed custom reducer can define its count directly in `Task`; the reducer remains active when users override the count. An `epochs` task parameter is useful when changing the count should also change the reducer configuration.
+:::
+
 ``` python
 @task
 def gpqa():

--- a/docs/metrics.qmd
+++ b/docs/metrics.qmd
@@ -331,10 +331,21 @@ If a task is run over more than one `epoch`, multiple scores will be generated f
 By default, the reduced view is built with `mean`. You may specify other strategies by passing an `Epochs`, which includes both a count and one or more reducers to combine sample scores with. For example:
 
 ::: callout-note
-An integer epoch override changes the count and preserves the reducer defined by the task. This applies to `eval(..., epochs=n)`, `eval_set(..., epochs=n)`, and `--epochs n`. To replace the task reducer, pass `Epochs(n, reducer)` or combine `--epochs n` with `--epochs-reducer reducer`. Combine `--epochs n` with `--no-epochs-reducer` to disable epoch reduction.
-
-A task with a fixed custom reducer can define its count directly in `Task`; the reducer remains active when users override the count. An `epochs` task parameter is useful when changing the count should also change the reducer configuration.
+An integer epoch override changes the count and preserves the reducer defined by the task. This applies to `eval(..., epochs=n)`, `eval_set(..., epochs=n)`, and `--epochs n`. To replace the task reducer, pass `Epochs(n, reducer)` or combine `--epochs n` with `--epochs-reducer reducer`. Combine `--epochs n` with `--no-epochs-reducer` to disable epoch reduction. A task with a fixed custom reducer can define its count directly in `Task`; the reducer remains active when users override the count. An `epochs` task parameter is useful when changing the count should also change the reducer configuration.
 :::
+
+For example, [ZeroBench](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/zerobench) includes a custom reducer in its epoch configuration:
+
+``` python
+reliability_at_evals = ["5_of_5_reliability"]
+repeats = Epochs(k, pass_at_evals + reliability_at_evals)
+```
+
+This command runs each sample seven times and keeps `5_of_5_reliability` as one of the reducers:
+
+``` console
+inspect eval inspect_evals/zerobench --epochs 7
+```
 
 ``` python
 @task

--- a/docs/metrics.qmd
+++ b/docs/metrics.qmd
@@ -331,21 +331,10 @@ If a task is run over more than one `epoch`, multiple scores will be generated f
 By default, the reduced view is built with `mean`. You may specify other strategies by passing an `Epochs`, which includes both a count and one or more reducers to combine sample scores with. For example:
 
 ::: callout-note
-An integer epoch override changes the count and preserves the reducer defined by the task. This applies to `eval(..., epochs=n)`, `eval_set(..., epochs=n)`, and `--epochs n`. To replace the task reducer, pass `Epochs(n, reducer)` or combine `--epochs n` with `--epochs-reducer reducer`. Combine `--epochs n` with `--no-epochs-reducer` to disable epoch reduction. A task with a fixed custom reducer can define its count directly in `Task`; the reducer remains active when users override the count. An `epochs` task parameter is useful when changing the count should also change the reducer configuration.
+An integer epoch override changes the count and preserves the reducer defined by the task. This applies to `eval(..., epochs=n)`, `eval_set(..., epochs=n)`, and `--epochs n`. To replace the task reducer, pass `Epochs(n, reducer)` or combine `--epochs n` with `--epochs-reducer reducer`. Combine `--epochs n` with `--no-epochs-reducer` to disable epoch reduction.
+
+A task with a fixed custom reducer can define its count directly in `Task`; the reducer remains active when users override the count. An `epochs` task parameter is useful when changing the count should also change the reducer configuration.
 :::
-
-For example, [ZeroBench](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/zerobench) includes a custom reducer in its epoch configuration:
-
-``` python
-reliability_at_evals = ["5_of_5_reliability"]
-repeats = Epochs(k, pass_at_evals + reliability_at_evals)
-```
-
-This command runs each sample seven times and keeps `5_of_5_reliability` as one of the reducers:
-
-``` console
-inspect eval inspect_evals/zerobench --epochs 7
-```
 
 ``` python
 @task

--- a/docs/options.qmd
+++ b/docs/options.qmd
@@ -127,9 +127,9 @@ For a complete matrix of which task, solver, and runtime settings can be configu
 |--------------------------|----------------------------------------------|
 | `--limit` | Limit samples to evaluate by specifying a maximum (e.g. `10`) or range (e.g. `10-20`) |
 | `--sample-id` | Evaluate a specific sample (e.g. `44`) or list of samples (e.g. `44,63,91`) |
-| `--epochs` | Number of times to repeat each sample (defaults to 1) |
-| `--epochs-reducer` | Method for building the reduced score view from per-epoch sample scores. Built in reducers include `mean`, `median`, `mode`, `max`, `at_least_{n}`, `pass_at_{k}`, and `pass_k_{k}`. Metrics that require unreduced scores still receive raw sample-epoch scores. |
-| `--no-epochs-reducer` | Do not build a reduced score view. Legacy metrics compute across all sample-epoch scores. |
+| `--epochs` | Number of times to repeat each sample (defaults to 1). This preserves any reducer defined by the task. |
+| `--epochs-reducer` | Method for building the reduced score view from per-epoch sample scores. Use with `--epochs` to replace any reducer defined by the task. Built in reducers include `mean`, `median`, `mode`, `max`, `at_least_{n}`, `pass_at_{k}`, and `pass_k_{k}`. Metrics that require unreduced scores still receive raw sample-epoch scores. |
+| `--no-epochs-reducer` | Do not build a reduced score view. Use with `--epochs` to disable any reducer defined by the task. Legacy metrics compute across all sample-epoch scores. |
 
 ## Parallelism
 


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The documentation lists the epoch override options but does not state that a count-only override preserves a reducer defined by the task. This may lead task authors to expose an `epochs` task parameter only to retain custom reducer configuration.

### What is the new behavior?

The epoch reduction guide and CLI option reference now state that integer and `--epochs` count overrides preserve the task reducer. They also explain how to replace or disable the reducer and when an `epochs` task parameter remains useful because changing the count should also change reducer configuration.

### Demonstration

ZeroBench includes its custom `5_of_5_reliability` reducer in the task's epoch configuration:

```python
reliability_at_evals = ["5_of_5_reliability"]
repeats = Epochs(k, pass_at_evals + reliability_at_evals)
```

The following commands override the count through the CLI and inspect the resulting log header:

```console
inspect eval inspect_evals/zerobench \
  --model mockllm/model \
  --limit 1 \
  --epochs 7 \
  --log-dir ./epoch-demo-logs

python - <<'PY'
from inspect_ai.log import list_eval_logs, read_eval_log

log = read_eval_log(list_eval_logs("./epoch-demo-logs")[0], header_only=True)
assert log.eval.config.epochs == 7
assert "5_of_5_reliability" in (log.eval.config.epochs_reducer or [])
PY
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This PR changes documentation only.

### Other information:

Validation completed:

- `pre-commit run --files docs/metrics.qmd docs/options.qmd` passed.
- `make check` passed.
- Targeted Quarto renders of `docs/metrics.qmd` and `docs/options.qmd` passed.
- The full Quarto render stopped after 36 of 95 pages because the Python kernel for `docs/extensions/index.qmd` returned a broken pipe. Both changed pages rendered successfully.
- The test suite reached 1,994 passed and 578 skipped before ten viewer test setup errors caused by the local moto S3 endpoint binding to `0.0.0.0` on macOS. The suite was stopped after the environmental failure was confirmed.

### Agent review

Codex authored the documentation change. No separate review pass was run because this is a small documentation-only diff.
