### PR TITLE
Preserve colons in Hugging Face literal targets

### DIFF
--- a/src/inspect_ai/_eval/task/hf.py
+++ b/src/inspect_ai/_eval/task/hf.py
@@ -220,7 +220,7 @@ def parse_task_spec(task_spec: str) -> tuple[str, str | None]:
 def _sanitize_target(record: DatasetRecord, target: str, is_choices: bool) -> str:
     # if the target is a literal, return the value after the colon without checking the record.
     if target.startswith("literal:"):
-        target = target.split(":")[1]
+        target = target.split(":", 1)[1]
         return target
 
     # otherwise, get the target from the record and convert to a letter if it's a number.

--- a/tests/_eval/task/test_hf.py
+++ b/tests/_eval/task/test_hf.py
@@ -42,6 +42,8 @@ def test_parse_task_spec_invalid():
         ({"label": 2}, "label", False, "2"),
         ({"value": "test"}, "literal:test", False, "test"),
         ({"value": "ignore"}, "literal:custom", False, "custom"),
+        ({}, "literal:12:30", False, "12:30"),
+        ({}, "literal:https://example.com/a:b", False, "https://example.com/a:b"),
     ],
 )
 def test_sanitize_target(record, target, is_choices, expected):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Fixes #5367.

Hugging Face task configs support `field_spec.target: literal:<value>`, but literal values containing another colon are truncated. `literal:12:30` becomes `12`, and URI-like targets are cut after the first segment.

### What is the new behavior?

Literal targets preserve everything after the first `literal:` prefix. Regression cases cover both a time-like value and a URI-like value.

### Does this PR introduce a breaking change?

No.

### Other information:

Regression coverage was added to `tests/_eval/task/test_hf.py`.

Validation:
- final branch diff checked against current `main`
- focused regression logic executed successfully in Python
- full `make check` / `make test` not run in this environment
