### PR TITLE
Prevent TLS slowdowns during long-running Linux evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fixed Linux evaluations slowing down as model clients open more HTTPS connections.
 - Sample selection: `--sample-id` now accepts ids containing colons (e.g. `user:cybergym/arvo_6008`); a `task:` prefix is stripped only when it names a task in the run.
 - Multiple choice: A dataset target of `0` now raises an error instead of being interpreted as option Z on tasks with 26 or more choices.
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,6 +42,7 @@ ruff==0.9.6
 textual-dev>=0.86.2
 together>=2.0.0
 trio
+trustme
 types-aioboto3
 types-beautifulsoup4
 types-boto3

--- a/src/inspect_ai/_util/http_defaults_httpx2.py
+++ b/src/inspect_ai/_util/http_defaults_httpx2.py
@@ -46,7 +46,10 @@ should raise the expiry alongside the cap.
 from __future__ import annotations
 
 import os
+import re
 import socket
+import ssl
+import sys
 from logging import getLogger
 from typing import Any, overload
 
@@ -202,6 +205,47 @@ async def _floor_connect_timeout(request: httpx2.Request) -> None:
         timeout["connect"] = floor
 
 
+def _default_ssl_context() -> ssl.SSLContext | None:
+    # truststore repeatedly loads OpenSSL's default paths before handshakes.
+    # OpenSSL 3.0-3.3 accumulates duplicate directory lookups as a result.
+    # Load the same system trust once; retain native and custom TLS backends.
+    if (
+        sys.platform != "linux"
+        or ssl.SSLContext.__module__ != "ssl"
+        or os.environ.get("SSL_CERT_FILE")
+        or os.environ.get("SSL_CERT_DIR")
+    ):
+        return None
+
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile is None:
+        if paths.capath is None:
+            return None
+        with os.scandir(paths.capath) as entries:
+            if not any(
+                re.fullmatch(r"[0-9a-fA-F]{8}\.[0-9]", entry.name) for entry in entries
+            ):
+                return None
+
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.load_default_certs()
+    return context
+
+
+def _default_proxy(proxy: str | httpx2.URL | httpx2.Proxy) -> httpx2.Proxy:
+    proxy = proxy if isinstance(proxy, httpx2.Proxy) else httpx2.Proxy(proxy)
+    if proxy.url.scheme == "https" and proxy.ssl_context is None:
+        context = _default_ssl_context()
+        if context is not None:
+            return httpx2.Proxy(
+                proxy.url,
+                ssl_context=context,
+                auth=proxy.auth,
+                headers=proxy.headers,
+            )
+    return proxy
+
+
 def _transport_kwargs(
     limits: httpx2.Limits, overrides: dict[str, Any]
 ) -> dict[str, Any]:
@@ -233,6 +277,12 @@ def default_client_kwargs(**overrides: Any) -> dict[str, Any]:
     kwargs.setdefault("follow_redirects", True)
 
     if "transport" not in kwargs:
+        if kwargs.get("verify", True) is True:
+            context = _default_ssl_context()
+            if context is not None:
+                kwargs["verify"] = context
+        if kwargs.get("proxy") is not None:
+            kwargs["proxy"] = _default_proxy(kwargs["proxy"])
         transport_kwargs = _transport_kwargs(limits, kwargs)
         # Supplying a transport turns off httpx's environment proxy discovery,
         # so rebuild the mounts with the same settings rather than losing
@@ -247,7 +297,9 @@ def default_client_kwargs(**overrides: Any) -> dict[str, Any]:
         mounts: dict[str, httpx2.AsyncBaseTransport | None] = {
             key: None
             if url is None
-            else httpx2.AsyncHTTPTransport(proxy=httpx2.Proxy(url), **transport_kwargs)
+            else httpx2.AsyncHTTPTransport(
+                proxy=_default_proxy(url), **transport_kwargs
+            )
             for key, url in environment_proxies.items()
         }
         mounts.update(kwargs.get("mounts") or {})

--- a/tests/model/test_http_defaults.py
+++ b/tests/model/test_http_defaults.py
@@ -2,7 +2,11 @@
 
 import os
 import socket
+import ssl
+import sys
 import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, NamedTuple
 
 import anthropic
@@ -11,6 +15,7 @@ import httpx
 import httpx._utils
 import httpx2._utils
 import pytest
+import trustme
 from test_helpers.utils import skip_if_trio
 
 import inspect_ai._util._async as _async_backend
@@ -123,14 +128,16 @@ def google_api() -> GoogleGenAIAPI:
 
 
 def test_both_flavors_export_the_same_names() -> None:
-    # Edit http_defaults.py, then mirror to http_defaults_httpx2.py. The
-    # parametrized tests below catch a changed function that was not mirrored;
-    # only this catches an added one, because no test references it yet.
-    def names(module: object) -> set[str]:
+    # Public defaults stay aligned; each backend can have its own TLS helpers.
+    def names(module: Any) -> set[str]:
         return {
-            n
-            for n in dir(module)
-            if not n.startswith("__") and n not in ("httpx", "httpx2")
+            name
+            for name, value in vars(module).items()
+            if name.isupper()
+            or (
+                not name.startswith("_")
+                and getattr(value, "__module__", None) == module.__name__
+            )
         }
 
     assert names(http_defaults_httpx2) == names(http_defaults)
@@ -335,7 +342,237 @@ async def test_the_floor_hook_survives_httpx_hooks_on_httpx2() -> None:
     assert seen["read"] == 30.0
 
 
+# --- TLS --------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_ca() -> trustme.CA:
+    return trustme.CA()
+
+
+@pytest.fixture
+def test_ca_file(test_ca: trustme.CA, tmp_path: Path) -> Path:
+    path = tmp_path / "ca.pem"
+    path.write_bytes(test_ca.cert_pem.bytes())
+    return path
+
+
+@pytest.fixture
+def default_cert_loads(
+    monkeypatch: pytest.MonkeyPatch, test_ca_file: Path
+) -> list[ssl.SSLContext]:
+    """Use a test CA as Linux's default trust and count each configuration."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    for variable in ("SSL_CERT_FILE", "SSL_CERT_DIR"):
+        monkeypatch.delenv(variable, raising=False)
+    paths = SimpleNamespace(cafile=str(test_ca_file), capath=None)
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: paths)
+    loads: list[ssl.SSLContext] = []
+
+    def load_test_certificates(context: ssl.SSLContext) -> None:
+        loads.append(context)
+        context.load_verify_locations(cafile=paths.cafile)
+
+    monkeypatch.setattr(
+        ssl.SSLContext, "set_default_verify_paths", load_test_certificates
+    )
+    return loads
+
+
+def tls_handshake(
+    client_context: ssl.SSLContext,
+    server_context: ssl.SSLContext,
+    hostname: str = "localhost",
+) -> None:
+    """Complete a real TLS handshake offline, without connection timing races."""
+    client_in, client_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+    server_in, server_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+    client = client_context.wrap_bio(client_in, client_out, server_hostname=hostname)
+    server = server_context.wrap_bio(server_in, server_out, server_side=True)
+    for _ in range(10):
+        completed = 0
+        for connection, outgoing, incoming in (
+            (client, client_out, server_in),
+            (server, server_out, client_in),
+        ):
+            try:
+                connection.do_handshake()
+                completed += 1
+            except ssl.SSLWantReadError:
+                pass
+            incoming.write(outgoing.read())
+        if completed == 2:
+            return
+    pytest.fail("TLS handshake did not finish")
+
+
+@pytest.mark.parametrize("trust_env", [True, False])
+def test_tls_connections_load_default_certificates_only_once(
+    default_cert_loads: list[ssl.SSLContext], test_ca: trustme.CA, trust_env: bool
+) -> None:
+    kwargs = http_defaults_httpx2.default_client_kwargs(trust_env=trust_env)
+    context = pool_of(kwargs["transport"])._ssl_context
+    server = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    test_ca.issue_cert("localhost").configure_cert(server)
+
+    for _ in range(20):
+        tls_handshake(context, server)
+
+    assert len(default_cert_loads) == 1
+    assert default_cert_loads[0] is context
+    assert kwargs["verify"] is context
+    assert context.check_hostname
+    assert context.verify_mode == ssl.CERT_REQUIRED
+
+
+@pytest.mark.parametrize(
+    "trusted,hostname",
+    [(True, "wrong-host.invalid"), (False, "localhost")],
+    ids=["wrong-hostname", "untrusted-certificate"],
+)
+def test_default_tls_rejects_invalid_certificates(
+    default_cert_loads: list[ssl.SSLContext],
+    test_ca: trustme.CA,
+    trusted: bool,
+    hostname: str,
+) -> None:
+    kwargs = http_defaults_httpx2.default_client_kwargs()
+    context = pool_of(kwargs["transport"])._ssl_context
+    server = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ca = test_ca if trusted else trustme.CA()
+    ca.issue_cert("localhost").configure_cert(server)
+    with pytest.raises(ssl.SSLCertVerificationError):
+        tls_handshake(context, server, hostname)
+
+
+@pytest.mark.parametrize("override", ["disabled", "context", "file"])
+def test_explicit_verification_settings_are_preserved(
+    default_cert_loads: list[ssl.SSLContext], test_ca_file: Path, override: str
+) -> None:
+    verify: ssl.SSLContext | str | bool
+    if override == "disabled":
+        verify = False
+    elif override == "context":
+        verify = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    else:
+        verify = str(test_ca_file)
+    kwargs = http_defaults_httpx2.default_client_kwargs(verify=verify)
+    context = pool_of(kwargs["transport"])._ssl_context
+    assert kwargs["verify"] is verify
+    assert default_cert_loads == []
+    if isinstance(verify, ssl.SSLContext):
+        assert context is verify
+    else:
+        assert context.check_hostname is (verify is not False)
+
+
+@pytest.mark.parametrize("variable", ["SSL_CERT_FILE", "SSL_CERT_DIR"])
+def test_certificate_environment_keeps_httpx2_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    default_cert_loads: list[ssl.SSLContext],
+    variable: str,
+) -> None:
+    monkeypatch.setenv(variable, "/custom/trust")
+    assert http_defaults_httpx2._default_ssl_context() is None
+    assert default_cert_loads == []
+
+
+@pytest.mark.parametrize("backend", ["darwin", "win32", "injected"])
+def test_other_tls_backends_keep_httpx2_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    default_cert_loads: list[ssl.SSLContext],
+    backend: str,
+) -> None:
+    if backend == "injected":
+        monkeypatch.setattr(ssl.SSLContext, "__module__", "custom_ssl")
+    else:
+        monkeypatch.setattr(sys, "platform", backend)
+    assert http_defaults_httpx2._default_ssl_context() is None
+    assert default_cert_loads == []
+
+
+def test_unavailable_default_paths_keep_httpx2_selection(
+    monkeypatch: pytest.MonkeyPatch, default_cert_loads: list[ssl.SSLContext]
+) -> None:
+    paths = SimpleNamespace(cafile=None, capath=None)
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: paths)
+    assert http_defaults_httpx2._default_ssl_context() is None
+    assert default_cert_loads == []
+
+
+def test_caller_transport_does_not_load_default_certificates(
+    default_cert_loads: list[ssl.SSLContext],
+) -> None:
+    transport = httpx2.MockTransport(lambda request: httpx2.Response(200))
+    kwargs = http_defaults_httpx2.default_client_kwargs(transport=transport)
+    assert kwargs["transport"] is transport
+    assert "verify" not in kwargs
+    assert default_cert_loads == []
+
+
+@pytest.mark.parametrize("filename", [None, "certificate.pem", "012abcDE.0"])
+def test_certificate_directory_requires_a_hashed_certificate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    default_cert_loads: list[ssl.SSLContext],
+    filename: str | None,
+) -> None:
+    if filename is not None:
+        (tmp_path / filename).touch()
+    paths = SimpleNamespace(cafile=None, capath=str(tmp_path))
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: paths)
+    assert (http_defaults_httpx2._default_ssl_context() is not None) is (
+        filename == "012abcDE.0"
+    )
+
+
 # --- proxies ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source", ["environment", "argument"])
+@pytest.mark.parametrize("verify", [True, False])
+def test_https_proxies_use_separate_verified_tls_contexts(
+    monkeypatch: pytest.MonkeyPatch,
+    default_cert_loads: list[ssl.SSLContext],
+    source: str,
+    verify: bool,
+) -> None:
+    url = "https://proxy.example:3128"
+    if source == "environment":
+        monkeypatch.setenv("HTTPS_PROXY", url)
+    client = http_defaults_httpx2.default_async_client(
+        verify=verify, **({"proxy": url} if source == "argument" else {})
+    )
+    pool = next(pool_of(t) for t in client._mounts.values() if t is not None)
+    assert pool._ssl_context.check_hostname is verify
+    proxy_context = pool._proxy_ssl_context
+    assert proxy_context is not pool._ssl_context
+    assert proxy_context.check_hostname
+    assert proxy_context.verify_mode == ssl.CERT_REQUIRED
+    assert proxy_context in default_cert_loads
+
+
+@pytest.mark.parametrize("custom_context", [True, False])
+def test_proxy_defaults_preserve_credentials_and_supplied_contexts(
+    default_cert_loads: list[ssl.SSLContext], custom_context: bool
+) -> None:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT) if custom_context else None
+    proxy = httpx2.Proxy(
+        "https://proxy.example:3128",
+        ssl_context=context,
+        auth=("username", "password"),
+        headers={"X-Proxy-Header": "value"},
+    )
+    configured = http_defaults_httpx2.default_client_kwargs(proxy=proxy)["proxy"]
+    assert configured.url == proxy.url
+    assert configured.auth == proxy.auth
+    assert configured.headers == proxy.headers
+    assert proxy.ssl_context is context
+    if custom_context:
+        assert configured is proxy
+    else:
+        assert configured is not proxy
+        assert configured.ssl_context in default_cert_loads
 
 
 @pytest.mark.parametrize("defaults", DEFAULT_MODULES)

--- a/uv.lock
+++ b/uv.lock
@@ -2222,6 +2222,7 @@ dev = [
     { name = "textual-dev" },
     { name = "together" },
     { name = "trio" },
+    { name = "trustme" },
     { name = "types-aioboto3" },
     { name = "types-beautifulsoup4" },
     { name = "types-boto3" },
@@ -2353,6 +2354,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "together", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "trio", marker = "extra == 'dev'" },
+    { name = "trustme", marker = "extra == 'dev'" },
     { name = "twine", marker = "extra == 'dist'" },
     { name = "types-aioboto3", marker = "extra == 'dev'" },
     { name = "types-beautifulsoup4", marker = "extra == 'dev'" },
@@ -6907,6 +6909,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/dc/a2d25ed73ad49cfd79bf18d262577c3731c98e382284e28d522f49a0df35/trio-0.34.0.tar.gz", hash = "sha256:63b9485408bdfdde544fced107045a8c0086cdc4bd0ef2f797b9e0dd111b964b", size = 607457, upload-time = "2026-08-11T00:33:42.198Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/1f/555f1364bed52a92a864181962b77f1b15adadeacf23b86105324363e461/trio-0.34.0-py3-none-any.whl", hash = "sha256:6c7c9f49917694dcdcd5f67abd168df5599eca480d61f29854d17a61a75c2f05", size = 511840, upload-time = "2026-08-11T00:33:40.552Z" },
+]
+
+[[package]]
+name = "trustme"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/931476f4cf1cd9e736f32651005078061a50dc164a2569fb874e00eb2786/trustme-1.2.1.tar.gz", hash = "sha256:6528ba2bbc7f2db41f33825c8dd13e3e3eb9d334ba0f909713c8c3139f4ae47f", size = 26844, upload-time = "2025-01-02T01:55:32.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/f3/c34dbabf6da5eda56fe923226769d40e11806952cd7f46655dd06e10f018/trustme-1.2.1-py3-none-any.whl", hash = "sha256:d768e5fc57c86dfc5ec9365102e9b092541cd6954b35d8c1eea01a84f35a762a", size = 16530, upload-time = "2025-01-02T01:55:30.181Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Long-running evaluations can gradually slow down and hit connection timeouts as their clients open more HTTPS connections.

On Linux with OpenSSL 3.0–3.3, truststore repeatedly adds the default certificate directory to the same SSL context. These duplicate lookups accumulate, making certificate verification increasingly expensive ([upstream issue](https://github.com/sethmlarson/truststore/issues/212)).

### What is the new behavior?

Configure system trust once when Inspect creates its Linux HTTP clients, using Python's standard SSL context. Certificate and hostname verification stay enabled. Custom TLS settings and other platforms keep their existing behavior; HTTPS proxies receive a separate verified context.

### Does this PR introduce a breaking change?

No configuration changes are required.

### Other information:

`uv run make check` and all pre-commit checks pass. `uv run make test` with four workers: **11,971 passed, 5,125 skipped**.

The TLS regression fails on the original code: 20 connections reload trust 20 times. With this change it loads once; valid certificates succeed, and untrusted certificates and wrong hostnames fail.

### Slow tests

With host-specific `INSPECT_TELEMETRY`, `INSPECT_API_KEY_OVERRIDE`, and `INSPECT_REQUIRED_HOOKS` unset:

```bash
uv run --no-sync pytest tests/model/test_http_defaults.py tests/model/providers/test_openai_proxy.py --timeout=120 -q
uv run --no-sync pytest tests/model/test_http_defaults.py tests/model/providers/test_openai_proxy.py --runtrio --timeout=120 -q
```

Normal: 120 passed, 22 Trio cases skipped. Trio: 21 passed, 120 normal cases skipped, one unsupported Google/aiohttp case skipped. These tests use offline TLS handshakes and a local server; live-provider and Docker tests were not run.

### Agent review

Implemented with Codex. GPT-6 performed one fresh-context review, followed by a review of the generated certificate fixtures. No correctness findings; two suggested compatibility tests were added.
