### PR TITLE
fix(docker): preserve health wait after compose startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Sandbox Tools: Binaries downloaded from S3 that fail SHA256 verification or lack a pinned digest are now rejected instead of run with a warning; `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` has been removed.
 - Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.
 - Docker: Timed commands no longer run an agent-planted timeout executable from the sandbox's PATH with elevated privileges.
+- Docker: Compose sandbox startup now retains the complete health-check wait budget rather than timing out while services start.
 - Inspect View: Requests for unreadable log headers now return 403 instead of 500.
 - Eval Set: Tasks that set a non-mean epochs reducer now reuse their completed log on subsequent `eval_set()` calls instead of being re-run every time.
 - Human Agent: Sandbox installation of the `task` CLI now refuses a pre-planted or non-root-owned `/opt/human_agent`, errors instead of silently skipping when it cannot be created, and no longer runs a staged install script.

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -39,24 +39,32 @@ async def compose_up(
 
     # are there healthchecks in the service definitions? if so then peg our timeout
     # at the maximum total wait time. otherwise, pick a reasonable default
-    healthcheck_time = services_healthcheck_time(services)
-    if healthcheck_time > 0:
-        timeout: int = healthcheck_time
+    healthcheck_timeout = services_healthcheck_time(services)
+    if healthcheck_timeout > 0:
         trace_message(
-            logger, TRACE_DOCKER, f"Docker services healthcheck timeout: {timeout}"
+            logger,
+            TRACE_DOCKER,
+            f"Docker services healthcheck timeout: {healthcheck_timeout}",
         )
     else:
-        timeout = COMPOSE_WAIT
+        healthcheck_timeout = COMPOSE_WAIT
 
-    # align global wait timeout to maximum healthcheck timeout
-    up_command.extend(["--wait-timeout", str(timeout + 1)])
+    # Compose creates and starts services before applying --wait-timeout. Reserve
+    # up to COMPOSE_WAIT seconds for startup, then give Docker its full healthcheck
+    # window.
+    wait_timeout = healthcheck_timeout + 1
+    up_command.extend(["--wait-timeout", str(wait_timeout)])
 
     # Start the environment. Note that we don't check the result because docker will
     # return a non-zero exit code for services that exit (even successfully) when
     # passing the --wait flag (see https://github.com/docker/compose/issues/10596).
     # In practice, we will catch any errors when calling compose_check_running()
     # immediately after we call compose_up().
-    result = await compose_command(up_command, project=project, timeout=timeout)
+    result = await compose_command(
+        up_command,
+        project=project,
+        timeout=COMPOSE_WAIT + wait_timeout,
+    )
     return result
 
 

--- a/tests/util/sandbox/test_docker_compose_config.py
+++ b/tests/util/sandbox/test_docker_compose_config.py
@@ -2,16 +2,21 @@
 
 import os
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai.util import ComposeConfig, ComposeService
+from inspect_ai.util._sandbox.docker import compose as compose_module
 from inspect_ai.util._sandbox.docker.config import (
     auto_compose_dir,
     is_auto_compose_file,
 )
 from inspect_ai.util._sandbox.docker.docker import DockerSandboxEnvironment
+from inspect_ai.util._sandbox.docker.service import (
+    ComposeService as DockerComposeService,
+)
 from inspect_ai.util._sandbox.docker.util import ComposeProject
 
 
@@ -179,3 +184,41 @@ async def test_compose_config_with_extensions(request) -> None:
     finally:
         if project.config and os.path.exists(project.config):
             os.unlink(project.config)
+
+
+async def test_compose_up_process_timeout_includes_startup_and_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leave the full Docker wait window after bounded startup."""
+    compose_command = AsyncMock()
+    monkeypatch.setattr(compose_module, "compose_command", compose_command)
+    services: dict[str, DockerComposeService] = {
+        "default": {
+            "image": "nginx",
+            "healthcheck": {
+                "start_period": "2s",
+                "interval": "2s",
+                "timeout": "5s",
+                "retries": 3,
+            },
+        }
+    }
+
+    await compose_module.compose_up(
+        ComposeProject(
+            name="inspect-test",
+            config=None,
+            sample_id=None,
+            epoch=None,
+            env=None,
+        ),
+        services,
+    )
+
+    call = compose_command.await_args
+    assert call is not None
+    command = call.args[0]
+    wait_timeout = int(command[command.index("--wait-timeout") + 1])
+    process_timeout = call.kwargs["timeout"]
+
+    assert process_timeout == compose_module.COMPOSE_WAIT + wait_timeout


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`compose_up()` gives the Compose subprocess the health-check estimate as its process deadline while passing a one-second-larger `--wait-timeout`. Docker Compose creates and starts services before it begins waiting for health, so a startup can consume the process deadline before Docker's requested health-check wait has elapsed.

### What is the new behavior?

The subprocess deadline now reserves up to 600 seconds for service creation and startup followed by the complete Docker health-check window. The Docker `--wait-timeout`, retry count and retry-deadline calculation policy, and terminal timeout error remain unchanged. The first-attempt process deadline rises from 28 to 629 seconds with this health check and from 600 to 1,201 seconds without one; its derived retry deadlines change only in the health-check case (28/14 to 60/30) and remain 60/30 without a health check. `DockerSandboxEnvironment` uses a narrower `host_timeout = timeout + 10` allowance elsewhere; maintainers may prefer that smaller startup allowance.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation:
- `uv run make check` passed: Ruff, formatting, mypy (1,461 source files), and the suppression ledger.
- The focused timeout-contract test passed for both asyncio and trio.

### Slow tests

- `uv run pytest --runslow tests/util/ tests/checkpoint/` completed at code-equivalent candidate `3f292f62` with 2,023 passed and 841 skipped; Docker 29.7.2 was available.
- On the final candidate, `uv run pytest --runslow tests/util/sandbox/test_docker_compose_config.py -v` completed with 5 passed and 5 skipped. The dedicated trio command covers the changed test only; the file's other four trio variants were not run.

### Agent review

- Reviewer: gpt-6-astra, one fresh-context review and two same-context body-only re-checks.
- Findings: 1 — clarified the retry-deadline behavior; fixed.

Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

Opened and updated by Claude on behalf of @sjawhar.
