### PR TITLE
Fix test_score[multiple-scorers] failing after choice() started raising on samples without choices

### DIFF
--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -348,11 +348,11 @@ def adds_to_state() -> Scorer:
         pytest.param(
             LOG_SCORED,
             "append",
-            [("f1", dict[str, Any]()), ("choice", dict[str, Any]())],
+            [("f1", dict[str, Any]()), ("includes", dict[str, Any]())],
             {
                 "match": {"num_metrics": 2},
                 "f1": {"num_metrics": 2},
-                "choice": {"num_metrics": 2},
+                "includes": {"num_metrics": 2},
             },
             None,
             id="multiple-scorers",


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Fixes meridianlabs-ai/inspect_ai#372

### What is the current behavior? (You can also link to an open issue here)

`tests/_eval/test_score.py::test_score[multiple-scorers]` fails in both slow-test jobs (asyncio and trio) on current `main`:

```
ValueError: The choice scorer requires samples with choices
src/inspect_ai/scorer/_choice.py:83
```

The param re-scores the free-text fixture log `tests/scorer/logs/2025-02-11T15-18-04-05-00_popularity_*.eval` (all samples have `choices: null`, targets `" Yes"` / `" No"`) with `[f1, choice]`. Since #5310, `choice()` deliberately raises on samples without answer options, so `score_async()` aborts and the test fails. The raise is the intended new behavior; the test's use of `choice` was incidental (it only needs two scorers to assert that each scorer sees prior scorers' results in `state.scores`).

### What is the new behavior?

The second scorer in the `multiple-scorers` param is `includes` instead of `choice`. `includes` has the same two metrics (`accuracy`, `stderr`), is a pure text comparison, and never raises on free-text targets, so every assertion in the test (score ordering, `num_metrics == 2`, and the `state.scores` propagation checks) holds unchanged. `src/inspect_ai/scorer/_choice.py` is untouched.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test-only change; no CHANGELOG entry.

### Other information:

Confirmed the pre-fix failure locally: with `[f1, choice]` the fixture raises `ValueError: The choice scorer requires samples with choices`.

Verification (installed with `pip install -e ".[dev]"`):
- `ruff check`, `ruff format --check`, `mypy` on `tests/_eval/test_score.py`: clean
- `pytest tests/_eval/test_score.py`: 13 passed, 25 skipped (gated)

### Slow tests

`test_score` is gated on `--runapi` and `@skip_if_no_openai`. None of `match`/`f1`/`includes` call a model, so I ran it with a placeholder `OPENAI_API_KEY` set in-process:

- `pytest tests/_eval/test_score.py::test_score --runapi` → 7 passed (all asyncio params, including `multiple-scorers`), 7 skipped (trio variants)
- `pytest tests/_eval/test_score.py -k "test_score and multiple-scorers" --runapi --runtrio` → 1 passed (`trio-multiple-scorers`)
- Not run: nothing else in the file is affected; no Docker or live provider tests apply to this change.

### Agent review
- Reviewer: Claude Fable 5.1 subagent (fresh context, same model as author), 1 pass
- Findings: 0 defects. Reviewer independently confirmed `includes` resolves by name via `resolve_scorers`, has 2 metrics, satisfies all assertions, and that no docs or other tests reference this param's use of `choice`. It also reproduced the pre-fix `ValueError` and re-ran the asyncio and trio variants (pass). It recommended keeping the swap rather than regenerating the shared fixture log with choices.

Authored by Claude Code (autonomous agent) in response to the `@auto` trigger on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

