### PR TITLE
fix: deepagent(background=True) survives eval-end scorers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Inspect View: Cancelling or failing an S3 log download no longer eventually stops the view server from serving any S3 logs.
 - Inspect View: Downloading a log whose name contains non-Latin-1 characters no longer fails.
 - Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
+- Deep Agent: Background subagents now remain available while eval scorers run after the solver completes.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/agent/_deepagent/agent_tool.py
+++ b/src/inspect_ai/agent/_deepagent/agent_tool.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Iterator, Literal, Sequence
+from typing import TYPE_CHECKING, AsyncIterator, Callable, Iterator, Literal, Sequence
 
 if TYPE_CHECKING:
     from inspect_ai.approval._policy import ApprovalPolicy
     from inspect_ai.tool._tools._skill import Skill
 
 import anyio
+from anyio.abc import TaskGroup
 from shortuuid import uuid as shortuuid
 
 from inspect_ai.agent._agent import Agent, AgentState
@@ -63,10 +64,10 @@ class AgentFuture:
     """Live state of a background-dispatched subagent.
 
     Construction is sync-safe: the ``cancel_scope`` and ``started_at``
-    fields need an active event loop to populate, so they are passed
-    explicitly by ``_dispatch_background`` (which runs inside the loop).
-    They are typed ``Optional`` only to allow tests / unit-level use
-    outside an event loop; production code always sets them.
+    fields need an active event loop to populate, so the registry passes
+    them explicitly while dispatching. They are typed ``Optional`` only to
+    allow tests / unit-level use outside an event loop; production code
+    always sets them.
     """
 
     agent_id: str
@@ -80,12 +81,10 @@ class AgentFuture:
 
     cancel_scope: anyio.CancelScope | None = None
     """Cancel scope used by ``agent_cancel`` to terminate the child.
-    Set by ``_dispatch_background`` before the background coroutine
-    is kicked off."""
+    Set by the registry before the background coroutine is kicked off."""
 
     started_at: float = 0.0
-    """Monotonic time the dispatch was initiated. Set by
-    ``_dispatch_background`` via ``anyio.current_time()``."""
+    """Monotonic time the registry initiated the dispatch."""
 
     status: BackgroundStatus = "running"
     result: str | None = None
@@ -101,9 +100,10 @@ class AgentFuture:
 class BackgroundRegistry:
     """Per-deepagent registry of background agent futures.
 
-    Lives in a ContextVar set/reset in ``deepagent.execute()``. Nested
-    deepagents get isolated namespaces because ContextVars carry per-task
-    semantics.
+    Each execution owns its own child task group, so dispatch can continue
+    while a scorer runs after the sample's solver task group has closed.
+    Nested deepagents get isolated namespaces because ContextVars carry
+    per-task semantics.
     """
 
     max_background: int
@@ -116,6 +116,8 @@ class BackgroundRegistry:
     eager push and the periodic reminder's "collect" list) so neither
     re-announces a finish the model already saw; never filters what any tool
     displays."""
+
+    _task_group: TaskGroup | None = field(default=None, init=False, repr=False)
 
     def next_id(self) -> str:
         """Allocate the next AGENT-N handle. Counter never reuses."""
@@ -130,6 +132,82 @@ class BackgroundRegistry:
         don't occupy a slot.
         """
         return sum(1 for f in self.futures.values() if f.status == "running")
+
+    def _settle_cancelled_children(self) -> None:
+        """Settle children cancelled before ``_run_background`` can start.
+
+        A task-group cancellation can win immediately after ``start_soon``.
+        Such a child never reaches ``_run_background``'s ``finally`` block.
+        """
+        for future in self.futures.values():
+            if not future.done.is_set():
+                future.status = "cancelled"
+                future.done.set()
+
+    @asynccontextmanager
+    async def _children(self) -> AsyncIterator[None]:
+        """Own children until the deepagent exits, then cancel and drain them."""
+        try:
+            async with anyio.create_task_group() as task_group:
+                self._task_group = task_group
+                try:
+                    yield
+                finally:
+                    task_group.cancel_scope.cancel()
+        except Exception as ex:
+            from inspect_ai.util._anyio import inner_exception
+
+            raise inner_exception(ex) from None
+        finally:
+            self._settle_cancelled_children()
+            self._task_group = None
+
+    def _spawn(
+        self,
+        child_agent: Agent,
+        sa: Subagent,
+        dispatch_input: str | list[ChatMessage],
+        span_id: str,
+        forked: bool,
+        from_message: str | None,
+    ) -> AgentFuture:
+        """Register and schedule one child atomically."""
+        task_group = self._task_group
+        if task_group is None:
+            raise RuntimeError("Background registry is not active.")
+
+        if self.running_count() >= self.max_background:
+            raise ToolError(
+                f"Maximum {self.max_background} background agents reached. "
+                f"Call agent_wait or agent_cancel to free a slot."
+            )
+
+        counter = self.counter
+        agent_id = self.next_id()
+        future = AgentFuture(
+            agent_id=agent_id,
+            span_id=span_id,
+            subagent_name=sa.name,
+            cancel_scope=anyio.CancelScope(),
+            started_at=anyio.current_time(),
+        )
+        self.futures[agent_id] = future
+        try:
+            task_group.start_soon(
+                _run_background,
+                future,
+                child_agent,
+                sa,
+                dispatch_input,
+                span_id,
+                forked,
+                from_message,
+            )
+        except BaseException:
+            del self.futures[agent_id]
+            self.counter = counter
+            raise
+        return future
 
 
 _background_registry: ContextVar[BackgroundRegistry | None] = ContextVar(
@@ -577,18 +655,12 @@ def _dispatch_background(
     forked: bool,
     from_message: str | None,
 ) -> str:
-    """Spawn the child agent in the background and return the AGENT-N handle.
+    """Spawn the child agent in the execution-owned task group.
 
-    Validates the cap, registers an ``AgentFuture``, and kicks the child
-    off via ``background()`` (sample-scoped lifetime).
-
-    All registration is synchronous (no awaits) so the cap check and
-    insert form an atomic critical section under cooperative scheduling —
-    two parallel ``agent(background=True)`` calls cannot both succeed past
-    the cap.
+    ``BackgroundRegistry._spawn`` synchronously performs the cap check,
+    registration, and task scheduling, rolling back registration if
+    ``start_soon`` fails.
     """
-    from inspect_ai.util._background import background
-
     registry = current_background_registry()
     if registry is None:
         raise ToolError(
@@ -596,30 +668,7 @@ def _dispatch_background(
             "(No deepagent background registry on the current ContextVar.)"
         )
 
-    # Cap check + registration is a single synchronous critical section:
-    # there is no `await` between reading running_count() and inserting the
-    # future, so the cooperative scheduler cannot interleave a sibling
-    # dispatch between the check and the insert (no cap-overrun race). In v1
-    # tool calls also execute sequentially, so siblings never even contend.
-    if registry.running_count() >= registry.max_background:
-        raise ToolError(
-            f"Maximum {registry.max_background} background agents reached. "
-            f"Call agent_wait or agent_cancel to free a slot."
-        )
-
-    agent_id = registry.next_id()
-    future = AgentFuture(
-        agent_id=agent_id,
-        span_id=span_id,
-        subagent_name=sa.name,
-        cancel_scope=anyio.CancelScope(),
-        started_at=anyio.current_time(),
-    )
-    registry.futures[agent_id] = future
-
-    background(
-        _run_background,
-        future,
+    future = registry._spawn(
         child_agent,
         sa,
         dispatch_input,
@@ -627,8 +676,7 @@ def _dispatch_background(
         forked,
         from_message,
     )
-
-    return f"Dispatched {agent_id}."
+    return f"Dispatched {future.agent_id}."
 
 
 async def _run_background(
@@ -647,11 +695,10 @@ async def _run_background(
     reference in ``future.child_state`` for the parent's status-peek to
     read — ``run()``'s internal state is unreachable from outside.
 
-    On cancellation (``future.cancel_scope`` is cancelled, or the sample
-    ends), we record ``cancelled`` status and re-raise. ``CancelledError``
-    derives from ``BaseException`` so the ``except Exception`` in
-    ``background()`` (``_background.py:62-65``) will not log it as an
-    error.
+    On cancellation (``future.cancel_scope`` is cancelled, or the registry
+    task group exits), we record ``cancelled`` status and re-raise.
+    ``CancelledError`` derives from ``BaseException`` so it reaches the
+    cancellation handler below rather than being recorded as a child error.
     """
     from copy import copy, deepcopy
 
@@ -662,7 +709,7 @@ async def _run_background(
 
     assert future.cancel_scope is not None, (
         "_run_background requires a cancel_scope; "
-        "_dispatch_background should set this before kicking off."
+        "the registry should set this before kicking off."
     )
     try:
         with future.cancel_scope:
@@ -707,27 +754,26 @@ async def _run_background(
         if future.cancel_scope.cancelled_caught:
             future.status = "cancelled"
     except anyio.get_cancelled_exc_class():
-        # Outer cancellation (sample teardown) propagates *through* our
-        # inner scope rather than being absorbed. Record and re-raise —
-        # structured concurrency requires it to propagate.
+        # Outer cancellation propagates through our inner scope rather than
+        # being absorbed. Record and re-raise so structured concurrency can
+        # propagate it.
         future.status = "cancelled"
         raise
     except (LimitExceededError, TerminateSampleError):
         # Sample-level control flow must propagate so the sample runner
-        # records/enforces it (run.py catches these off sample.tg). The
-        # subagent's OWN limits were already caught into limit_scope by
-        # apply_limits(catch_errors=True), so any LimitExceededError that
-        # reaches here belongs to an outer (sample/parent) scope and must
-        # not be downgraded to a per-agent "errored" result. The sample is
-        # terminating; record a terminal status so the `finally: done.set()`
-        # below never wakes a waiter with a stale "running" status.
+        # records/enforces it. The subagent's OWN limits were already caught
+        # into limit_scope by apply_limits(catch_errors=True), so any
+        # LimitExceededError that reaches here belongs to an outer
+        # (sample/parent) scope and must not be downgraded to a per-agent
+        # "errored" result. Record a terminal status so the ``finally`` below
+        # never wakes a waiter with a stale "running" status.
         future.status = "cancelled"
         raise
     except Exception as ex:
         # A background subagent failure is captured on the future and
         # surfaced via agent_status / agent_wait — it must NOT propagate
-        # to sample.tg (that would fail the whole sample). Swallow after
-        # recording; log so the failure is still visible in the eval log.
+        # through the deepagent child task group. Swallow after recording;
+        # log so the failure is still visible in the eval log.
         future.status = "errored"
         future.error = f"{type(ex).__name__}: {ex}"
         logger.warning(

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -239,11 +239,13 @@ def deepagent(
             approval=approval,
         )
 
-        # The background registry lives for the duration of inner(state) so
-        # the agent tool and lifecycle tools can read it via the ContextVar.
+        # Keep the registry installed through child cancellation and drain so
+        # scorer-time deepagents never borrow the sample task group's lifetime.
         if background_enabled:
-            with background_registry(BackgroundRegistry(max_background=max_background)):
-                return await inner(state)
+            registry = BackgroundRegistry(max_background=max_background)
+            with background_registry(registry):
+                async with registry._children():
+                    return await inner(state)
         else:
             return await inner(state)
 

--- a/tests/agent/deepagent/test_deepagent_background.py
+++ b/tests/agent/deepagent/test_deepagent_background.py
@@ -15,6 +15,7 @@ import pytest
 
 from inspect_ai import Task, eval
 from inspect_ai.agent import deepagent, subagent
+from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._deepagent.agent_tool import (
     AgentFuture,
     BackgroundRegistry,
@@ -29,6 +30,8 @@ from inspect_ai.agent._deepagent.deepagent import (
 from inspect_ai.dataset import Sample
 from inspect_ai.event._tool import ToolEvent
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.scorer import Score, Scorer, Target, accuracy, scorer
+from inspect_ai.solver import Generate, Solver, TaskState, generate, solver
 from inspect_ai.tool import Tool, tool
 from inspect_ai.util import message_limit
 
@@ -87,6 +90,27 @@ def _snapshot_test_helper() -> Tool:
         return ",".join(items)
 
     return execute
+
+
+def _capture_background_registry(
+    captured: list[BackgroundRegistry],
+) -> Tool:
+    """Build a parent tool that retains the current registry for assertions."""
+
+    @tool
+    def capture_background_registry() -> Tool:
+        """Record the current deepagent background registry."""
+
+        async def execute() -> str:
+            """Capture the active background registry for the parent."""
+            registry = current_background_registry()
+            assert registry is not None
+            captured.append(registry)
+            return "captured"
+
+        return execute
+
+    return capture_background_registry()
 
 
 def _submit(answer: str = "done") -> ModelOutput:
@@ -522,29 +546,30 @@ class TestDispatchBackground:
 
         reg = BackgroundRegistry(max_background=2)
         with background_registry(reg):
-            self._stub_future(reg)
-            self._stub_future(reg)
-            # Both running; cap is 2 → next dispatch should raise.
-            sa = subagent_factory(
-                name="general",
-                description="d",
-                prompt="p",
-            )
-
-            async def dummy_agent(state):
-                return state
-
-            with pytest.raises(Exception) as exc_info:
-                _dispatch_background(
-                    child_agent=dummy_agent,
-                    sa=sa,
-                    dispatch_input="ignored",
-                    span_id="x",
-                    forked=False,
-                    from_message=None,
+            async with reg._children():
+                self._stub_future(reg)
+                self._stub_future(reg)
+                # Both running; cap is 2 → next dispatch should raise.
+                sa = subagent_factory(
+                    name="general",
+                    description="d",
+                    prompt="p",
                 )
-            assert "Maximum 2" in str(exc_info.value)
-            assert "agent_wait" in str(exc_info.value)
+
+                async def dummy_agent(state):
+                    return state
+
+                with pytest.raises(Exception) as exc_info:
+                    _dispatch_background(
+                        child_agent=dummy_agent,
+                        sa=sa,
+                        dispatch_input="ignored",
+                        span_id="x",
+                        forked=False,
+                        from_message=None,
+                    )
+                assert "Maximum 2" in str(exc_info.value)
+                assert "agent_wait" in str(exc_info.value)
 
     async def test_cap_check_excludes_terminal_futures(self) -> None:
         """Completed/cancelled/errored futures don't count toward the cap."""
@@ -589,6 +614,36 @@ class TestDispatchBackground:
                 from_message=None,
             )
         assert "Background dispatch is not available" in str(exc_info.value)
+
+    async def test_scheduling_failure_rolls_back_registration(self) -> None:
+        """A closed registry task group cannot leave a ghost future behind."""
+        from inspect_ai.agent._deepagent.agent_tool import _dispatch_background
+        from inspect_ai.agent._deepagent.subagent import subagent as subagent_factory
+
+        async with anyio.create_task_group() as task_group:
+            pass
+
+        registry = BackgroundRegistry(max_background=1)
+        registry._task_group = task_group
+        subagent = subagent_factory(name="general", description="d", prompt="p")
+
+        async def child_agent(state):
+            return state
+
+        with background_registry(registry):
+            with pytest.raises(RuntimeError):
+                _dispatch_background(
+                    child_agent=child_agent,
+                    sa=subagent,
+                    dispatch_input="ignored",
+                    span_id="x",
+                    forked=False,
+                    from_message=None,
+                )
+
+        assert registry.futures == {}
+        assert registry.running_count() == 0
+        assert registry.counter == 0
 
 
 class TestBackgroundExecution:
@@ -883,6 +938,41 @@ class TestRegistryIsolation:
 
             # Restored: outer's one agent is visible again
             assert len(active_background_agents()) == 1
+
+    async def test_parallel_contexts_do_not_share_futures(self) -> None:
+        """Concurrent ContextVar scopes retain only their own futures."""
+        both_entered = anyio.Event()
+        release = anyio.Event()
+        registries: dict[str, BackgroundRegistry] = {}
+        observed: dict[str, list[str]] = {}
+
+        async def observe(label: str) -> None:
+            registry = BackgroundRegistry(max_background=1)
+            registry.futures["AGENT-1"] = AgentFuture(
+                agent_id="AGENT-1",
+                span_id=label,
+                subagent_name=label,
+                cancel_scope=anyio.CancelScope(),
+                started_at=anyio.current_time(),
+            )
+            with background_registry(registry):
+                registries[label] = registry
+                if len(registries) == 2:
+                    both_entered.set()
+                await both_entered.wait()
+                observed[label] = [
+                    future.subagent_name for future in active_background_agents()
+                ]
+                if len(observed) == 2:
+                    release.set()
+                await release.wait()
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(observe, "alpha")
+            task_group.start_soon(observe, "beta")
+
+        assert registries["alpha"] is not registries["beta"]
+        assert observed == {"alpha": ["alpha"], "beta": ["beta"]}
 
 
 # ---------------------------------------------------------------------------
@@ -1661,7 +1751,6 @@ class TestReminderE2E:
     def test_composes_with_callable_on_continue(self) -> None:
         # A user-supplied on_continue is still invoked, and the reminder
         # rides along on top of it.
-        from inspect_ai.agent._agent import AgentState
 
         calls = {"n": 0}
 
@@ -1854,6 +1943,243 @@ class TestAbandonOnExit:
         assert "AGENT-1" in str(agent_events[0].result)
 
 
+class TestBackgroundRegistryLifetime:
+    """A deepagent owns and drains its children before its caller continues."""
+
+    async def test_immediate_group_exit_settles_future(self) -> None:
+        """Immediate group exit leaves a terminal cancelled future."""
+        from inspect_ai.agent._deepagent.agent_tool import _dispatch_background
+        from inspect_ai.agent._deepagent.subagent import subagent as subagent_factory
+
+        registry = BackgroundRegistry(max_background=1)
+        subagent_type = subagent_factory(name="general", description="d", prompt="p")
+
+        async def child_agent(state):
+            await anyio.sleep_forever()
+            return state
+
+        with background_registry(registry):
+            async with registry._children():
+                _dispatch_background(
+                    child_agent=child_agent,
+                    sa=subagent_type,
+                    dispatch_input="ignored",
+                    span_id="x",
+                    forked=False,
+                    from_message=None,
+                )
+                future = registry.futures["AGENT-1"]
+
+        assert registry.running_count() == 0
+        assert future.status == "cancelled"
+        assert future.done.is_set()
+
+    def test_scorer_waits_for_background_reviewer_after_solver(self) -> None:
+        """A scorer can dispatch and collect a reviewer after solver completion."""
+        reviewer = _build_submit_subagent("reviewer", "reviewed")
+        reviewer_model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                _agent_call(prompt="Review the completed solver output."),
+                _tool_call(
+                    "agent_wait",
+                    agent_ids=["AGENT-1"],
+                    mode="all",
+                    timeout=0.2,
+                ),
+                _submit("scorecard complete"),
+            ],
+        )
+
+        @scorer(metrics=[accuracy()])
+        def score_with_reviewer() -> Scorer:
+            async def score(state: TaskState, target: Target) -> Score:
+                review_agent = deepagent(
+                    subagents=[reviewer],
+                    model=reviewer_model,
+                    background=True,
+                    submit=True,
+                )
+                await review_agent(AgentState(messages=list(state.messages)))
+                return Score(value=1.0)
+
+            return score
+
+        task = Task(
+            dataset=[Sample(input="Solve this.", target="done")],
+            solver=[generate()],
+            scorer=score_with_reviewer(),
+        )
+        solver_model = get_model(
+            "mockllm/model",
+            custom_outputs=[ModelOutput.from_content("mockllm/model", "done")],
+        )
+        log = eval(task, model=solver_model)[0]
+
+        assert log.status == "success"
+        assert log.samples is not None
+        sample = log.samples[0]
+        submit_events = [
+            event
+            for event in sample.events
+            if isinstance(event, ToolEvent) and event.function == "submit"
+        ]
+        assert any("scorecard complete" in str(event.result) for event in submit_events)
+        agent_events = [
+            event
+            for event in sample.events
+            if isinstance(event, ToolEvent) and event.function == "agent"
+        ]
+        assert len(agent_events) == 1
+        assert agent_events[0].error is None
+        wait_events = [
+            event
+            for event in sample.events
+            if isinstance(event, ToolEvent) and event.function == "agent_wait"
+        ]
+        assert len(wait_events) == 1
+        assert wait_events[0].error is None
+        assert "completed" in str(wait_events[0].result)
+        assert "reviewed" in str(wait_events[0].result)
+
+    def test_normal_return_drains_background_children(self) -> None:
+        """A parent return settles a child before the enclosing solver continues."""
+        captured: list[BackgroundRegistry] = []
+        child = _build_blocking_subagent("normal_child")
+        parent = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                _agent_call(prompt="Start the child."),
+                _tool_call("capture_background_registry"),
+                _submit("complete"),
+            ],
+        )
+        agent = deepagent(
+            subagents=[child],
+            tools=[_capture_background_registry(captured)],
+            model=parent,
+            background=True,
+            submit=True,
+        )
+
+        @solver
+        def run_agent() -> Solver:
+            async def solve(state: TaskState, generate: Generate) -> TaskState:
+                await agent(AgentState(messages=list(state.messages)))
+                assert len(captured) == 1
+                future = captured[0].futures["AGENT-1"]
+                assert future.status == "cancelled"
+                assert future.done.is_set()
+                return state
+
+            return solve
+
+        log = eval(
+            Task(dataset=[Sample(input="Do work.")], solver=[run_agent()]),
+            model="mockllm/model",
+        )[0]
+        assert log.status == "success"
+
+    def test_root_failure_drains_background_children(self) -> None:
+        """A root model error drains a child before the caller receives it."""
+        captured: list[BackgroundRegistry] = []
+        child = _build_blocking_subagent("failing_child")
+        output_count = 0
+
+        def parent_output(input, tools, tool_choice, config):
+            nonlocal output_count
+            output_count += 1
+            if output_count == 1:
+                return _agent_call(prompt="Start the child.")
+            if output_count == 2:
+                return _tool_call("capture_background_registry")
+            raise RuntimeError("root failure")
+
+        agent = deepagent(
+            subagents=[child],
+            tools=[_capture_background_registry(captured)],
+            model=get_model("mockllm/model", custom_outputs=parent_output),
+            background=True,
+            submit=True,
+        )
+
+        @solver
+        def run_agent() -> Solver:
+            async def solve(state: TaskState, generate: Generate) -> TaskState:
+                with pytest.raises(RuntimeError, match="root failure"):
+                    await agent(AgentState(messages=list(state.messages)))
+                assert len(captured) == 1
+                future = captured[0].futures["AGENT-1"]
+                assert future.status == "cancelled"
+                assert future.done.is_set()
+                return state
+
+            return solve
+
+        log = eval(
+            Task(dataset=[Sample(input="Do work.")], solver=[run_agent()]),
+            model="mockllm/model",
+        )[0]
+        assert log.status == "success"
+
+    def test_parent_cancellation_drains_background_children(self) -> None:
+        """A parent cancellation settles a child before the caller resumes."""
+        captured: list[BackgroundRegistry] = []
+        child = _build_blocking_subagent("cancelled_child")
+
+        @solver
+        def run_agent() -> Solver:
+            async def solve(state: TaskState, generate: Generate) -> TaskState:
+                with anyio.CancelScope() as cancel_scope:
+
+                    @tool
+                    def cancel_parent() -> Tool:
+                        """Cancel the root deepagent."""
+
+                        async def execute() -> str:
+                            """Cancel the enclosing deepagent execution."""
+                            cancel_scope.cancel()
+                            await anyio.sleep(0)
+                            return "unreachable"
+
+                        return execute
+
+                    parent = get_model(
+                        "mockllm/model",
+                        custom_outputs=[
+                            _agent_call(prompt="Start the child."),
+                            _tool_call("capture_background_registry"),
+                            _tool_call("cancel_parent"),
+                        ],
+                    )
+                    agent = deepagent(
+                        subagents=[child],
+                        tools=[
+                            _capture_background_registry(captured),
+                            cancel_parent(),
+                        ],
+                        model=parent,
+                        background=True,
+                        submit=True,
+                    )
+                    await agent(AgentState(messages=list(state.messages)))
+
+                assert cancel_scope.cancel_called
+                assert len(captured) == 1
+                future = captured[0].futures["AGENT-1"]
+                assert future.status == "cancelled"
+                assert future.done.is_set()
+                return state
+
+            return solve
+
+        log = eval(
+            Task(dataset=[Sample(input="Do work.")], solver=[run_agent()]),
+            model="mockllm/model",
+        )[0]
+        assert log.status == "success"
+
+
 # ---------------------------------------------------------------------------
 # Phase 5 Tier 2 — async edge branches
 # ---------------------------------------------------------------------------
@@ -1938,8 +2264,6 @@ class TestReminderComposition:
         assert len(_reminder_messages(result)) >= 1
 
     def test_on_continue_false_suppresses_reminder(self) -> None:
-        from inspect_ai.agent._agent import AgentState
-
         calls = {"n": 0}
 
         async def my_continue(state: AgentState) -> bool:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When `deepagent(background=True)` runs from an eval-end scorer, it schedules its background subagent on the sample task group. The solver has already closed that group before scorer execution, so dispatch fails while the Deep Agent is still executing.

### What is the new behavior?

Each Deep Agent execution owns the task group for its background subagents. The group is cancelled and drained when that execution exits, while normal completion, cancellation, and error handling retain their existing terminal future semantics.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

The regression covers a scorer that dispatches and waits for a background reviewer after solver completion, plus normal return, root failure, parent cancellation, immediate cancellation, scheduling rollback, and parallel registry isolation.

### Slow tests

- `uv run pytest tests/agent/deepagent/test_deepagent_background.py -v`: 105 passed, 32 skipped.
- `uv run pytest tests/agent/deepagent/test_deepagent_background.py -v --runtrio`: 32 passed, 105 skipped.
- `uv run pytest tests/agent/deepagent --runslow -q`: 249 passed, 32 skipped. It includes `test_deepagent_background_demo` and uses mock models, with no provider credentials or Docker required.
- API- and Docker-dependent coverage was not run. The broader `uv run pytest --runslow --runapi tests/agent/` suite previously reached 69% before its 900-second execution deadline; provider credentials were not injected and Docker was not operated.

### Agent review

- Reviewer: OpenAI GPT-6 Astra in a fresh context, 2 passes.
- Findings: 2 body omissions. The required slow-test disclosure and the feasible Deep Agent slow-test result were missing; both are fixed in this draft.

Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

Opened and updated by Claude on behalf of @sjawhar.
