### PR TITLE
Preserve comma-containing values passed with --env

### DIFF
--- a/src/inspect_ai/_cli/common.py
+++ b/src/inspect_ai/_cli/common.py
@@ -114,7 +114,7 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 def process_common_options(options: CommonOptions) -> None:
     # set environment variables
-    env_args = parse_cli_args(options["env"])
+    env_args = parse_cli_args(options["env"], force_str=True)
     init_cli_env(env_args)
 
     # set traceback locals env var

--- a/src/inspect_ai/_util/config.py
+++ b/src/inspect_ai/_util/config.py
@@ -29,11 +29,15 @@ def parse_cli_args(
             parts = arg.split("=")
             if len(parts) > 1:
                 key = parts[0].replace("-", "_")
-                value = yaml.safe_load("=".join(parts[1:]))
-                if isinstance(value, str):
-                    value = value.split(",")
-                    value = value if len(value) > 1 else value[0]
-                params[key] = str(value) if force_str else value
+                raw_value = "=".join(parts[1:])
+                if force_str:
+                    value: Any = raw_value
+                else:
+                    value = yaml.safe_load(raw_value)
+                    if isinstance(value, str):
+                        value = value.split(",")
+                        value = value if len(value) > 1 else value[0]
+                params[key] = value
     return params
 
 

--- a/tests/cli/test_parse_cli_args.py
+++ b/tests/cli/test_parse_cli_args.py
@@ -58,3 +58,13 @@ def test_boolean_flag_without_value_skipped() -> None:
     """Args without '=' (bare flags like enable-auto-tool-choice) are skipped."""
     result = parse_cli_args(["enable-auto-tool-choice"])
     assert result == {}
+
+
+def test_force_str_preserves_commas() -> None:
+    result = parse_cli_args(["NO_PROXY=localhost,127.0.0.1"], force_str=True)
+    assert result == {"NO_PROXY": "localhost,127.0.0.1"}
+
+
+def test_force_str_preserves_yaml_like_and_equals_values() -> None:
+    result = parse_cli_args(["TOKEN=001=true,false"], force_str=True)
+    assert result == {"TOKEN": "001=true,false"}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Fixes #5368.

The common `--env NAME=value` path YAML-parses values and splits comma-containing strings into lists. `init_cli_env()` then stringifies those lists, so values such as `NO_PROXY=localhost,127.0.0.1` are changed before reaching the environment.

### What is the new behavior?

`parse_cli_args(..., force_str=True)` preserves the raw value after the first `=` without YAML or comma coercion, and the common `--env` path uses that mode. Normal model/task argument parsing keeps its existing typed and comma-list behavior.

Regression coverage checks comma-containing values, YAML-like strings, embedded `=`, and existing typed parsing.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:
- final branch diff checked against current `main`
- focused regression logic executed successfully in Python
- full `make check` / `make test` not run in this environment
