### PR TITLE
Load Excel UTF-8 CSV datasets without an encoding override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Agent Bridge: Bare model names now resolve using the provider of the bridge endpoint, so clients can send names without a provider prefix.
 - Scoring: `multiple_choice()` now recognizes answer letters wrapped in LaTeX or markdown (`$B$`, `**B**`, `(B)`), which previously scored INCORRECT.
 - Datasets: `csv_dataset()` now honors the dialect's delimiter when no explicit delimiter is supplied, including tab-separated and registered custom dialects.
+- Datasets: `csv_dataset()` now loads UTF-8 files with a byte-order mark, including Excel CSV exports, without requiring an explicit encoding.
 - Datasets: `file_dataset()` now reads `.tsv` and `.tab` files as tab-delimited instead of rejecting them.
 - Elicitation: long lines in `ask_user` prompts are no longer hard-wrapped by the console, so long commands copy out of the terminal intact.
 - Compaction: summary compaction now produces a more detailed, structured summary that preserves code snippets, user messages, and any security-relevant constraints stated earlier in the conversation.

--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -54,7 +54,7 @@ def csv_dataset(
     shuffle_choices: bool | int | None = None,
     limit: int | None = None,
     dialect: str = "unix",
-    encoding: str = "utf-8",
+    encoding: str = "utf-8-sig",
     name: str | None = None,
     fs_options: dict[str, Any] | None = None,
     fieldnames: list[str] | None = None,
@@ -77,7 +77,8 @@ def csv_dataset(
         shuffle_choices: Whether to shuffle the choices. If an int is passed, this will be used as the seed when shuffling.
         limit: Limit the number of records to read.
         dialect: CSV dialect ("unix", "excel" or"excel-tab"). Defaults to "unix". See https://docs.python.org/3/library/csv.html#dialects-and-formatting-parameters for more details
-        encoding: Text encoding for file (defaults to "utf-8").
+        encoding: Text encoding for file (defaults to "utf-8-sig", which accepts
+            UTF-8 with or without a byte-order mark).
         name: Optional name for dataset (for logging). If not specified,
             defaults to the stem of the filename
         fs_options: Optional. Additional arguments to pass through

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -431,6 +431,49 @@ def test_json_dataset_supports_kwargs() -> None:
     )
 
 
+@pytest.mark.parametrize("encoding", ["utf-8", "utf-8-sig"])
+@pytest.mark.parametrize("fieldnames", [None, ["input", "target"]])
+def test_csv_utf8_with_or_without_bom(
+    tmp_path: Path, encoding: str, fieldnames: list[str] | None
+) -> None:
+    csv_file = tmp_path / "data.csv"
+    body = "café \ufeff text,résumé\r\n"
+    if fieldnames is None:
+        body = "input,target\r\n" + body
+    csv_file.write_bytes(body.encode(encoding))
+
+    dataset = csv_dataset(str(csv_file), fieldnames=fieldnames)
+
+    assert len(dataset) == 1
+    assert dataset[0].input == "café \ufeff text"
+    assert dataset[0].target == "résumé"
+
+
+@pytest.mark.parametrize("encoding", ["utf-16", "cp1252"])
+def test_csv_explicit_encoding(tmp_path: Path, encoding: str) -> None:
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_bytes("input,target\r\ncafé,résumé\r\n".encode(encoding))
+
+    dataset = csv_dataset(str(csv_file), encoding=encoding)
+
+    assert len(dataset) == 1
+    assert dataset[0].input == "café"
+    assert dataset[0].target == "résumé"
+
+
+def test_csv_explicit_utf8_preserves_bom(tmp_path: Path) -> None:
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_bytes("café,résumé\r\n".encode("utf-8-sig"))
+
+    dataset = csv_dataset(
+        str(csv_file), encoding="utf-8", fieldnames=["input", "target"]
+    )
+
+    assert len(dataset) == 1
+    assert dataset[0].input == "\ufeffcafé"
+    assert dataset[0].target == "résumé"
+
+
 def write_ragged_csv(tmp_path: Path, body: str) -> str:
     path = tmp_path / "data.csv"
     path.write_text(body, newline="")


### PR DESCRIPTION
Fixes #5353.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`csv_dataset()` rejects a UTF-8 CSV with a leading BOM, such as an Excel UTF-8 export, with `ValueError: No input in dataset`. With explicit field names, the BOM instead becomes part of the first input value.

### What is the new behavior?

Default to `utf-8-sig`, which reads UTF-8 with or without a leading BOM. Update the docstring and changelog. Seven regression cases cover BOM/non-BOM files, inferred/explicit field names, non-ASCII text, an embedded U+FEFF, and explicit UTF-8, UTF-16 and CP1252 encodings. Both BOM cases failed before the fix; all seven pass afterward.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No migration is needed for ordinary UTF-8 files. Callers intentionally retaining a leading U+FEFF can continue passing `encoding="utf-8"` explicitly. As scoped in the issue, this changes only `csv_dataset()`; `file_dataset()` still supplies its own existing encoding default.

### Other information:

Validated on Windows with Python 3.13.2 and the frozen development environment. GNU make is unavailable, so its checks were invoked directly:

- `uv run --frozen pytest tests/dataset/test_dataset.py -q`: **79 passed**.
- `uv run --frozen pytest tests/dataset -q`: **143 passed, 4 failed, 1 skipped**. The four document filename/MIME-type failures also reproduce on a clean checkout of upstream `8ebe620`; the optional Hugging Face datasets test skipped.
- Repository-wide Ruff lint/format checks, including the separate tool-support source directory, and the suppression ledger check pass. Mypy passes for both changed Python files.
- Full `mypy --exclude tests/test_package src tests`: **63 errors in 27 files**, with identical error lines on clean upstream (Windows/POSIX compatibility). No suppressions added.
- Full `pytest -x -q`: **4 passed, 1 failed**, stopping at `test_stdio_bad_socket_path_exits_2` because Windows lacks `asyncio.open_unix_connection`; the same failure reproduces on clean upstream. An earlier parallel full-suite attempt was interrupted after failures and has no completed summary. The full suite is not claimed green.
- `git diff --check` passes.

### Slow tests

No Docker or live-provider tests run; this synchronous CSV decoding change does not touch providers, tools, sandboxes or async plumbing.

### Agent review

Prepared with Codex. One independent Codex/GPT-6 review pass ran in a fresh context, using the same model as the author. No actionable findings. The reviewer inspected the full diff, file helper and dataset wrappers, ran the CSV tests (**39 passed**), and separately checked `file://` loading. The remaining `file_dataset()` default was noted and left outside this issue's scope.
