### PR TITLE
Accept lowercase z UTC timestamps on Python 3.11+

### DIFF
--- a/src/inspect_ai/_util/dateutil.py
+++ b/src/inspect_ai/_util/dateutil.py
@@ -20,22 +20,22 @@ logger = getLogger(__name__)
 
 
 def _normalize_iso_z_suffix(input: str) -> str:
-    """Normalize Z suffix in ISO format strings for Python 3.10 compatibility.
+    """Normalize Z suffix in ISO format strings for Python compatibility.
 
     Python 3.10's fromisoformat() doesn't support Z suffix for UTC.
-    Python 3.11+ handles Z natively.
+    Python 3.11+ supports uppercase Z natively, but lowercase z remains invalid.
 
     Args:
         input: ISO format string (may end with Z or z)
 
     Returns:
-        ISO format string with Z/z replaced by +00:00 (if Python < 3.11)
+        ISO format string accepted by the running Python version.
     """
-    return (
-        input
-        if sys.version_info >= (3, 11) or not input.endswith(("Z", "z"))
-        else input[:-1] + "+00:00"
-    )
+    if input.endswith("z"):
+        return input[:-1] + "+00:00"
+    if input.endswith("Z") and sys.version_info < (3, 11):
+        return input[:-1] + "+00:00"
+    return input
 
 
 def is_file_older_than(path: str | Path, delta: timedelta, *, default: bool) -> bool:

--- a/tests/util/test_dateutil.py
+++ b/tests/util/test_dateutil.py
@@ -1,0 +1,18 @@
+from datetime import time, timezone
+
+from pydantic import TypeAdapter
+
+from inspect_ai._util.dateutil import UtcTime, datetime_from_iso_format_safe
+
+
+def test_datetime_from_iso_format_safe_accepts_lowercase_z() -> None:
+    value = datetime_from_iso_format_safe("2025-04-17T12:00:00z")
+
+    assert value.utcoffset() == timezone.utc.utcoffset(value)
+    assert value.isoformat() == "2025-04-17T12:00:00+00:00"
+
+
+def test_utc_time_accepts_lowercase_z() -> None:
+    value = TypeAdapter(UtcTime).validate_python("12:34:56z")
+
+    assert value == time(12, 34, 56, tzinfo=timezone.utc)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Fixes #5369.

The ISO timestamp normalizer documents support for both `Z` and `z`, but on Python 3.11+ it returns lowercase `z` unchanged. The standard library accepts uppercase `Z` but rejects lowercase `z`, so lowercase UTC timestamps fail.

### What is the new behavior?

A trailing lowercase `z` is always normalized to `+00:00`. Uppercase `Z` keeps the existing Python-version behavior. Regression coverage checks both datetime parsing and the `UtcTime` validator.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:
- final branch diff checked against current `main`
- focused regression logic executed successfully in Python
- full `make check` / `make test` not run in this environment
