### PR TITLE
Treat 405 as unavailable for OpenAI-compatible token-counting and compaction endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI-compatible token-counting and compaction endpoints that return 405 are now handled the same as those that return 404.
 - Bedrock and SageMaker now require `aiobotocore` instead of `aioboto3`, which is no longer installed, and Inspect no longer holds `botocore` back to an old release.
 - Bugfix: `eval_retry` now reuses the model roles recorded in the original log, including roles the task set itself in `Task(...)`.
 - Review: New `Reviewer` protocol and `review` policies (`Task(review=)`, `eval(review=)`, `--review`) run after a tool call executes and before the model sees its result, and can `continue`, `terminate`, or `escalate`; each decision is recorded as a `ReviewEvent`.

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -10,7 +10,6 @@ from openai import (
     AsyncOpenAI,
     BadRequestError,
     DefaultAsyncHttpxClient,
-    NotFoundError,
     NotGiven,
     RateLimitError,
     omit,
@@ -387,8 +386,14 @@ class OpenAIAPI(ModelAPI):
         if self.responses_api:
             try:
                 return await self._count_tokens_native(input, config)
-            except NotFoundError:
-                pass  # endpoint not available (e.g. Azure); fall through to tiktoken
+            except APIStatusError as ex:
+                # 404 means the endpoint has no route. 405 can mean the real
+                # GET /responses/{response_id} route matched "input_tokens"
+                # when the POST /responses/input_tokens route is unavailable.
+                if ex.status_code not in (404, 405):
+                    raise
+                # Endpoint unavailable (e.g. Azure); fall through to tiktoken.
+                pass
 
         # For non-responses API, use tiktoken-based counting
         from .._tokens import count_tokens
@@ -823,7 +828,12 @@ class OpenAIAPI(ModelAPI):
                 input=input_params,
                 instructions=instructions if instructions is not None else omit,
             )
-        except NotFoundError:
+        except APIStatusError as ex:
+            # 404 means the endpoint has no route. 405 can mean the real
+            # GET /responses/{response_id} route matched "compact" when the
+            # POST /responses/compact route is unavailable.
+            if ex.status_code not in (404, 405):
+                raise
             raise NotImplementedError(
                 f"Native compaction endpoint not available for {self.service_model_name()}"
             ) from None

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -377,8 +377,8 @@ class OpenAIAPI(ModelAPI):
         """Count tokens using native API for messages, tiktoken for text.
 
         For messages, uses OpenAI's input_tokens endpoint which can accurately
-        count encrypted reasoning blocks. Raises an exception if native
-        counting fails.
+        count encrypted reasoning blocks. Falls back to tiktoken if the native
+        endpoint is unavailable. All other failures propagate unchanged.
         """
         if isinstance(input, str):
             return await self.count_text_tokens(input)
@@ -803,7 +803,8 @@ class OpenAIAPI(ModelAPI):
             A tuple of (compacted messages, usage info).
 
         Raises:
-            NotImplementedError: If the model is not using the Responses API.
+            NotImplementedError: If the model is not using the Responses API or
+                the native compaction endpoint is unavailable.
         """
         if not self.responses_api:
             raise NotImplementedError(

--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -1,7 +1,10 @@
 import base64
 import json
 
+import httpx2
+import openai
 import pytest
+from openai import DefaultAsyncHttpxClient
 from test_helpers.utils import skip_if_no_openai, skip_if_no_openai_model
 
 from inspect_ai import Task, eval
@@ -9,12 +12,72 @@ from inspect_ai.dataset._dataset import Sample
 from inspect_ai.model import (
     ChatMessageUser,
     GenerateConfig,
+    Model,
     get_model,
 )
 from inspect_ai.model._chat_message import ChatMessageSystem
 from inspect_ai.model._internal import parse_content_with_internal
 from inspect_ai.model._openai import openai_completion_params
 from inspect_ai.tool import tool
+
+
+def _openai_model_with_status_response(status_code: int, path: str) -> Model:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        assert request.method == "POST"
+        assert request.url.path == path
+        return httpx2.Response(
+            status_code,
+            headers={"allow": "GET"} if status_code == 405 else {},
+            json={"detail": f"HTTP {status_code}"},
+            request=request,
+        )
+
+    http_client = DefaultAsyncHttpxClient(transport=httpx2.MockTransport(handler))
+    return get_model(
+        "openai/test",
+        api_key="test",
+        base_url="http://test/v1",
+        http_client=http_client,
+        responses_api=True,
+        memoize=False,
+    )
+
+
+@pytest.mark.parametrize("status_code", [404, 405])
+async def test_openai_count_tokens_falls_back_for_unavailable_endpoint(
+    status_code: int,
+) -> None:
+    async with _openai_model_with_status_response(
+        status_code, "/v1/responses/input_tokens"
+    ) as model:
+        assert await model.count_tokens([ChatMessageUser(content="hello")]) == 1
+
+
+async def test_openai_count_tokens_propagates_other_endpoint_errors() -> None:
+    async with _openai_model_with_status_response(
+        403, "/v1/responses/input_tokens"
+    ) as model:
+        with pytest.raises(openai.PermissionDeniedError):
+            await model.count_tokens([ChatMessageUser(content="hello")])
+
+
+@pytest.mark.parametrize("status_code", [404, 405])
+async def test_openai_compact_reports_unavailable_endpoint(
+    status_code: int,
+) -> None:
+    async with _openai_model_with_status_response(
+        status_code, "/v1/responses/compact"
+    ) as model:
+        with pytest.raises(NotImplementedError, match="endpoint not available"):
+            await model.compact([ChatMessageUser(content="hello")], [])
+
+
+async def test_openai_compact_propagates_other_endpoint_errors() -> None:
+    async with _openai_model_with_status_response(
+        403, "/v1/responses/compact"
+    ) as model:
+        with pytest.raises(openai.PermissionDeniedError):
+            await model.compact([ChatMessageUser(content="hello")], [])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

OpenAI-compatible services may implement the Responses API without its newer input-token-counting or compaction operations. When a missing `POST` operation collides with the real `GET /responses/{response_id}` route, the service can return 405 rather than 404.

`OpenAIAPI` recognizes 404 as indicating that these native operations are unavailable, but propagates 405. Consequently, token counting fails instead of using its local fallback, and compaction exposes the provider error instead of reporting that native compaction is unsupported.

Fixes #5330.

### What is the new behavior?

Input token counting now treats both 404 and 405 as signals that the native operation is unavailable and falls back to local token counting. Native compaction similarly translates either status into `NotImplementedError`. Other API failures continue to propagate unchanged.

Regression coverage uses the OpenAI SDK with an HTTP mock transport, verifies the requested method and path, covers both 404 and 405, and confirms that an unrelated 403 still propagates.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

#### Tests

- `PATH="$PWD/.venv/bin:$PATH" make check` — passed (Ruff, mypy, and suppression checks).
- `PATH="$PWD/.venv/bin:$PATH" make test` — 12,023 passed, 5,168 skipped.
- `PATH="$PWD/.venv/bin:$PATH" pytest tests/model/providers/test_openai.py` — 25 passed, 36 skipped.

#### Slow tests

- `PATH="$PWD/.venv/bin:$PATH" pytest --runtrio tests/model/providers/test_openai.py` — 15 passed, 46 skipped. The added async regression tests passed under Trio.
- Live OpenAI API tests were not run: `PATH="$PWD/.venv/bin:$PATH" pytest --runapi --runslow tests/model/providers/test_openai*.py`. No OpenAI Platform API key was available; a ChatGPT/Codex login cannot authenticate general OpenAI API calls.
- The affected test file contains no tests marked `slow` or `flaky`.

#### Agent review

- Reviewer: Codex GPT-5.6 Sol (fresh-context subagent), 1 pass.
- Findings: 0 actionable. A preliminary issue-scope concern was dismissed after confirming that compaction is another instance of the same route-collision defect, was documented before maintainer acceptance, and is not excluded by the accepted issue.