### PR TITLE
fix: stamp additionalProperties:false only on object schema nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Inspect View: Cancelling or failing an S3 log download no longer eventually stops the view server from serving any S3 logs.
 - Inspect View: Downloading a log whose name contains non-Latin-1 characters no longer fails.
 - Timelines: Filtering now removes matching excluded spans from branches as well as main timeline content.
+- Anthropic: Structured output requests whose response schema has an optional (nullable) field no longer fail with HTTP 400; `additionalProperties: false` is now applied to object nodes only.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -29,8 +29,8 @@ from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_choice import ToolFunction
 from inspect_ai.util._json import (
     JSON_SCHEMA_EXTENDED_FIELDS,
-    JSONSchema,
     json_schema_dump,
+    set_additional_properties_false,
 )
 
 from .._chat_message import (
@@ -302,29 +302,6 @@ class ConverseClientConverseRequest(BaseModel):
         Union[dict[str, Any], list[Any], int, float, str, bool, None] | None
     ) = None
     additionalModelResponseFieldPaths: list[str] = []
-
-
-def _lock_object_additional_properties(schema: JSONSchema) -> None:
-    """Set `additionalProperties: false` on object nodes only.
-
-    Bedrock's structured-output grammar compiler requires objects to forbid
-    extra properties, but rejects `additionalProperties` on `anyOf` nodes (how
-    optional/union fields are expressed). Setting it only on objects keeps
-    optional fields working. This matches the object-only handling in the
-    OpenAI and Anthropic SDKs; it is done locally here rather than via the
-    shared `set_additional_properties_false` (which stamps every node) because
-    only Bedrock's compiler is strict enough to reject the looser shape.
-    """
-    if schema.type == "object" or schema.properties:
-        schema.additionalProperties = False
-    if schema.items:
-        _lock_object_additional_properties(schema.items)
-    if schema.properties:
-        for prop_schema in schema.properties.values():
-            _lock_object_additional_properties(prop_schema)
-    if schema.anyOf:
-        for any_schema in schema.anyOf:
-            _lock_object_additional_properties(any_schema)
 
 
 # Claude families AWS documents as not supporting Converse prompt caching.
@@ -959,7 +936,7 @@ class BedrockAPI(ModelAPI):
             return None
 
         schema = config.response_schema.json_schema.model_copy(deep=True)
-        _lock_object_additional_properties(schema)
+        set_additional_properties_false(schema)
         return {
             "type": "json_schema",
             "schema": json_schema_dump(schema, exclude=JSON_SCHEMA_EXTENDED_FIELDS),

--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -351,10 +351,18 @@ def resolve_schema_references(schema: dict[str, Any]) -> dict[str, Any]:
 
 
 def set_additional_properties_false(schema: JSONSchema) -> None:
-    # Set on top level
-    schema.additionalProperties = False
+    """Set `additionalProperties: false` on every object node of a schema.
 
-    # Recursively process nested schemas
+    Structured-output providers require objects to forbid extra properties but
+    reject `additionalProperties` on non-object nodes: the Anthropic API answers
+    HTTP 400 ("For 'anyOf', 'additionalProperties' is not supported") when the
+    keyword lands on the `anyOf` that Pydantic emits for an optional field, and
+    Bedrock's grammar compiler does the same. Only object nodes are stamped,
+    matching the transformation the Anthropic and OpenAI SDKs apply themselves.
+    """
+    if schema.type == "object" or schema.properties:
+        schema.additionalProperties = False
+
     if schema.items:
         set_additional_properties_false(schema.items)
 

--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -360,7 +360,11 @@ def set_additional_properties_false(schema: JSONSchema) -> None:
     Bedrock's grammar compiler does the same. Only object nodes are stamped,
     matching the transformation the Anthropic and OpenAI SDKs apply themselves.
     """
-    if schema.type == "object" or schema.properties:
+    if (
+        schema.type == "object"
+        or (isinstance(schema.type, list) and "object" in schema.type)
+        or schema.properties
+    ):
         schema.additionalProperties = False
 
     if schema.items:

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, create_autospec, patch
 
 import pytest
+from pydantic import BaseModel
 from test_helpers.utils import setenv_if_unset, skip_if_no_anthropic
 
 from inspect_ai import Task, eval
@@ -20,10 +21,12 @@ from inspect_ai.model import (
     ChatMessageTool,
     ChatMessageUser,
     GenerateConfig,
+    ResponseSchema,
     get_model,
 )
 from inspect_ai.model._providers.anthropic import AnthropicAPI
 from inspect_ai.tool import ToolCall, ToolFunction, ToolInfo
+from inspect_ai.util import json_schema
 
 
 @pytest.mark.anyio
@@ -115,6 +118,29 @@ def test_anthropic_extra_headers_not_mutated_across_calls() -> None:
             "anthropic_beta": "context-1m-2025-08-07",
             "x-test-header": "value",
         }
+
+
+def test_response_schema_with_optional_field_omits_additional_properties_on_anyof():
+    """The API rejects additionalProperties on the anyOf an optional field renders as."""
+
+    class Report(BaseModel):
+        summary: str
+        severity: Literal["low", "high"] | None = None
+
+    api = AnthropicAPI(model_name="claude-opus-4-8", api_key="test-key")
+    config = GenerateConfig(
+        max_tokens=64,
+        response_schema=ResponseSchema(name="report", json_schema=json_schema(Report)),
+    )
+    _params, extra_body, _headers, betas = api.completion_config(config)
+
+    assert "structured-outputs-2025-11-13" in betas
+    schema = extra_body["output_format"]["schema"]
+    assert schema["additionalProperties"] is False
+    severity = schema["properties"]["severity"]
+    assert "anyOf" in severity
+    assert "additionalProperties" not in severity
+    assert all("additionalProperties" not in member for member in severity["anyOf"])
 
 
 @pytest.mark.anyio

--- a/tests/util/test_json_schema.py
+++ b/tests/util/test_json_schema.py
@@ -10,6 +10,7 @@ from inspect_ai.util._json import (
     json_schema,
     json_schema_dump,
     json_schema_to_base_model,
+    set_additional_properties_false,
 )
 
 
@@ -636,3 +637,29 @@ def test_json_schema_dump_anyof_exclude():
     assert "minimum" not in result["anyOf"][1]
     assert result["anyOf"][0]["type"] == "string"
     assert result["anyOf"][1]["type"] == "integer"
+
+
+def test_set_additional_properties_false_stamps_object_nodes_only():
+    """Optional fields render as anyOf; providers reject additionalProperties there."""
+
+    class Inner(BaseModel):
+        label: str
+
+    class Outer(BaseModel):
+        name: str
+        nickname: str | None = None
+        inner: Inner
+        items: list[Inner]
+
+    schema = json_schema(Outer)
+    set_additional_properties_false(schema)
+    dumped = json_schema_dump(schema, exclude=JSON_SCHEMA_EXTENDED_FIELDS)
+
+    assert dumped["additionalProperties"] is False
+    assert dumped["properties"]["inner"]["additionalProperties"] is False
+    assert dumped["properties"]["items"]["items"]["additionalProperties"] is False
+    assert "additionalProperties" not in dumped["properties"]["name"]
+    nickname = dumped["properties"]["nickname"]
+    assert "anyOf" in nickname
+    assert "additionalProperties" not in nickname
+    assert all("additionalProperties" not in member for member in nickname["anyOf"])

--- a/tests/util/test_json_schema.py
+++ b/tests/util/test_json_schema.py
@@ -663,3 +663,18 @@ def test_set_additional_properties_false_stamps_object_nodes_only():
     assert "anyOf" in nickname
     assert "additionalProperties" not in nickname
     assert all("additionalProperties" not in member for member in nickname["anyOf"])
+
+
+def test_set_additional_properties_false_stamps_nullable_object_type_arrays():
+    """Object alternatives expressed by a type array remain strict."""
+    schema = JSONSchema(
+        anyOf=[
+            JSONSchema(type=["object", "null"]),
+            JSONSchema(type=["object", "null"], properties={}),
+        ]
+    )
+
+    set_additional_properties_false(schema)
+
+    assert schema.anyOf is not None
+    assert all(member.additionalProperties is False for member in schema.anyOf)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

A response schema with an optional field contains an `anyOf` wrapper. The shared schema transformation adds `additionalProperties: false` to that wrapper and to scalar alternatives. Anthropic rejects that response-schema shape with HTTP 400.

### What is the new behavior?

The shared transformation now applies `additionalProperties: false` only to object schemas. Anthropic request schemas retain strict object nodes without sending the keyword on `anyOf` or scalar nodes. Bedrock now reuses the shared transformation instead of its duplicate object-only implementation.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation:
- `uv run make check` passed: ruff, formatting, mypy, and the suppressions check.
- `uv run pytest tests/util/test_json_schema.py::test_set_additional_properties_false_stamps_object_nodes_only tests/util/test_json_schema.py::test_set_additional_properties_false_stamps_nullable_object_type_arrays tests/model/providers/test_anthropic.py::test_response_schema_with_optional_field_omits_additional_properties_on_anyof -v` passed (3 passed).
- `uv run pytest tests/util/test_json_schema.py tests/model/providers/test_anthropic.py tests/model/providers/test_bedrock_structured_output.py -ra` passed (230 passed, 76 skipped).
- Schema drivers confirmed the Anthropic configuration keeps both ordinary and type-array nullable object schemas strict while omitting the keyword from optional-field `anyOf` wrappers and scalar alternatives.

### Slow tests

- Not run: live Anthropic API cases require `--runapi`; live Bedrock structured-output cases require `ENABLE_BEDROCK_TESTS`; the slow Anthropic test requires `--runslow`; Trio variants require `--runtrio`.

### Agent review

- Reviewer: openai/gpt-6-astra via Oh My Pi, fresh context, 2 passes. Findings: the first pass found a nullable object expressed by a type array could lose `additionalProperties: false`; the predicate and regression coverage were added. The second pass confirmed no remaining findings.

Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

Opened and updated by Claude on behalf of @sjawhar.
