### PR TITLE
retain generated Docker Compose config for deliberately retained projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Sandbox Tools: Binaries downloaded from S3 that fail SHA256 verification or lack a pinned digest are now rejected instead of run with a warning; `INSPECT_SANDBOX_TOOLS_STRICT_DIGESTS` has been removed.
 - Sandbox tools: Fixed a race during injection that let a non-root sandbox user replace the tools archive before root unpacked it.
 - Docker: Timed commands no longer run an agent-planted timeout executable from the sandbox's PATH with elevated privileges.
+- Docker: Retained sandbox environments keep generated Compose configuration until exact project cleanup, including custom networks.
 - Inspect View: Requests for unreadable log headers now return 403 instead of 500.
 - Eval Set: Tasks that set a non-mean epochs reducer now reuse their completed log on subsequent `eval_set()` calls instead of being re-run every time.
 - Human Agent: Sandbox installation of the `task` CLI now refuses a pre-planted or non-root-owned `/opt/human_agent`, errors instead of silently skipping when it cannot be created, and no longer runs a staged install script.

--- a/src/inspect_ai/util/_sandbox/docker/cleanup.py
+++ b/src/inspect_ai/util/_sandbox/docker/cleanup.py
@@ -103,12 +103,21 @@ async def project_cleanup_shutdown(cleanup: bool) -> None:
                 print(
                     "\n"
                     "Cleanup all containers  : [blue]inspect sandbox cleanup docker[/blue]\n"
-                    "Cleanup single container: [blue]inspect sandbox cleanup docker <container-id>[/blue]",
+                    "Cleanup single environment: "
+                    "[blue]inspect sandbox cleanup docker <project-name>[/blue]",
                     "\n",
                 )
 
-        # remove auto-compose files
-        for file in auto_compose_files().copy():
+        # A retained project needs the exact generated config for a later targeted
+        # cleanup; it may declare networks the generic fallback cannot remove.
+        files_to_cleanup = auto_compose_files().copy()
+        if not cleanup:
+            files_to_cleanup.difference_update(
+                project.config
+                for project in shutdown_projects
+                if project.config is not None
+            )
+        for file in files_to_cleanup:
             safe_cleanup_auto_compose(file)
 
         _cleanup_completed.set(True)

--- a/tests/util/sandbox/test_docker_compose_config.py
+++ b/tests/util/sandbox/test_docker_compose_config.py
@@ -7,6 +7,9 @@ import pytest
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai.util import ComposeConfig, ComposeService
+from inspect_ai.util._sandbox.docker import cleanup as cleanup_module
+from inspect_ai.util._sandbox.docker import config as docker_config
+from inspect_ai.util._sandbox.docker.compose import Project
 from inspect_ai.util._sandbox.docker.config import (
     auto_compose_dir,
     is_auto_compose_file,
@@ -179,3 +182,126 @@ async def test_compose_config_with_extensions(request) -> None:
     finally:
         if project.config and os.path.exists(project.config):
             os.unlink(project.config)
+
+
+async def test_retained_project_preserves_config_until_exact_cleanup(
+    capsys, monkeypatch, tmp_path: Path
+) -> None:
+    """A retained project keeps its network config for later project-scoped cleanup."""
+    project_name = "inspect-retained-iabcdef"
+    other_project_name = "inspect-other-ighijkl"
+    config_path = tmp_path / f"{project_name}.yaml"
+    other_config_path = tmp_path / f"{other_project_name}.yaml"
+    config_path.write_text(
+        "services:\n  default:\n    image: python:3.12-bookworm\n"
+        "networks:\n  retained-network:\n    internal: true\n",
+        encoding="utf-8",
+    )
+    other_config_path.write_text("services: {}\n", encoding="utf-8")
+    project = ComposeProject(
+        name=project_name,
+        config=config_path.as_posix(),
+        sample_id=0,
+        epoch=0,
+        env=None,
+    )
+    compose_down_configs: list[str] = []
+
+    async def fake_compose_ps(
+        _project: ComposeProject, *, all: bool = False
+    ) -> list[dict[str, str]]:
+        return []
+
+    async def fake_compose_ls() -> list[Project]:
+        return [
+            Project(
+                Name=project_name,
+                Status="running",
+                ConfigFiles=config_path.as_posix(),
+            ),
+            Project(
+                Name=other_project_name,
+                Status="running",
+                ConfigFiles=other_config_path.as_posix(),
+            ),
+        ]
+
+    async def fake_compose_down(cleanup_project: ComposeProject, _quiet: bool) -> None:
+        assert cleanup_project.config is not None
+        compose_down_configs.append(
+            Path(cleanup_project.config).read_text(encoding="utf-8")
+        )
+
+    monkeypatch.setattr(cleanup_module, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(docker_config, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(cleanup_module, "compose_ps", fake_compose_ps)
+    monkeypatch.setattr(cleanup_module, "compose_ls", fake_compose_ls)
+    monkeypatch.setattr(cleanup_module, "compose_down", fake_compose_down)
+
+    cleanup_module.project_cleanup_startup()
+    cleanup_module.project_startup(project)
+    await cleanup_module.project_cleanup_shutdown(cleanup=False)
+
+    assert config_path.exists()
+    assert "retained-network" in config_path.read_text(encoding="utf-8")
+    assert (
+        "Cleanup single environment: inspect sandbox cleanup docker <project-name>"
+        in capsys.readouterr().out
+    )
+
+    await cleanup_module.cli_cleanup(project_name)
+
+    assert compose_down_configs == [
+        "services:\n  default:\n    image: python:3.12-bookworm\n"
+        "networks:\n  retained-network:\n    internal: true\n"
+    ]
+    assert not config_path.exists()
+    assert other_config_path.exists()
+
+
+async def test_full_cleanup_removes_auto_compose_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Full cleanup removes the auto-compose config after bringing the project down."""
+    project_name = "inspect-cleanup-iabcdef"
+    config_path = tmp_path / f"{project_name}.yaml"
+    config_path.write_text("services: {}\n", encoding="utf-8")
+    project = ComposeProject(
+        name=project_name,
+        config=config_path.as_posix(),
+        sample_id=0,
+        epoch=0,
+        env=None,
+    )
+
+    async def fake_compose_down(cleanup_project: ComposeProject, _quiet: bool) -> None:
+        assert cleanup_project == project
+
+    monkeypatch.setattr(cleanup_module, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(docker_config, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(cleanup_module, "compose_down", fake_compose_down)
+
+    cleanup_module.project_cleanup_startup()
+    cleanup_module.project_startup(project)
+    await cleanup_module.project_cleanup_shutdown(cleanup=True)
+
+    assert not config_path.exists()
+
+
+async def test_cli_cleanup_removes_orphaned_auto_compose_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """CLI cleanup removes a config whose inspect project is no longer running."""
+    config_path = tmp_path / "inspect-orphan-iabcdef.yaml"
+    config_path.write_text("services: {}\n", encoding="utf-8")
+
+    async def fake_compose_ls() -> list[Project]:
+        return []
+
+    monkeypatch.setattr(cleanup_module, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(docker_config, "auto_compose_dir", lambda: tmp_path)
+    monkeypatch.setattr(cleanup_module, "compose_ls", fake_compose_ls)
+
+    await cleanup_module.cli_cleanup(None)
+
+    assert not config_path.exists()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When an evaluation retains Docker sandbox environments for manual cleanup, shutdown deletes their generated Compose configuration. A later project-scoped cleanup then cannot use the configuration that declares its custom networks.

### What is the new behavior?

Generated Compose configuration remains while an Inspect Docker project is deliberately retained. `inspect sandbox cleanup docker <project-name>` can use it for project-scoped cleanup; full cleanup and orphaned-config cleanup still remove generated configuration. The shutdown hint now reads `Cleanup single environment: inspect sandbox cleanup docker <project-name>` rather than `Cleanup single container: inspect sandbox cleanup docker <container-id>`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation:

- `uv sync --extra dev`
- `uv run make check`
- `uv run make test`: 11,951 passed and 5,128 skipped.
- `uv run make suppressions-check`

### Slow tests

- `uv run pytest --runslow tests/util/sandbox/test_docker_compose_config.py -v`: 7 passed; 7 Trio variants skipped in this invocation.
- `uv run pytest --runslow --runtrio tests/util/sandbox/test_docker_compose_config.py -v`: 7 passed; 7 asyncio variants skipped in this invocation.
- `uv run pytest --runslow tests/util/sandbox/`: 503 passed and 296 skipped.
- `uv run pytest --runslow tests/util/ tests/checkpoint/`: 2,149 passed and 860 skipped.

### Agent review
- Reviewer: openai/gpt-6-astra (fresh context), 2 passes.
- Findings: The first pass identified 2 body omissions, both fixed. The current pass required no repairs.

Running in trajectory-labs-pbc/inspect_ai since release/2026-09-09.

Opened and updated by Claude on behalf of @sjawhar.
