### PR TITLE
fix(bridge): keep client-executed tool_search for non-OpenAI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Control Channel: `inspect ctl sample cancel` now works on a sample that is still initializing (e.g. waiting on sandbox provisioning) — the cancel applies the moment the sample starts, and `inspect ctl sample list` marks the pending cancel.
 - Sample and Task Sources: `sample_complete()` now fires for a running sample cancelled individually, so a source waiting on that sample no longer stalls; a blocking callback can no longer hang a task cancel.
 - Agent Bridge: Google clients now receive token log probabilities and top candidates returned by the host model.
+- Agent Bridge: Client-executed tool search can now expose discovered tools to non-OpenAI model providers.
 - Scoring: `math()` now records `reason="invalid_response_format"` when no answer can be extracted, so format failures are distinguishable from wrong answers.
 - Scorer: metrics that own a degenerate shape (e.g. `grouped()`) now report it on an all-unscored run instead of collapsing to a synthesized flat NaN, on both the list and dict metric paths; metrics that raise on empty input still report NaN, with a one-time warning. (#5150)
 - Approval: Policy files given as percent-encoded `file://` URIs (e.g. paths with spaces, as `Path.as_uri()` produces) are now accepted by `eval()`, `Task()`, and `--approval`.

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -300,13 +300,13 @@ async def inspect_responses_api_request_impl(
                 item_tools = item.get("tools")
                 client_discovery_output = True
             for declared in item_tools or []:
+                if client_discovery_output:
+                    client_discovered_tools.append(declared)
+                    continue
                 key = (declared.get("type"), declared.get("name"))
                 if key not in declared_tool_keys:
                     declared_tool_keys.add(key)
-                    if client_discovery_output:
-                        client_discovered_tools.append(declared)
-                    else:
-                        responses_tools.append(declared)
+                    responses_tools.append(declared)
 
     has_computer_use = any(
         _contains_computer_tool(tool) for tool in responses_tools
@@ -442,6 +442,16 @@ def _record_tool_namespace(
             f"'{existing[1]}::{existing[0]}' and '{namespace}::{name}'."
         )
     tool_namespaces[exposed_name] = identity
+
+
+def _register_client_tool_name(tool_names: set[str], name: str) -> None:
+    """Register a tool exposed to a generic provider without silent shadowing."""
+    if name in tool_names:
+        raise RuntimeError(
+            f"Ambiguous client tool catalog: discovered tool "
+            f"'{name}' conflicts with a tool that is already available."
+        )
+    tool_names.add(name)
 
 
 def _harvest_tool_namespaces(
@@ -641,6 +651,7 @@ def tool_from_responses_tool(
         return ToolInfo(
             name=TOOL_SEARCH_NAME,
             description=tool_param.get("description") or TOOL_SEARCH_NAME,
+            parameters=ToolParams.model_validate(tool_param["parameters"]),
             options={
                 TOOL_SEARCH_OPTIONS_MARKER: True,
                 "description": tool_param.get("description"),
@@ -727,12 +738,16 @@ def tools_from_client_tool_search_output(
             and tool_param.get("execution") != "client"
         ):
             return []
-        return tools_from_responses_tool(
+        client_tools = tools_from_responses_tool(
             tool_param,
             web_search_providers,
             code_execution_providers,
             allow_remote_mcp,
         )
+        for client_tool in client_tools:
+            if isinstance(client_tool, ToolInfo):
+                _register_client_tool_name(tool_names, client_tool.name)
+        return client_tools
 
     namespace = tool_param["name"]
     flattened: list[ToolInfo | Tool] = []
@@ -754,12 +769,7 @@ def tools_from_client_tool_search_output(
             if isinstance(inner_tool, ToolInfo):
                 name = inner_tool.name
                 generic_name = f"{namespace}__{name}"
-                if generic_name in tool_names:
-                    raise RuntimeError(
-                        f"Ambiguous client tool catalog: discovered tool "
-                        f"'{generic_name}' conflicts with a tool that is already available."
-                    )
-                tool_names.add(generic_name)
+                _register_client_tool_name(tool_names, generic_name)
                 inner_tool.name = generic_name
                 _record_tool_namespace(tool_namespaces, generic_name, name, namespace)
             flattened.append(inner_tool)

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -1,7 +1,8 @@
 import json
+from collections.abc import Iterable
 from logging import getLogger
 from time import time
-from typing import Any, Iterable, Set, cast
+from typing import Any, Set, TypeGuard, cast
 
 from openai.types.responses import (
     Response,
@@ -59,6 +60,9 @@ from openai.types.responses.response_output_item import (
     McpCall,
     McpListTools,
     McpListToolsTool,
+)
+from openai.types.responses.response_tool_search_output_item_param_param import (
+    ResponseToolSearchOutputItemParamParam,
 )
 from openai.types.responses.tool_param import CodeInterpreter
 from pydantic import TypeAdapter
@@ -205,6 +209,33 @@ def _is_openai_responses_provider(model: Model) -> bool:
     return isinstance(model.api, OpenAIAPI)
 
 
+def _is_client_tool_search_output(
+    item: ResponseInputItemParam,
+    client_tool_search_declared: bool,
+    client_tool_search_call_ids: set[str],
+) -> TypeGuard[ResponseToolSearchOutputItemParamParam]:
+    """Whether a tool_search output is authorized by client-side discovery."""
+    return (
+        is_tool_search_output(item)
+        and item.get("execution") != "server"
+        and (
+            item.get("call_id") in client_tool_search_call_ids
+            or client_tool_search_declared
+        )
+    )
+
+
+def _contains_computer_tool(tool_param: ToolParam) -> bool:
+    """Whether a tool declaration contains computer use."""
+    return is_computer_tool_param(tool_param) or (
+        is_namespace_tool_param(tool_param)
+        and any(
+            _contains_computer_tool(cast(ToolParam, inner))
+            for inner in tool_param.get("tools", [])
+        )
+    )
+
+
 async def inspect_responses_api_request_impl(
     json_data: dict[str, Any],
     headers: dict[str, str] | None,
@@ -229,26 +260,57 @@ async def inspect_responses_api_request_impl(
 
     # validate computer use compatibility
     responses_tools: list[ToolParam] = list(json_data.get("tools", []))
+    client_discovered_tools: list[ToolParam] = []
+    client_tool_search_declared = any(
+        is_tool_search_tool_param(tool) and tool.get("execution") == "client"
+        for tool in responses_tools
+    )
 
-    # some CLI agents (e.g. codex >= 0.144) declare their tools via
-    # `additional_tools` input items rather than (or in addition to) the
-    # request's top-level `tools` array. Merge those declarations into the
-    # tool list so the generate() call carries real tools -- otherwise the
-    # model receives no tools at all and cannot emit structured tool calls.
+    # Merge declarations that arrive as input items into the tool list used for
+    # generation. A client-executed tool_search result is a declaration for the
+    # next non-OpenAI generation; native OpenAI Responses models replay it
+    # through their provider-specific input instead.
     input: str | list[ResponseInputItemParam] = json_data["input"]
+    client_tool_search_call_ids: set[str] = set()
+    if isinstance(input, list):
+        for item in input:
+            if (
+                isinstance(item, dict)
+                and item.get("type") == "tool_search_call"
+                and is_response_tool_search_call(item)
+                and item.get("execution") == "client"
+            ):
+                call_id = item.get("call_id")
+                if isinstance(call_id, str):
+                    client_tool_search_call_ids.add(call_id)
     declared_tool_keys = {
         (tool.get("type"), tool.get("name")) for tool in responses_tools
     }
     if isinstance(input, list):
         for item in input:
-            if isinstance(item, dict) and is_additional_tools(item):
-                for declared in item.get("tools", []) or []:
-                    key = (declared.get("type"), declared.get("name"))
-                    if key not in declared_tool_keys:
-                        declared_tool_keys.add(key)
+            if not isinstance(item, dict):
+                continue
+            item_tools: Iterable[ToolParam] | None = None
+            client_discovery_output = False
+            if is_additional_tools(item):
+                item_tools = item.get("tools")
+            elif not is_openai and _is_client_tool_search_output(
+                item, client_tool_search_declared, client_tool_search_call_ids
+            ):
+                item_tools = item.get("tools")
+                client_discovery_output = True
+            for declared in item_tools or []:
+                key = (declared.get("type"), declared.get("name"))
+                if key not in declared_tool_keys:
+                    declared_tool_keys.add(key)
+                    if client_discovery_output:
+                        client_discovered_tools.append(declared)
+                    else:
                         responses_tools.append(declared)
 
-    has_computer_use = any(is_computer_tool_param(tool) for tool in responses_tools)
+    has_computer_use = any(
+        _contains_computer_tool(tool) for tool in responses_tools
+    ) or any(_contains_computer_tool(tool) for tool in client_discovered_tools)
     if has_computer_use and not is_openai:
         raise RuntimeError(
             f"computer use with the OpenAI Responses agent bridge requires an "
@@ -261,12 +323,18 @@ async def inspect_responses_api_request_impl(
     # field on outgoing ResponseFunctionToolCalls (codex-cli dispatches by
     # (namespace, name) and would reject calls with a missing namespace).
     tools: list[ToolInfo | Tool] = []
-    tool_namespaces: dict[str, str] = {}
+    tool_namespaces: dict[str, tuple[str, str]] = {}
     for tool in responses_tools:
         if not is_openai and tool["type"] == "custom":
             continue
-        # tool_search passthrough is OpenAI-Responses-only; drop for other targets
-        if not is_openai and is_tool_search_tool_param(tool):
+        # Server-executed tool_search is native to OpenAI Responses. A
+        # client-executed search is resolved by the scaffold and can be sent to
+        # any model provider.
+        if (
+            not is_openai
+            and is_tool_search_tool_param(tool)
+            and tool.get("execution") != "client"
+        ):
             continue
         if is_namespace_tool_param(tool):
             _harvest_tool_namespaces(tool, tool_namespaces)
@@ -275,6 +343,19 @@ async def inspect_responses_api_request_impl(
                 tool, web_search, code_execution, bridge.allow_remote_mcp
             )
         )
+    tool_names = {tool.name for tool in tools if isinstance(tool, ToolInfo)}
+    if not is_openai:
+        for tool in client_discovered_tools:
+            tools.extend(
+                tools_from_client_tool_search_output(
+                    tool,
+                    web_search,
+                    code_execution,
+                    bridge.allow_remote_mcp,
+                    tool_namespaces,
+                    tool_names,
+                )
+            )
     tools = [tool for tool in tools if tool]
     # client-controlled; validated by tool_choice_from_responses_tool_choice below
     responses_tool_choice: Any = json_data.get("tool_choice", None)
@@ -284,11 +365,9 @@ async def inspect_responses_api_request_impl(
 
     # convert inspect messages (input was read above, before tool merging)
 
-    # deferred namespace tools (e.g. codex multi_agent) are not declared in the
-    # top-level `tools` array; they are discovered via tool_search and appear as
-    # namespace entries inside tool_search_output items in the conversation.
-    # Harvest those too so outgoing function calls carry the right `namespace`.
-    if isinstance(input, list):
+    # OpenAI-native calls use raw inner names; generic providers receive the
+    # exact generic-to-raw mappings registered during client discovery above.
+    if is_openai and isinstance(input, list):
         for item in input:
             if isinstance(item, dict) and is_tool_search_output(item):
                 for discovered in item.get("tools", []) or []:
@@ -349,17 +428,33 @@ async def inspect_responses_api_request_impl(
     return response
 
 
-def _harvest_tool_namespaces(
-    namespace_tool: Any, tool_namespaces: dict[str, str]
+def _record_tool_namespace(
+    tool_namespaces: dict[str, tuple[str, str]],
+    exposed_name: str,
+    name: str,
+    namespace: str,
 ) -> None:
-    """Map each inner tool name to its namespace (codex dispatches by (namespace, name))."""
+    identity = (name, namespace)
+    existing = tool_namespaces.get(exposed_name)
+    if existing is not None and existing != identity:
+        raise RuntimeError(
+            f"Ambiguous tool catalog: '{exposed_name}' names both "
+            f"'{existing[1]}::{existing[0]}' and '{namespace}::{name}'."
+        )
+    tool_namespaces[exposed_name] = identity
+
+
+def _harvest_tool_namespaces(
+    namespace_tool: Any, tool_namespaces: dict[str, tuple[str, str]]
+) -> None:
+    """Map each exposed name to its original namespace and inner name."""
     ns_name = namespace_tool.get("name")
     if not isinstance(ns_name, str):
         return
     for inner in namespace_tool.get("tools", []) or []:
         inner_name = cast(dict[str, Any], inner).get("name")
         if isinstance(inner_name, str):
-            tool_namespaces[inner_name] = ns_name
+            _record_tool_namespace(tool_namespaces, inner_name, inner_name, ns_name)
 
 
 def _seed_function_call_namespace(param: ResponseFunctionToolCallParam) -> None:
@@ -610,6 +705,67 @@ def tools_from_responses_tool(
     return [tool] if tool is not None else []
 
 
+def tools_from_client_tool_search_output(
+    tool_param: ToolParam,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
+    allow_remote_mcp: bool,
+    tool_namespaces: dict[str, tuple[str, str]],
+    tool_names: set[str],
+) -> list[ToolInfo | Tool]:
+    """Expose client-discovered tools to a non-OpenAI model API.
+
+    Namespace tools must use the generic ``<namespace>__<name>`` convention for
+    the non-OpenAI provider while Responses calls retain separate namespace and
+    name fields.
+    """
+    if not is_namespace_tool_param(tool_param):
+        if tool_param["type"] == "custom":
+            return []
+        if (
+            is_tool_search_tool_param(tool_param)
+            and tool_param.get("execution") != "client"
+        ):
+            return []
+        return tools_from_responses_tool(
+            tool_param,
+            web_search_providers,
+            code_execution_providers,
+            allow_remote_mcp,
+        )
+
+    namespace = tool_param["name"]
+    flattened: list[ToolInfo | Tool] = []
+    for inner in tool_param.get("tools", []):
+        inner_param = cast(ToolParam, inner)
+        if inner_param["type"] == "custom":
+            continue
+        if (
+            is_tool_search_tool_param(inner_param)
+            and inner_param.get("execution") != "client"
+        ):
+            continue
+        for inner_tool in tools_from_responses_tool(
+            inner_param,
+            web_search_providers,
+            code_execution_providers,
+            allow_remote_mcp,
+        ):
+            if isinstance(inner_tool, ToolInfo):
+                name = inner_tool.name
+                generic_name = f"{namespace}__{name}"
+                if generic_name in tool_names:
+                    raise RuntimeError(
+                        f"Ambiguous client tool catalog: discovered tool "
+                        f"'{generic_name}' conflicts with a tool that is already available."
+                    )
+                tool_names.add(generic_name)
+                inner_tool.name = generic_name
+                _record_tool_namespace(tool_namespaces, generic_name, name, namespace)
+            flattened.append(inner_tool)
+    return flattened
+
+
 def resolve_code_interpreter_providers(
     tool_param: CodeInterpreter,
     code_execution: CodeExecutionProviders,
@@ -747,6 +903,7 @@ def messages_from_responses_input(
         tool_to_tool_info(tool) if not isinstance(tool, ToolInfo) else tool
         for tool in tools
     ]
+    available_tool_names = {tool.name for tool in tools_info}
 
     messages: list[ChatMessage] = []
     function_calls_by_id: dict[str, str] = {}
@@ -881,7 +1038,13 @@ def messages_from_responses_input(
                             )
 
                 elif is_response_function_tool_call(param):
-                    function_calls_by_id[param["call_id"]] = param["name"]
+                    function = param["name"]
+                    namespace = param.get("namespace")
+                    if namespace is not None:
+                        namespaced_function = f"{namespace}__{function}"
+                        if namespaced_function in available_tool_names:
+                            function = namespaced_function
+                    function_calls_by_id[param["call_id"]] = function
                     # Preserve the call's `namespace` for verbatim replay to the
                     # real model. The provider replays from assistant_internal
                     # (keyed by call_id) but only caches calls it generated this
@@ -893,7 +1056,7 @@ def messages_from_responses_input(
                     tool_calls.append(
                         parse_tool_call(
                             id=param["call_id"],
-                            function=param["name"],
+                            function=function,
                             arguments=param["arguments"],
                             tools=tools_info,
                         )
@@ -1167,7 +1330,7 @@ mcp_tool_adapter = TypeAdapter(list[McpListToolsTool])
 
 def responses_output_items_from_assistant_message(
     message: ChatMessageAssistant,
-    tool_namespaces: dict[str, str] | None = None,
+    tool_namespaces: dict[str, tuple[str, str]] | None = None,
 ) -> list[ResponseOutputItem]:
     output: list[ResponseOutputItem] = []
     # normalize message content to list
@@ -1290,12 +1453,17 @@ def responses_output_items_from_assistant_message(
                 )
             )
         else:
-            namespace = (tool_namespaces or {}).get(tool_call.function)
+            tool_identity = (tool_namespaces or {}).get(tool_call.function)
+            if tool_identity is None:
+                name = tool_call.function
+                namespace = None
+            else:
+                name, namespace = tool_identity
             output.append(
                 ResponseFunctionToolCall(
                     type="function_call",
                     call_id=tool_call.id,
-                    name=tool_call.function,
+                    name=name,
                     arguments=json.dumps(tool_call.arguments),
                     namespace=namespace,
                 )

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -343,7 +343,9 @@ async def inspect_responses_api_request_impl(
                 tool, web_search, code_execution, bridge.allow_remote_mcp
             )
         )
-    tool_names = {tool.name for tool in tools if isinstance(tool, ToolInfo)}
+    tool_names: dict[str, tuple[str, str | None, ToolParams] | None] = {
+        tool.name: None for tool in tools if isinstance(tool, ToolInfo)
+    }
     if not is_openai:
         for tool in client_discovered_tools:
             tools.extend(
@@ -444,14 +446,25 @@ def _record_tool_namespace(
     tool_namespaces[exposed_name] = identity
 
 
-def _register_client_tool_name(tool_names: set[str], name: str) -> None:
-    """Register a tool exposed to a generic provider without silent shadowing."""
-    if name in tool_names:
+def _register_client_tool(
+    tool_names: dict[str, tuple[str, str | None, ToolParams] | None],
+    exposed_name: str,
+    name: str,
+    namespace: str | None,
+    parameters: ToolParams,
+) -> bool:
+    """Register a generic-provider tool, retaining duplicate discovery results."""
+    identity = (name, namespace, parameters)
+    existing = tool_names.get(exposed_name)
+    if existing == identity:
+        return False
+    if existing is not None or exposed_name in tool_names:
         raise RuntimeError(
             f"Ambiguous client tool catalog: discovered tool "
-            f"'{name}' conflicts with a tool that is already available."
+            f"'{exposed_name}' conflicts with a tool that is already available."
         )
-    tool_names.add(name)
+    tool_names[exposed_name] = identity
+    return True
 
 
 def _harvest_tool_namespaces(
@@ -648,10 +661,15 @@ def tool_from_responses_tool(
         # client-resolved tool discovery (e.g. codex-cli). Preserve the native
         # tool fields in options so the OpenAI Responses provider can re-emit the
         # ToolSearchToolParam verbatim; the scaffold resolves the calls locally.
+        parameters = (
+            ToolParams.model_validate(tool_param["parameters"])
+            if tool_param.get("execution") == "client"
+            else ToolParams()
+        )
         return ToolInfo(
             name=TOOL_SEARCH_NAME,
             description=tool_param.get("description") or TOOL_SEARCH_NAME,
-            parameters=ToolParams.model_validate(tool_param["parameters"]),
+            parameters=parameters,
             options={
                 TOOL_SEARCH_OPTIONS_MARKER: True,
                 "description": tool_param.get("description"),
@@ -722,7 +740,7 @@ def tools_from_client_tool_search_output(
     code_execution_providers: CodeExecutionProviders | None,
     allow_remote_mcp: bool,
     tool_namespaces: dict[str, tuple[str, str]],
-    tool_names: set[str],
+    tool_names: dict[str, tuple[str, str | None, ToolParams] | None],
 ) -> list[ToolInfo | Tool]:
     """Expose client-discovered tools to a non-OpenAI model API.
 
@@ -744,10 +762,17 @@ def tools_from_client_tool_search_output(
             code_execution_providers,
             allow_remote_mcp,
         )
+        unique_client_tools: list[ToolInfo | Tool] = []
         for client_tool in client_tools:
-            if isinstance(client_tool, ToolInfo):
-                _register_client_tool_name(tool_names, client_tool.name)
-        return client_tools
+            if not isinstance(client_tool, ToolInfo) or _register_client_tool(
+                tool_names,
+                client_tool.name,
+                client_tool.name,
+                None,
+                client_tool.parameters,
+            ):
+                unique_client_tools.append(client_tool)
+        return unique_client_tools
 
     namespace = tool_param["name"]
     flattened: list[ToolInfo | Tool] = []
@@ -769,7 +794,14 @@ def tools_from_client_tool_search_output(
             if isinstance(inner_tool, ToolInfo):
                 name = inner_tool.name
                 generic_name = f"{namespace}__{name}"
-                _register_client_tool_name(tool_names, generic_name)
+                if not _register_client_tool(
+                    tool_names,
+                    generic_name,
+                    name,
+                    namespace,
+                    inner_tool.parameters,
+                ):
+                    continue
                 inner_tool.name = generic_name
                 _record_tool_namespace(tool_namespaces, generic_name, name, namespace)
             flattened.append(inner_tool)

--- a/tests/agent/test_bridge_namespace_tool.py
+++ b/tests/agent/test_bridge_namespace_tool.py
@@ -134,7 +134,7 @@ def test_response_function_tool_call_preserves_namespace():
             ToolCall(id="call-2", function="search", arguments={"q": "x"}),
         ],
     )
-    tool_namespaces = {"submit_pov": "submit"}
+    tool_namespaces = {"submit_pov": ("submit_pov", "submit")}
     items = responses_output_items_from_assistant_message(message, tool_namespaces)
     function_calls = [
         item for item in items if getattr(item, "type", None) == "function_call"

--- a/tests/agent/test_bridge_tool_search.py
+++ b/tests/agent/test_bridge_tool_search.py
@@ -47,6 +47,7 @@ from inspect_ai.model._openai_responses import (
     is_tool_search_tool_param,
     maybe_tool_search_tool,
 )
+from inspect_ai.model._providers.anthropic import AnthropicAPI
 from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
@@ -388,6 +389,79 @@ async def test_client_tool_search_call_allows_missing_call_id() -> None:
     assert response.output_text == "done"
 
 
+async def test_client_tool_search_accumulates_namespace_discoveries() -> None:
+    """Later results from one namespace add their newly discovered tools."""
+    requested_tool_search = _tool_search_tool_param()
+    first_discovery = _deferred_mcp_namespace()
+    second_discovery = _deferred_mcp_namespace()
+    first_discovery["tools"] = [first_discovery["tools"][0]]
+    second_discovery["tools"] = [second_discovery["tools"][1]]
+    expected_names = {
+        TOOL_SEARCH_NAME,
+        f"{first_discovery['name']}__browser",
+        f"{second_discovery['name']}__javascript_exec",
+    }
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        assert {tool.name for tool in tools} == expected_names
+        return ModelOutput.from_content("mockllm/model", "done")
+
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={
+            "inspect": get_model("mockllm/model", custom_outputs=custom_outputs)
+        },
+    )
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {"role": "user", "content": "Find browser tools."},
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_1",
+                    "call_id": "tool_search_1",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_1",
+                    "tools": [first_discovery],
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_2",
+                    "call_id": "tool_search_2",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_2",
+                    "tools": [second_discovery],
+                    "status": "completed",
+                },
+            ],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
+
+
 @pytest.mark.parametrize(
     "discovered_tools",
     [
@@ -481,6 +555,51 @@ async def test_client_tool_search_rejects_ambiguous_flattened_name() -> None:
         )
 
 
+@pytest.mark.parametrize("plain_first", [True, False], ids=["plain", "namespace"])
+async def test_client_discovery_rejects_plain_namespace_name_collisions(
+    plain_first: bool,
+) -> None:
+    """Plain and namespaced discovery entries cannot share a generic name."""
+    namespace_tool = _deferred_mcp_namespace()
+    plain_tool = _discoverable_function_tool()
+    plain_tool["name"] = f"{namespace_tool['name']}__browser"
+    discovered_tools = (
+        [plain_tool, namespace_tool] if plain_first else [namespace_tool, plain_tool]
+    )
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": get_model("mockllm/model")},
+    )
+
+    with pytest.raises(RuntimeError, match="Ambiguous client tool catalog"):
+        await inspect_responses_api_request(
+            {
+                "model": "inspect",
+                "input": [
+                    {
+                        "type": "tool_search_call",
+                        "id": "ts_1",
+                        "call_id": "tool_search_1",
+                        "arguments": {"query": "browser tools"},
+                        "execution": "client",
+                        "status": "completed",
+                    },
+                    {
+                        "type": "tool_search_output",
+                        "call_id": "tool_search_1",
+                        "tools": discovered_tools,
+                        "status": "completed",
+                    },
+                ],
+                "tools": [_tool_search_tool_param()],
+            },
+            None,
+            None,
+            None,
+            bridge,
+        )
+
+
 def test_client_discovery_skips_custom_and_server_builtins() -> None:
     """Custom and server-resolved built-ins never reach generic providers."""
     tool_namespaces: dict[str, tuple[str, str]] = {}
@@ -534,6 +653,26 @@ def test_tool_from_responses_tool_tool_search() -> None:
     assert tool.options["execution"] == "client"
     assert tool.options["description"] == "Search for available tools"
     assert tool.options["parameters"] == _tool_search_tool_param()["parameters"]
+
+
+def test_client_tool_search_keeps_schema_for_generic_provider() -> None:
+    """Generic-provider serialization keeps the client discovery schema."""
+    tool = tool_from_responses_tool(
+        _tool_search_tool_param(),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
+    )
+    assert isinstance(tool, ToolInfo)
+
+    params = AnthropicAPI(
+        model_name="claude-sonnet-4-6", api_key="test-key"
+    ).tool_params_for_tool_info(tool, GenerateConfig())
+
+    assert len(params) == 1
+    param = cast(dict[str, Any], params[0])
+    assert param["name"] == TOOL_SEARCH_NAME
+    assert param["input_schema"] == _tool_search_tool_param()["parameters"]
 
 
 # 2. ToolInfo -> native ToolSearchToolParam (and None for ordinary tools)

--- a/tests/agent/test_bridge_tool_search.py
+++ b/tests/agent/test_bridge_tool_search.py
@@ -51,6 +51,7 @@ from inspect_ai.model._providers.anthropic import AnthropicAPI
 from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
+from inspect_ai.tool._tool_params import ToolParams
 
 WEB_SEARCH_PROVIDERS: Any = {}
 CODE_EXECUTION_PROVIDERS: Any = {}
@@ -462,6 +463,145 @@ async def test_client_tool_search_accumulates_namespace_discoveries() -> None:
     assert response.output_text == "done"
 
 
+async def test_client_tool_search_deduplicates_repeated_plain_discoveries() -> None:
+    """Repeated identical plain discoveries do not make the tool catalog ambiguous."""
+    requested_tool_search = _tool_search_tool_param()
+    discovered_tool = _discoverable_function_tool()
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        assert {tool.name for tool in tools} == {TOOL_SEARCH_NAME, "read_file"}
+        return ModelOutput.from_content("mockllm/model", "done")
+
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={
+            "inspect": get_model("mockllm/model", custom_outputs=custom_outputs)
+        },
+    )
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {"role": "user", "content": "Find a file tool."},
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_1",
+                    "call_id": "tool_search_1",
+                    "arguments": {"query": "file tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_1",
+                    "tools": [discovered_tool],
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_2",
+                    "call_id": "tool_search_2",
+                    "arguments": {"query": "file tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_2",
+                    "tools": [discovered_tool],
+                    "status": "completed",
+                },
+            ],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
+
+
+async def test_client_tool_search_accumulates_overlapping_namespace_discoveries() -> (
+    None
+):
+    """Overlapping namespace results retain the newly discovered tool."""
+    requested_tool_search = _tool_search_tool_param()
+    first_discovery = _deferred_mcp_namespace()
+    overlapping_discovery = _deferred_mcp_namespace()
+    first_discovery["tools"] = [first_discovery["tools"][0]]
+    expected_names = {
+        TOOL_SEARCH_NAME,
+        f"{first_discovery['name']}__browser",
+        f"{overlapping_discovery['name']}__javascript_exec",
+    }
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        assert {tool.name for tool in tools} == expected_names
+        return ModelOutput.from_content("mockllm/model", "done")
+
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={
+            "inspect": get_model("mockllm/model", custom_outputs=custom_outputs)
+        },
+    )
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {"role": "user", "content": "Find browser tools."},
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_1",
+                    "call_id": "tool_search_1",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_1",
+                    "tools": [first_discovery],
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_2",
+                    "call_id": "tool_search_2",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_2",
+                    "tools": [overlapping_discovery],
+                    "status": "completed",
+                },
+            ],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
+
+
 @pytest.mark.parametrize(
     "discovered_tools",
     [
@@ -603,7 +743,7 @@ async def test_client_discovery_rejects_plain_namespace_name_collisions(
 def test_client_discovery_skips_custom_and_server_builtins() -> None:
     """Custom and server-resolved built-ins never reach generic providers."""
     tool_namespaces: dict[str, tuple[str, str]] = {}
-    tool_names: set[str] = set()
+    tool_names: dict[str, tuple[str, str | None, ToolParams] | None] = {}
     discovered_tools = [
         cast(ToolParam, {"type": "custom", "name": "custom_tool"}),
         cast(ToolParam, {"type": "tool_search", "execution": "server"}),
@@ -633,7 +773,7 @@ def test_client_discovery_skips_custom_and_server_builtins() -> None:
             == []
         )
     assert tool_namespaces == {}
-    assert tool_names == set()
+    assert tool_names == {}
 
 
 # 1. incoming tool_search param -> ToolInfo with marker + verbatim execution
@@ -673,6 +813,42 @@ def test_client_tool_search_keeps_schema_for_generic_provider() -> None:
     param = cast(dict[str, Any], params[0])
     assert param["name"] == TOOL_SEARCH_NAME
     assert param["input_schema"] == _tool_search_tool_param()["parameters"]
+
+
+@pytest.mark.parametrize(
+    "tool_param",
+    [
+        cast(ToolParam, {"type": "tool_search"}),
+        cast(ToolParam, {"type": "tool_search", "execution": "server"}),
+        cast(ToolParam, {"type": "tool_search", "parameters": None}),
+    ],
+    ids=["omitted", "server", "null-schema"],
+)
+async def test_native_tool_search_allows_optional_parameters(
+    tool_param: ToolParam,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI-native tool search preserves an omitted or null schema."""
+    model = get_model("openai/gpt-4o", api_key="test-key", memoize=False)
+
+    async def generate(*_args: Any, **_kwargs: Any) -> ModelOutput:
+        return ModelOutput.from_content("openai/gpt-4o", "done")
+
+    monkeypatch.setattr(model, "generate", generate)
+    bridge = AgentBridge(AgentState(messages=[]), model_aliases={"inspect": model})
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [{"role": "user", "content": "Find a browser tool."}],
+            "tools": [tool_param],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
 
 
 # 2. ToolInfo -> native ToolSearchToolParam (and None for ordinary tools)

--- a/tests/agent/test_bridge_tool_search.py
+++ b/tests/agent/test_bridge_tool_search.py
@@ -11,15 +11,32 @@ from __future__ import annotations
 import json
 from typing import Any, cast
 
-from openai.types.responses import ResponseInputItemParam, ToolParam
+import pytest
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseInputItemParam,
+    ResponseToolSearchCall,
+    ToolParam,
+    ToolSearchToolParam,
+)
 
+from inspect_ai.agent._agent import AgentState
+from inspect_ai.agent._bridge.responses import inspect_responses_api_request
 from inspect_ai.agent._bridge.responses_impl import (
     messages_from_responses_input,
     responses_output_items_from_assistant_message,
     tool_from_responses_tool,
+    tools_from_client_tool_search_output,
 )
-from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageTool
+from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageTool,
+)
 from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model import get_model
+from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.model._openai_responses import (
     TOOL_SEARCH_NAME,
     TOOL_SEARCH_OPTIONS_MARKER,
@@ -31,22 +48,34 @@ from inspect_ai.model._openai_responses import (
     maybe_tool_search_tool,
 )
 from inspect_ai.tool._tool_call import ToolCall
+from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
 
 WEB_SEARCH_PROVIDERS: Any = {}
 CODE_EXECUTION_PROVIDERS: Any = {}
 
 
-def _tool_search_tool_param() -> ToolParam:
-    return cast(
-        ToolParam,
-        {
-            "type": "tool_search",
-            "description": "Search for available tools",
-            "execution": "client",
-            "parameters": {"type": "object", "properties": {}},
+def _tool_search_tool_param() -> ToolSearchToolParam:
+    return {
+        "type": "tool_search",
+        "description": "Search for available tools",
+        "execution": "client",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of tools to return. Defaults to 8.",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Search query for deferred tools.",
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
         },
-    )
+    }
 
 
 def _discoverable_function_tool() -> dict[str, Any]:
@@ -61,6 +90,431 @@ def _discoverable_function_tool() -> dict[str, Any]:
         },
         "strict": False,
     }
+
+
+def _deferred_mcp_namespace() -> dict[str, Any]:
+    return {
+        "type": "namespace",
+        "name": "mcp__browser_tools",
+        "description": "Deferred browser tools.",
+        "tools": [
+            {
+                "type": "function",
+                "name": "browser",
+                "description": "Control the browser.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"action": {"type": "string"}},
+                    "required": ["action"],
+                    "additionalProperties": False,
+                },
+                "strict": False,
+                "defer_loading": True,
+            },
+            {
+                "type": "function",
+                "name": "javascript_exec",
+                "description": "Run JavaScript in the task browser.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"script": {"type": "string"}},
+                    "required": ["script"],
+                    "additionalProperties": False,
+                },
+                "strict": False,
+                "defer_loading": True,
+            },
+        ],
+    }
+
+
+async def test_client_tool_search_reaches_non_openai_with_discovered_mcp_tools() -> (
+    None
+):
+    """A client discovery call survives a non-OpenAI bridge continuation."""
+    requested_tool_search = _tool_search_tool_param()
+    discovered_mcp_namespace = _deferred_mcp_namespace()
+    browser_tool_name = f"{discovered_mcp_namespace['name']}__browser"
+    tool_names_seen: list[set[str]] = []
+    outputs = iter(
+        [
+            ModelOutput.for_tool_call(
+                "mockllm/model",
+                TOOL_SEARCH_NAME,
+                {"query": "browser tools", "limit": 8},
+                tool_call_id="tool_search_1",
+            ),
+            ModelOutput.for_tool_call(
+                "mockllm/model",
+                browser_tool_name,
+                {"action": "screenshot"},
+                tool_call_id="browser_1",
+            ),
+            ModelOutput.from_content("mockllm/model", "done"),
+        ]
+    )
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        names = {tool.name for tool in tools}
+        tool_names_seen.append(names)
+        if len(tool_names_seen) == 1:
+            assert names == {TOOL_SEARCH_NAME}, (
+                "client tool_search missing from the first non-OpenAI bridge generation"
+            )
+        else:
+            assert names == {
+                TOOL_SEARCH_NAME,
+                browser_tool_name,
+                f"{discovered_mcp_namespace['name']}__javascript_exec",
+            }, (
+                "client-discovered MCP namespace missing from the non-OpenAI "
+                "bridge continuation"
+            )
+        if len(tool_names_seen) == 3:
+            replayed_calls = [
+                call
+                for message in _input
+                if isinstance(message, ChatMessageAssistant)
+                for call in message.tool_calls or []
+                if call.id == "browser_1"
+            ]
+            assert len(replayed_calls) == 1
+            assert replayed_calls[0].function == browser_tool_name
+            replayed_results = [
+                message
+                for message in _input
+                if isinstance(message, ChatMessageTool)
+                and message.tool_call_id == "browser_1"
+            ]
+            assert len(replayed_results) == 1
+            assert replayed_results[0].function == browser_tool_name
+        return next(outputs)
+
+    model = get_model("mockllm/model", custom_outputs=custom_outputs)
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": model},
+    )
+    first_response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [{"role": "user", "content": "Find a browser tool."}],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    first_calls = [
+        item
+        for item in first_response.output
+        if isinstance(item, ResponseToolSearchCall)
+    ]
+    assert len(first_calls) == 1
+    first_call = first_calls[0]
+    assert first_call.call_id == "tool_search_1"
+    assert first_call.arguments == {"query": "browser tools", "limit": 8}
+    assert first_call.execution == "client"
+
+    discovery_output = {
+        "type": "tool_search_output",
+        "call_id": first_call.call_id,
+        "tools": [discovered_mcp_namespace],
+        "status": "completed",
+    }
+    continuation = [
+        {"role": "user", "content": "Find a browser tool."},
+        *(item.model_dump(exclude_none=True) for item in first_response.output),
+        discovery_output,
+    ]
+    second_response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": continuation,
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    second_calls = [
+        item
+        for item in second_response.output
+        if isinstance(item, ResponseFunctionToolCall)
+    ]
+    assert len(second_calls) == 1
+    second_call = second_calls[0]
+    assert second_call.call_id == "browser_1"
+    assert second_call.name == "browser"
+    assert second_call.namespace == discovered_mcp_namespace["name"]
+    assert second_call.arguments == '{"action": "screenshot"}'
+    third_response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {"role": "user", "content": "Find a browser tool."},
+                *(item.model_dump(exclude_none=True) for item in first_response.output),
+                discovery_output,
+                *(
+                    item.model_dump(exclude_none=True)
+                    for item in second_response.output
+                ),
+                {
+                    "type": "function_call_output",
+                    "call_id": second_call.call_id,
+                    "output": "screenshot taken",
+                },
+            ],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert third_response.output_text == "done"
+    assert tool_names_seen == [
+        {TOOL_SEARCH_NAME},
+        {
+            TOOL_SEARCH_NAME,
+            browser_tool_name,
+            f"{discovered_mcp_namespace['name']}__javascript_exec",
+        },
+        {
+            TOOL_SEARCH_NAME,
+            browser_tool_name,
+            f"{discovered_mcp_namespace['name']}__javascript_exec",
+        },
+    ]
+
+
+async def test_client_tool_search_rejects_explicit_server_discovery_output() -> None:
+    """An explicit server result cannot override client discovery metadata."""
+    requested_tool_search = _tool_search_tool_param()
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        assert {tool.name for tool in tools} == {TOOL_SEARCH_NAME}
+        return ModelOutput.from_content("mockllm/model", "done")
+
+    model = get_model("mockllm/model", custom_outputs=custom_outputs)
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": model},
+    )
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {"role": "user", "content": "Find a browser tool."},
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_1",
+                    "call_id": "tool_search_1",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "tool_search_1",
+                    "execution": "server",
+                    "tools": [_discoverable_function_tool()],
+                    "status": "completed",
+                },
+            ],
+            "tools": [requested_tool_search],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
+
+
+async def test_client_tool_search_call_allows_missing_call_id() -> None:
+    """Codex may omit call_id while the SDK falls back to the item id."""
+
+    def custom_outputs(
+        _input: list[ChatMessage],
+        tools: list[ToolInfo],
+        _tool_choice: ToolChoice,
+        _config: GenerateConfig,
+    ) -> ModelOutput:
+        assert {tool.name for tool in tools} == {TOOL_SEARCH_NAME}
+        return ModelOutput.from_content("mockllm/model", "done")
+
+    model = get_model("mockllm/model", custom_outputs=custom_outputs)
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": model},
+    )
+    response = await inspect_responses_api_request(
+        {
+            "model": "inspect",
+            "input": [
+                {
+                    "type": "tool_search_call",
+                    "id": "ts_1",
+                    "arguments": {"query": "browser tools"},
+                    "execution": "client",
+                    "status": "completed",
+                }
+            ],
+            "tools": [_tool_search_tool_param()],
+        },
+        None,
+        None,
+        None,
+        bridge,
+    )
+
+    assert response.output_text == "done"
+
+
+@pytest.mark.parametrize(
+    "discovered_tools",
+    [
+        [{"type": "computer"}],
+        [
+            {
+                "type": "namespace",
+                "name": "deferred",
+                "tools": [{"type": "computer"}],
+            }
+        ],
+    ],
+    ids=["top-level", "namespace"],
+)
+async def test_client_tool_search_rejects_discovered_computer_use(
+    discovered_tools: list[dict[str, Any]],
+) -> None:
+    """Client discovery cannot add computer use to a non-OpenAI bridge."""
+    model = get_model("mockllm/model")
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": model},
+    )
+
+    with pytest.raises(RuntimeError, match="computer use with the OpenAI Responses"):
+        await inspect_responses_api_request(
+            {
+                "model": "inspect",
+                "input": [
+                    {
+                        "type": "tool_search_call",
+                        "id": "ts_1",
+                        "call_id": "tool_search_1",
+                        "arguments": {"query": "browser tools"},
+                        "execution": "client",
+                        "status": "completed",
+                    },
+                    {
+                        "type": "tool_search_output",
+                        "call_id": "tool_search_1",
+                        "tools": discovered_tools,
+                        "status": "completed",
+                    },
+                ],
+                "tools": [_tool_search_tool_param()],
+            },
+            None,
+            None,
+            None,
+            bridge,
+        )
+
+
+async def test_client_tool_search_rejects_ambiguous_flattened_name() -> None:
+    """A deferred namespace cannot shadow an existing generic tool."""
+    discovered_mcp_namespace = _deferred_mcp_namespace()
+    existing_tool = _discoverable_function_tool()
+    existing_tool["name"] = f"{discovered_mcp_namespace['name']}__browser"
+    model = get_model("mockllm/model")
+    bridge = AgentBridge(
+        AgentState(messages=[]),
+        model_aliases={"inspect": model},
+    )
+
+    with pytest.raises(RuntimeError, match="Ambiguous client tool catalog"):
+        await inspect_responses_api_request(
+            {
+                "model": "inspect",
+                "input": [
+                    {
+                        "type": "tool_search_call",
+                        "id": "ts_1",
+                        "call_id": "tool_search_1",
+                        "arguments": {"query": "browser tools"},
+                        "execution": "client",
+                        "status": "completed",
+                    },
+                    {
+                        "type": "tool_search_output",
+                        "call_id": "tool_search_1",
+                        "tools": [discovered_mcp_namespace],
+                        "status": "completed",
+                    },
+                ],
+                "tools": [_tool_search_tool_param(), existing_tool],
+            },
+            None,
+            None,
+            None,
+            bridge,
+        )
+
+
+def test_client_discovery_skips_custom_and_server_builtins() -> None:
+    """Custom and server-resolved built-ins never reach generic providers."""
+    tool_namespaces: dict[str, tuple[str, str]] = {}
+    tool_names: set[str] = set()
+    discovered_tools = [
+        cast(ToolParam, {"type": "custom", "name": "custom_tool"}),
+        cast(ToolParam, {"type": "tool_search", "execution": "server"}),
+        cast(
+            ToolParam,
+            {
+                "type": "namespace",
+                "name": "deferred",
+                "tools": [
+                    {"type": "custom", "name": "custom_tool"},
+                    {"type": "tool_search", "execution": "server"},
+                ],
+            },
+        ),
+    ]
+
+    for tool in discovered_tools:
+        assert (
+            tools_from_client_tool_search_output(
+                tool,
+                WEB_SEARCH_PROVIDERS,
+                CODE_EXECUTION_PROVIDERS,
+                False,
+                tool_namespaces,
+                tool_names,
+            )
+            == []
+        )
+    assert tool_namespaces == {}
+    assert tool_names == set()
 
 
 # 1. incoming tool_search param -> ToolInfo with marker + verbatim execution
@@ -79,6 +533,7 @@ def test_tool_from_responses_tool_tool_search() -> None:
     assert tool.options[TOOL_SEARCH_OPTIONS_MARKER] is True
     assert tool.options["execution"] == "client"
     assert tool.options["description"] == "Search for available tools"
+    assert tool.options["parameters"] == _tool_search_tool_param()["parameters"]
 
 
 # 2. ToolInfo -> native ToolSearchToolParam (and None for ordinary tools)
@@ -161,11 +616,11 @@ def test_harvest_tool_namespaces_from_tool_search_output() -> None:
             {"type": "function", "name": "wait_agent"},
         ],
     }
-    tool_namespaces: dict[str, str] = {}
+    tool_namespaces: dict[str, tuple[str, str]] = {}
     _harvest_tool_namespaces(namespace_tool, tool_namespaces)
     assert tool_namespaces == {
-        "spawn_agent": "multi_agent_v1",
-        "wait_agent": "multi_agent_v1",
+        "spawn_agent": ("spawn_agent", "multi_agent_v1"),
+        "wait_agent": ("wait_agent", "multi_agent_v1"),
     }
 
 
@@ -173,7 +628,7 @@ def test_output_items_restore_namespace_for_deferred_tool() -> None:
     from inspect_ai.agent._bridge.responses_impl import _harvest_tool_namespaces
 
     # mapping as harvested from a tool_search_output namespace entry
-    tool_namespaces: dict[str, str] = {}
+    tool_namespaces: dict[str, tuple[str, str]] = {}
     _harvest_tool_namespaces(
         {"name": "multi_agent_v1", "tools": [{"name": "spawn_agent"}]},
         tool_namespaces,
@@ -194,6 +649,31 @@ def test_output_items_restore_namespace_for_deferred_tool() -> None:
     assert len(calls) == 1
     assert calls[0].name == "spawn_agent"
     assert calls[0].namespace == "multi_agent_v1"
+
+
+def test_output_items_restore_stored_raw_name_for_generic_tool() -> None:
+    """A generic provider name maps back to the original Responses identity."""
+    message = ChatMessageAssistant(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="browser_1",
+                function="generic_browser",
+                arguments={"action": "screenshot"},
+            )
+        ],
+    )
+    items = responses_output_items_from_assistant_message(
+        message,
+        {"generic_browser": ("browser", "mcp__browser_tools")},
+    )
+    calls = [item for item in items if item.type == "function_call"]
+
+    assert len(calls) == 1
+    assert calls[0].call_id == "browser_1"
+    assert calls[0].name == "browser"
+    assert calls[0].namespace == "mcp__browser_tools"
+    assert calls[0].arguments == '{"action": "screenshot"}'
 
 
 def test_output_items_no_namespace_for_plain_tool() -> None:
@@ -559,7 +1039,7 @@ async def test_tool_search_output_replay_gated_on_cached_call() -> None:
 
 
 async def test_compaction_does_not_clear_tool_search() -> None:
-    from inspect_ai.model import ChatMessage, ChatMessageUser
+    from inspect_ai.model import ChatMessageUser
     from inspect_ai.model._compaction.edit import TOOL_RESULT_REMOVED, CompactionEdit
     from inspect_ai.model._model import get_model
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

For a non-OpenAI model routed through the Responses agent bridge, a client-executed `tool_search` declaration is removed before generation. The model therefore cannot request discovery, and tools returned by discovery are unavailable on the following generation.

This is adjacent to [#4968](https://github.com/UKGovernmentBEIS/inspect_ai/issues/4968) and its open PR [#4969](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4969), which handle native OpenAI `tool_search_output` parsing rather than generic-provider tool availability.

### What is the new behavior?

The bridge now retains client-executed discovery for generic providers, converts discovered namespace tools to generic names, and restores their original Responses names and namespaces when replaying calls. Server-executed built-ins and computer-use restrictions remain unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

- `uv run make check` passed, including the suppression-ledger check.
- The affected agent-bridge tests passed on asyncio and Trio; commands and counts are listed below.
- The full `make test` suite was not run; validation was scoped to the affected agent-bridge path.
- Prepared and tested with AI assistance.
- Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

### Slow tests

- `uv run pytest tests/agent/test_bridge_tool_search.py tests/agent/test_bridge_namespace_tool.py -v`: 45 passed, 18 skipped because Trio variants require a separate invocation.
- `uv run pytest tests/agent/test_bridge_tool_search.py --runtrio -v`: 18 passed, 34 skipped because the invocation runs Trio variants only.
- No live-provider or Docker-dependent test was run; the exercised bridge path uses `mockllm/model` and requires no provider credentials or network access.

### Agent review

- Reviewer: openai/gpt-6-astra via Oh My Pi, three fresh-context passes.
- Findings: first pass found three defects (generic-provider schema loss, lost later discovery, and a plain/namespaced collision); second found two regressions (duplicate discovery and native optional schemas); all five are corrected and covered by focused regressions. The third pass found no blocking regression.

Opened and updated by Claude on behalf of @sjawhar.
