### PR TITLE
fix(google): omit placeholder API key from ADC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Control Channel: `inspect ctl sample cancel` now works on a sample that is still initializing (e.g. waiting on sandbox provisioning) — the cancel applies the moment the sample starts, and `inspect ctl sample list` marks the pending cancel.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
+- Google: OAuth/ADC requests to the Gemini Developer API no longer send the placeholder API-key header alongside bearer authentication.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Approval: Policy files given as percent-encoded `file://` URIs (e.g. paths with spaces, as `Path.as_uri()` produces) are now accepted by `eval()`, `Task()`, and `--approval`.

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -1052,23 +1052,30 @@ class GoogleGenAIAPI(ModelAPI):
         ):
             http_options.httpx_async_client = default_async_client()
         api_key = self.api_key
-        if self._oauth and self._credentials is not None:
-            # The dev-endpoint client requires a non-empty api_key; pass a
-            # placeholder and carry the OAuth bearer token in headers instead
-            # (Authorization overrides the placeholder x-goog-api-key). Header
-            # building does no I/O — token freshness is ensured by the awaited
-            # _ensure_oauth_token() at the top of generate()/count_tokens().
+        credentials = self._credentials
+        oauth = self._oauth and credentials is not None
+        if oauth:
+            assert credentials is not None
+            # google-genai refuses a Gemini Developer API client without an API
+            # key, even when a bearer token is supplied. It therefore needs a
+            # placeholder at construction time, but Google rejects that
+            # placeholder when it is sent as x-goog-api-key alongside OAuth.
+            # Remove the SDK-added header after construction below.
             api_key = OAUTH_PLACEHOLDER_API_KEY
             http_options.headers = {
                 **(http_options.headers or {}),
-                **self._credentials.headers(self._quota_project_id),
+                **credentials.headers(self._quota_project_id),
             }
-        return Client(
+        client = Client(
             vertexai=self.is_vertex(),
             api_key=api_key,
             http_options=http_options,
             **self.model_args,
         )
+        if oauth:
+            assert client._api_client._http_options.headers is not None
+            del client._api_client._http_options.headers["x-goog-api-key"]
+        return client
 
     def handle_client_error(self, ex: ClientError) -> ModelOutput | Exception:
         # exceeding a quota with a limit of 0 means no access to model or capability,

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1889,22 +1889,15 @@ async def test_google_oauth_count_tokens_headers() -> None:
     assert headers["x-goog-user-project"] == "proj"
 
 
-def test_google_oauth_headers_survive_real_client() -> None:
-    """Contract test against the real google-genai client (no mocking).
-
-    The OAuth approach relies on undocumented SDK behavior: the dev-endpoint
-    client accepts a placeholder api_key, and `patch_http_options` merges
-    caller-supplied headers with caller precedence, so `Authorization` survives
-    alongside the SDK-set `x-goog-api-key`. Guards against a google-genai
-    release changing that merge.
-    """
+def test_google_oauth_real_client_excludes_placeholder_api_key() -> None:
+    """OAuth requests must not send the SDK's required placeholder as an API key."""
     api = _adc_api(_FakeCreds(token="tok-real"), quota_project_id="proj-real")
     client = api.model_client(api._http_options())
     headers = client._api_client._http_options.headers
     assert headers is not None
     assert headers["Authorization"] == "Bearer tok-real"
     assert headers["x-goog-user-project"] == "proj-real"
-    assert headers["x-goog-api-key"] == OAUTH_PLACEHOLDER_API_KEY
+    assert "x-goog-api-key" not in headers
 
 
 def test_google_use_adc_rejected_on_vertex() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Gemini Developer API clients configured with OAuth/Application Default Credentials must be constructed with an SDK placeholder API key. The SDK then sends that placeholder in `x-goog-api-key` alongside the bearer and quota-project headers, producing an invalid mixed-auth request. This corrects the OAuth/ADC support introduced by #4517.

### What is the new behavior?

After constructing an OAuth client, Inspect removes the SDK-added placeholder API-key header while retaining the bearer and quota-project headers. API-key authentication and Vertex configuration are unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

- Adds an Unreleased changelog entry for the corrected request authentication behavior.
- Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

### Validation

- `uv run make check`
- `uv run pytest tests/model/providers/test_google.py -k 'oauth' -q`: 13 passed, 9 skipped (the 9 Trio variants are covered by the next command)
- `uv run pytest tests/model/providers/test_google.py -k 'oauth' -q --runtrio`: 9 passed, 13 skipped (the 13 asyncio variants are covered by the preceding command)
- `make suppressions-check`
- `uv run make test` was started but did not complete locally. Its single checkpoint assertion failure reproduces unchanged on the base revision and is outside this diff.

### Slow tests

A live Gemini Developer API request was not run because it requires Application Default Credentials; the real SDK client-construction contract is covered locally.

### Agent review

- Reviewer: GPT-6 Astra (openai/gpt-6-astra) via fresh context. One full review and one record-only re-check after correcting a review-packet lag count.
- Findings: no code or PR-body repairs. The SDK-header deletion intentionally fails loudly if a future SDK stops adding that header.

Opened and updated by Claude on behalf of @sjawhar.
